### PR TITLE
Add a manpage for mgba.

### DIFF
--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -12,6 +12,7 @@
 .Sh SYNOPSIS
 .Nm mgba-qt
 .Op Fl b Ar biosfile
+.Op Fl l Ar loglevel
 .Op Fl p Ar patchfile
 .Op Fl s Ar n
 .Ar file
@@ -25,6 +26,33 @@ Specify a BIOS file to use during boot.
 If this flag is omitted,
 .Nm
 will use a high\(hylevel emulated BIOS.
+.It Fl l Ar loglevel
+Log messages during emulation.
+.Ar loglevel
+is a bitmask defining which types of messages to log:
+.Bl -inset
+.It 0x01
+fatal errors
+.It 0x02
+errors
+.It 0x04
+warnings
+.It 0x08
+informative messages
+.It 0x10
+debugging messages
+.It 0x20
+stub messages
+.It 0x100
+in\(hygame errors
+.It 0x200
+software interrupts
+.It 0x400
+emulator status messages
+.It 0x800
+serial I/O messages
+.El
+The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile
 Specify a patch file in IPS or UPS format.
 .It Fl s Ar n , Fl -frameskip Ar n

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -11,10 +11,27 @@
 .Nd Game Boy Advance emulator
 .Sh SYNOPSIS
 .Nm mgba-qt
+.Op Fl b Ar biosfile
+.Op Fl p Ar patchfile
+.Op Fl s Ar n
 .Ar file
 .Sh DESCRIPTION
 .Nm
 is a Game Boy Advance emulator.
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl b Ar biosfile , Fl -bios Ar biosfile
+Specify a BIOS file to use during boot.
+If this flag is omitted,
+.Nm
+will use a high\(hylevel emulated BIOS.
+.It Fl p Ar patchfile , Fl -patch Ar patchfile
+Specify a patch file in IPS or UPS format.
+.It Fl s Ar n , Fl -frameskip Ar n
+Skip every
+.Ar n
+frames.
+.El
 .Sh CONTROLS
 The default controls are as follows:
 .Bl -hang -width "Frame advance" -compact

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -93,6 +93,15 @@ configuration file.
 Default
 .Nm mgba-qt
 configuration file.
+.It Pa portable.ini
+If this file exists in the current directory,
+.Nm
+will read
+.Pa config.ini
+and
+.Pa qt.ini
+from the current directory instead of
+.Pa ~/.config/mgba .
 .El
 .Sh AUTHORS
 .An Jeffrey Pfau Aq Mt jeffrey@endrift.com

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -43,7 +43,7 @@ informative messages
 .It 16
 debugging messages
 .It 32
-stub messages
+stub messages for unimplemented features
 .It 256
 in\(hygame errors
 .It 512

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -25,7 +25,8 @@ The options are as follows:
 Specify a BIOS file to use during boot.
 If this flag is omitted,
 .Nm
-will use a high\(hylevel emulated BIOS.
+will use the BIOS specified in the configuration file,
+or a high\(hylevel emulated BIOS if none is specified.
 .It Fl l Ar loglevel
 Log messages during emulation.
 .Ar loglevel

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -31,25 +31,25 @@ Log messages during emulation.
 .Ar loglevel
 is a bitmask defining which types of messages to log:
 .Bl -inset
-.It 0x01
+.It 1
 fatal errors
-.It 0x02
+.It 2
 errors
-.It 0x04
+.It 4
 warnings
-.It 0x08
+.It 8
 informative messages
-.It 0x10
+.It 16
 debugging messages
-.It 0x20
+.It 32
 stub messages
-.It 0x100
+.It 256
 in\(hygame errors
-.It 0x200
+.It 512
 software interrupts
-.It 0x400
+.It 1024
 emulator status messages
-.It 0x800
+.It 2048
 serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -1,0 +1,52 @@
+.\" Copyright (c) 2015 Anthony J. Bentley <anthony@anjbe.name>
+.\"
+.\" This Source Code Form is subject to the terms of the Mozilla Public
+.\" License, v. 2.0. If a copy of the MPL was not distributed with this
+.\" file, you can obtain one at https://mozilla.org/MPL/2.0/.
+.Dd July 29, 2015
+.Dt MGBA-QT 6
+.Os
+.Sh NAME
+.Nm mgba-qt
+.Nd Game Boy Advance emulator
+.Sh SYNOPSIS
+.Nm mgba-qt
+.Ar file
+.Sh DESCRIPTION
+.Nm
+is a Game Boy Advance emulator.
+.Sh CONTROLS
+The default controls are as follows:
+.Bl -hang -width "Frame advance" -compact
+.It A
+.Cm x
+.It B
+.Cm z
+.It L
+.Cm a
+.It R
+.Cm s
+.It Start
+.Aq Cm Enter
+.It Select
+.Aq Cm Backspace
+.It Load state
+.Cm F1 Ns \(en Ns Cm F9
+.It Save state
+.Ao Cm Shift Ac Ns \(hy Ns Cm F1 Ns \(en Ns Cm F9
+.It Frame advance
+.Ao Cm Ctrl Ac Ns \(hy Ns Cm n
+.El
+.Sh AUTHORS
+.An Jeffrey Pfau Aq Mt jeffrey@endrift.com
+.Sh HOMEPAGE
+.Bl -bullet
+.It
+.Lk https://mgba.io/ "mGBA homepage"
+.It
+.Lk https://github.com/mgba-emu/mgba "Development repository"
+.It
+.Lk https://github.com/mgba-emu/mgba/issues "Bug tracker"
+.It
+.Lk https://forums.mgba.io/ "Message board"
+.El

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -83,6 +83,17 @@ The default controls are as follows:
 .It Frame advance
 .Ao Cm Ctrl Ac Ns \(hy Ns Cm n
 .El
+.Sh FILES
+.Bl -tag -width ~/.config/mgba/config.ini -compact
+.It Pa ~/.config/mgba/config.ini
+Default
+.Xr mgba 6
+configuration file.
+.It Pa ~/.config/mgba/qt.ini
+Default
+.Nm mgba-qt
+configuration file.
+.El
 .Sh AUTHORS
 .An Jeffrey Pfau Aq Mt jeffrey@endrift.com
 .Sh HOMEPAGE

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -31,27 +31,27 @@ or a high\(hylevel emulated BIOS if none is specified.
 Log messages during emulation.
 .Ar loglevel
 is a bitmask defining which types of messages to log:
-.Bl -inset
-.It 1
-fatal errors
-.It 2
-errors
-.It 4
-warnings
-.It 8
-informative messages
-.It 16
-debugging messages
-.It 32
-stub messages for unimplemented features
-.It 256
-in\(hygame errors
-.It 512
-software interrupts
-.It 1024
-emulator status messages
-.It 2048
-serial I/O messages
+.Bl -bullet -compact
+.It
+1 \(en fatal errors
+.It
+2 \(en errors
+.It
+4 \(en warnings
+.It
+8 \(en informative messages
+.It
+16 \(en debugging messages
+.It
+32 \(en stub messages for unimplemented features
+.It
+256 \(en in\(hygame errors
+.It
+512 \(en software interrupts
+.It
+1024 \(en emulator status messages
+.It
+2048 \(en serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile

--- a/doc/mgba-qt.6
+++ b/doc/mgba-qt.6
@@ -54,7 +54,7 @@ serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile
-Specify a patch file in IPS or UPS format.
+Specify a patch file in BPS, IPS, or UPS format.
 .It Fl s Ar n , Fl -frameskip Ar n
 Skip every
 .Ar n

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -227,8 +227,6 @@ from
 If
 .Ar count
 is not specified, examine 16 bytes, 8 halfwords, or 4 words.
-.It Cm \&!\ \&
-Break into the attached debugger.
 .El
 .Sh FILES
 .Bl -tag -width ~/.config/mgba/config.ini -compact

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -64,7 +64,7 @@ Play back a movie of recording input from
 .El
 .Sh CONTROLS
 The default controls are as follows:
-.Bl -hang -width Select -compact
+.Bl -hang -width "Frame advance" -compact
 .It A
 .Cm x
 .It B
@@ -83,6 +83,79 @@ The default controls are as follows:
 .Ao Cm Shift Ac Ns \(hy Ns Cm F1 Ns \(en Ns Cm F9
 .It Frame advance
 .Ao Cm Ctrl Ac Ns \(hy Ns Cm n
+.El
+.Sh DEBUGGER
+When
+.Nm
+is run with the
+.Fl d
+option, the command\(hyline debugger is enabled.
+It supports the following commands:
+.Pp
+.Bl -tag -compact -width 1
+.It Cm b Ns Oo Cm reak Oc Ar address
+.It Cm b Ns Oo Cm reak Oc Ns Cm /a Ar address
+.It Cm b Ns Oo Cm reak Oc Ns Cm /t Ar address
+Set a breakpoint at
+.Ar address .
+.It Cm c Ns Op Cm ontinue
+Continue execution.
+.It Cm d Ns Oo elete Oc Ar address
+Delete a breakpoint at
+.Ar address .
+.It Cm dis Ns Oo Cm asm Oc Ar address Op Ar count
+.It Cm dis Ns Oo Cm asm Oc Ns Cm /a Ar address Op Ar count
+.It Cm dis Ns Oo Cm asm Oc Ns Cm /t Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Ns Cm /a Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Ns Cm /t Ar address Op Ar count
+Disassemble
+.Ar count
+instructions starting at address
+.Ar address .
+If
+.Ar count
+is not specified, only disassemble the instruction at
+.Ar address .
+.It Cm h Ns Op Cm elp
+Print help.
+.It Cm i Ns Op Cm nfo
+.It Cm status
+Print the current contents of general\(hypurpose registers.
+.It Cm n Ns Op Cm ext
+Execute the next instruction.
+.It Cm p Ns Oo Cm rint Oc Ar value ...
+.It Cm p Ns Oo Cm rint Oc Ns Cm /t Ar value ...
+.It Cm p Ns Oo Cm rint Oc Ns Cm /x Ar value ...
+Print
+.Ar value .
+.It Cm q Ns Op Cm uit
+Quit the emulator.
+.It Cm reset
+Reset the emulation.
+.It Cm r/1 Ar address
+.It Cm r/2 Ar address
+.It Cm r/4 Ar address
+Read a byte, halfword, or word from
+.Ar address .
+.It Cm w Ns Oo Cm atch Oc Ar address
+Set a watchpoint at
+.Ar address .
+.It Cm w/1 Ar address
+.It Cm w/2 Ar address
+.It Cm w/4 Ar address
+Write a byte, halfword, or word to
+.Ar address .
+.It Cm w/r Ar register
+Write a word to
+.Ar register .
+.It Cm x/1 Ar address
+.It Cm x/2 Ar address
+.It Cm x/4 Ar address
+Examine bytes, halfwords, or words from
+.Ar address .
+.It Cm \&!\ \&
+Break into the attached debugger.
 .El
 .Sh AUTHORS
 .An Jeffrey Pfau Aq Mt jeffrey@endrift.com

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -225,6 +225,13 @@ Break into the attached debugger.
 Default
 .Nm
 configuration file.
+.It Pa portable.ini
+If this file exists in the current directory,
+.Nm
+will read
+.Pa config.ini
+from the current directory instead of
+.Pa ~/.config/mgba .
 .El
 .Sh AUTHORS
 .An Jeffrey Pfau Aq Mt jeffrey@endrift.com

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -1,0 +1,99 @@
+.\" Copyright (c) 2015 Anthony J. Bentley <anthony@anjbe.name>
+.\"
+.\" This Source Code Form is subject to the terms of the Mozilla Public
+.\" License, v. 2.0. If a copy of the MPL was not distributed with this
+.\" file, you can obtain one at https://mozilla.org/MPL/2.0/.
+.Dd July 29, 2015
+.Dt MGBA 6
+.Os
+.Sh NAME
+.Nm mgba
+.Nd Game Boy Advance emulator
+.Sh SYNOPSIS
+.Nm mgba
+.Op Fl 123456dfg
+.Op Fl b Ar biosfile
+.Op Fl c Ar cheatfile
+.Op Fl p Ar patchfile
+.Op Fl s Ar n
+.Op Fl v Ar moviefile
+.Ar file
+.Sh DESCRIPTION
+.Nm
+is a Game Boy Advance emulator.
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl 1
+Scale the window 1\(mu.
+.It Fl 2
+Scale the window 2\(mu.
+.It Fl 3
+Scale the window 3\(mu.
+.It Fl 4
+Scale the window 4\(mu.
+.It Fl 5
+Scale the window 5\(mu.
+.It Fl 6
+Scale the window 6\(mu.
+.It Fl b Ar biosfile , Fl -bios Ar biosfile
+Specify a BIOS file to use during boot.
+If this flag is omitted,
+.Nm
+will use a high\(hylevel emulated BIOS.
+.It Fl c Ar cheatfile , Fl -cheats Ar cheatfile
+Apply cheat codes from
+.Ar cheatfile .
+.It Fl d
+Start emulating via the command\(hyline debugger.
+.It Fl f
+Start the emulator full\(hyscreen.
+.It Fl g
+Start a
+.Xr gdb 1
+session.
+By default the session starts on port 2345.
+.It Fl p Ar patchfile , Fl -patch Ar patchfile
+Specify a patch file in IPS or UPS format.
+.It Fl s Ar n , Fl -frameskip Ar n
+Skip every
+.Ar n
+frames.
+.It Fl v Ar moviefile , Fl -movie Ar moviefile
+Play back a movie of recording input from
+.Ar moviefile .
+.El
+.Sh CONTROLS
+The default controls are as follows:
+.Bl -hang -width Select -compact
+.It A
+.Cm x
+.It B
+.Cm z
+.It L
+.Cm a
+.It R
+.Cm s
+.It Start
+.Aq Cm Enter
+.It Select
+.Aq Cm Backspace
+.It Load state
+.Cm F1 Ns \(en Ns Cm F9
+.It Save state
+.Ao Cm Shift Ac Ns \(hy Ns Cm F1 Ns \(en Ns Cm F9
+.It Frame advance
+.Ao Cm Ctrl Ac Ns \(hy Ns Cm n
+.El
+.Sh AUTHORS
+.An Jeffrey Pfau Aq Mt jeffrey@endrift.com
+.Sh HOMEPAGE
+.Bl -bullet
+.It
+.Lk https://endrift.com/mgba/ "mGBA homepage"
+.It
+.Lk https://github.com/mgba-emu/mgba "Development repository"
+.It
+.Lk https://endrift.com/mgba/bugs/ "Bug tracker"
+.It
+.Lk https://forums.mgba.io/ "Message board"
+.El

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -137,12 +137,12 @@ Continue execution.
 .It Cm d Ns Oo Cm elete Oc Ar address
 Delete a breakpoint at
 .Ar address .
-.It Cm dis Ns Oo Cm asm Oc Ar address Op Ar count
-.It Cm dis Ns Oo Cm asm Oc Ns Cm /a Ar address Op Ar count
-.It Cm dis Ns Oo Cm asm Oc Ns Cm /t Ar address Op Ar count
-.It Cm dis Ns Oo Cm assemble Oc Ar address Op Ar count
-.It Cm dis Ns Oo Cm assemble Oc Ns Cm /a Ar address Op Ar count
-.It Cm dis Ns Oo Cm assemble Oc Ns Cm /t Ar address Op Ar count
+.It Cm dis Ns Oo Cm asm Oc Op Ar address Op Ar count
+.It Cm dis Ns Oo Cm asm Oc Ns Cm /a Op Ar address Op Ar count
+.It Cm dis Ns Oo Cm asm Oc Ns Cm /t Op Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Op Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Ns Cm /a Op Ar address Op Ar count
+.It Cm dis Ns Oo Cm assemble Oc Ns Cm /t Op Ar address Op Ar count
 Disassemble
 .Ar count
 instructions starting at
@@ -156,6 +156,9 @@ If
 .Ar count
 is not specified, only disassemble the instruction at
 .Ar address .
+If
+.Ar address
+is not specified, only disassemble the current address.
 .It Cm h Ns Op Cm elp
 Print help.
 .It Cm i Ns Op Cm nfo

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -195,10 +195,12 @@ from
 .It Cm w Ns Oo Cm atch Oc Ar address
 Set a watchpoint at
 .Ar address .
-.It Cm w/1 Ar address
-.It Cm w/2 Ar address
-.It Cm w/4 Ar address
-Write a byte
+.It Cm w/1 Ar address data
+.It Cm w/2 Ar address data
+.It Cm w/4 Ar address data
+Write
+.Ar data
+as a byte
 .Pq Ql /1 ,
 halfword
 .Pq Ql /2 ,

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -89,11 +89,11 @@ The default controls are as follows:
 .Sh HOMEPAGE
 .Bl -bullet
 .It
-.Lk https://endrift.com/mgba/ "mGBA homepage"
+.Lk https://mgba.io/ "mGBA homepage"
 .It
 .Lk https://github.com/mgba-emu/mgba "Development repository"
 .It
-.Lk https://endrift.com/mgba/bugs/ "Bug tracker"
+.Lk https://github.com/mgba-emu/mgba/issues "Bug tracker"
 .It
 .Lk https://forums.mgba.io/ "Message board"
 .El

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -14,6 +14,7 @@
 .Op Fl 123456dfg
 .Op Fl b Ar biosfile
 .Op Fl c Ar cheatfile
+.Op Fl l Ar loglevel
 .Op Fl p Ar patchfile
 .Op Fl s Ar n
 .Op Fl v Ar moviefile
@@ -52,6 +53,34 @@ Start a
 .Xr gdb 1
 session.
 By default the session starts on port 2345.
+.It Fl l Ar loglevel
+Log messages during emulation to
+.Dv stdout .
+.Ar loglevel
+is a bitmask defining which types of messages to log:
+.Bl -inset
+.It 0x01
+fatal errors
+.It 0x02
+errors
+.It 0x04
+warnings
+.It 0x08
+informative messages
+.It 0x10
+debugging messages
+.It 0x20
+stub messages
+.It 0x100
+in\(hygame errors
+.It 0x200
+software interrupts
+.It 0x400
+emulator status messages
+.It 0x800
+serial I/O messages
+.El
+The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile
 Specify a patch file in IPS or UPS format.
 .It Fl s Ar n , Fl -frameskip Ar n

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -219,6 +219,13 @@ from
 .It Cm \&!\ \&
 Break into the attached debugger.
 .El
+.Sh FILES
+.Bl -tag -width ~/.config/mgba/config.ini -compact
+.It Pa ~/.config/mgba/config.ini
+Default
+.Nm
+configuration file.
+.El
 .Sh AUTHORS
 .An Jeffrey Pfau Aq Mt jeffrey@endrift.com
 .Sh HOMEPAGE

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -125,7 +125,11 @@ It supports the following commands:
 .It Cm b Ns Oo Cm reak Oc Ar address
 .It Cm b Ns Oo Cm reak Oc Ns Cm /a Ar address
 .It Cm b Ns Oo Cm reak Oc Ns Cm /t Ar address
-Set a breakpoint at
+Set a breakpoint \(en ARM
+.Pq Ql /a ,
+Thumb
+.Pq Ql /t ,
+or the current CPU mode \(en at
 .Ar address .
 .It Cm c Ns Op Cm ontinue
 Continue execution.
@@ -140,8 +144,13 @@ Delete a breakpoint at
 .It Cm dis Ns Oo Cm assemble Oc Ns Cm /t Ar address Op Ar count
 Disassemble
 .Ar count
-instructions starting at address
-.Ar address .
+instructions starting at
+.Ar address ,
+as ARM
+.Pq Ql /a ,
+Thumb
+.Pq Ql /t ,
+or the current CPU mode.
 If
 .Ar count
 is not specified, only disassemble the instruction at
@@ -156,8 +165,13 @@ Execute the next instruction.
 .It Cm p Ns Oo Cm rint Oc Ar value ...
 .It Cm p Ns Oo Cm rint Oc Ns Cm /t Ar value ...
 .It Cm p Ns Oo Cm rint Oc Ns Cm /x Ar value ...
-Print
-.Ar value .
+Print one or more
+.Ar value Ns s
+as binary
+.Pq Ql /t ,
+hexadecimal
+.Pq Ql /x ,
+or decimal.
 .It Cm q Ns Op Cm uit
 Quit the emulator.
 .It Cm reset
@@ -165,7 +179,13 @@ Reset the emulation.
 .It Cm r/1 Ar address
 .It Cm r/2 Ar address
 .It Cm r/4 Ar address
-Read a byte, halfword, or word from
+Read a byte
+.Pq Ql /1 ,
+halfword
+.Pq Ql /2 ,
+or word
+.Pq Ql /4
+from
 .Ar address .
 .It Cm w Ns Oo Cm atch Oc Ar address
 Set a watchpoint at
@@ -173,7 +193,13 @@ Set a watchpoint at
 .It Cm w/1 Ar address
 .It Cm w/2 Ar address
 .It Cm w/4 Ar address
-Write a byte, halfword, or word to
+Write a byte
+.Pq Ql /1 ,
+halfword
+.Pq Ql /2 ,
+or word
+.Pq Ql /4
+to
 .Ar address .
 .It Cm w/r Ar register
 Write a word to
@@ -181,7 +207,13 @@ Write a word to
 .It Cm x/1 Ar address
 .It Cm x/2 Ar address
 .It Cm x/4 Ar address
-Examine bytes, halfwords, or words from
+Examine bytes
+.Pq Ql /1 ,
+halfwords
+.Pq Ql /2 ,
+or words
+.Pq Ql /4
+from
 .Ar address .
 .It Cm \&!\ \&
 Break into the attached debugger.

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -208,8 +208,10 @@ or word
 .Pq Ql /4
 to
 .Ar address .
-.It Cm w/r Ar register
-Write a word to
+.It Cm w/r Ar register data
+Write
+.Ar data
+as a word to
 .Ar register .
 .It Cm x/1 Ar address Op Ar count
 .It Cm x/2 Ar address Op Ar count

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -211,10 +211,12 @@ to
 .It Cm w/r Ar register
 Write a word to
 .Ar register .
-.It Cm x/1 Ar address
-.It Cm x/2 Ar address
-.It Cm x/4 Ar address
-Examine bytes
+.It Cm x/1 Ar address Op Ar count
+.It Cm x/2 Ar address Op Ar count
+.It Cm x/4 Ar address Op Ar count
+Examine
+.Ar count
+bytes
 .Pq Ql /1 ,
 halfwords
 .Pq Ql /2 ,
@@ -222,6 +224,9 @@ or words
 .Pq Ql /4
 from
 .Ar address .
+If
+.Ar count
+is not specified, examine 16 bytes, 8 halfwords, or 4 words.
 .It Cm \&!\ \&
 Break into the attached debugger.
 .El

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -59,27 +59,27 @@ Log messages during emulation to
 .Dv stdout .
 .Ar loglevel
 is a bitmask defining which types of messages to log:
-.Bl -inset
-.It 1
-fatal errors
-.It 2
-errors
-.It 4
-warnings
-.It 8
-informative messages
-.It 16
-debugging messages
-.It 32
-stub messages for unimplemented features
-.It 256
-in\(hygame errors
-.It 512
-software interrupts
-.It 1024
-emulator status messages
-.It 2048
-serial I/O messages
+.Bl -bullet -compact
+.It
+1 \(en fatal errors
+.It
+2 \(en errors
+.It
+4 \(en warnings
+.It
+8 \(en informative messages
+.It
+16 \(en debugging messages
+.It
+32 \(en stub messages for unimplemented features
+.It
+256 \(en in\(hygame errors
+.It
+512 \(en software interrupts
+.It
+1024 \(en emulator status messages
+.It
+2048 \(en serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -82,7 +82,7 @@ serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.
 .It Fl p Ar patchfile , Fl -patch Ar patchfile
-Specify a patch file in IPS or UPS format.
+Specify a patch file in BPS, IPS, or UPS format.
 .It Fl s Ar n , Fl -frameskip Ar n
 Skip every
 .Ar n

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -59,25 +59,25 @@ Log messages during emulation to
 .Ar loglevel
 is a bitmask defining which types of messages to log:
 .Bl -inset
-.It 0x01
+.It 1
 fatal errors
-.It 0x02
+.It 2
 errors
-.It 0x04
+.It 4
 warnings
-.It 0x08
+.It 8
 informative messages
-.It 0x10
+.It 16
 debugging messages
-.It 0x20
+.It 32
 stub messages
-.It 0x100
+.It 256
 in\(hygame errors
-.It 0x200
+.It 512
 software interrupts
-.It 0x400
+.It 1024
 emulator status messages
-.It 0x800
+.It 2048
 serial I/O messages
 .El
 The default is to log warnings, errors, fatal errors, and status messages.

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -40,7 +40,8 @@ Scale the window 6\(mu.
 Specify a BIOS file to use during boot.
 If this flag is omitted,
 .Nm
-will use a high\(hylevel emulated BIOS.
+will use the BIOS specified in the configuration file,
+or a high\(hylevel emulated BIOS if none is specified.
 .It Fl c Ar cheatfile , Fl -cheats Ar cheatfile
 Apply cheat codes from
 .Ar cheatfile .

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -71,7 +71,7 @@ informative messages
 .It 16
 debugging messages
 .It 32
-stub messages
+stub messages for unimplemented features
 .It 256
 in\(hygame errors
 .It 512

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -163,7 +163,8 @@ is not specified, only disassemble the current address.
 Print help.
 .It Cm i Ns Op Cm nfo
 .It Cm status
-Print the current contents of general\(hypurpose registers.
+Print the current contents of general\(hypurpose registers and the current
+program state register, and disassemble the current instruction.
 .It Cm n Ns Op Cm ext
 Execute the next instruction.
 .It Cm p Ns Oo Cm rint Oc Ar value ...

--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -134,7 +134,7 @@ or the current CPU mode \(en at
 .Ar address .
 .It Cm c Ns Op Cm ontinue
 Continue execution.
-.It Cm d Ns Oo elete Oc Ar address
+.It Cm d Ns Oo Cm elete Oc Ar address
 Delete a breakpoint at
 .Ar address .
 .It Cm dis Ns Oo Cm asm Oc Ar address Op Ar count


### PR DESCRIPTION
My first instinct when about to use a new emulator is to check the manpage, so I can see the command line flags and default keybindings.

I don’t know what magic CMake needs to install it in the man directories.

Gave it MPL 2.0. Would prefer something simpler like MIT honestly, but figured it was better to be consistent with the rest of mgba (unless you’re willing to relicense…).