### PR TITLE
Initialize more of the sockaddr_in structs.

### DIFF
--- a/src/util/socket.h
+++ b/src/util/socket.h
@@ -51,6 +51,7 @@ static inline Socket SocketOpenTCP(int port, uint32_t bindAddress) {
 	}
 
 	struct sockaddr_in bindInfo = {
+		.sin_len = 0,
 		.sin_family = AF_INET,
 		.sin_port = htons(port),
 		.sin_addr = { 0 }
@@ -71,6 +72,7 @@ static inline Socket SocketConnectTCP(int port, uint32_t destinationAddress) {
 	}
 
 	struct sockaddr_in bindInfo = {
+		.sin_len = 0,
 		.sin_family = AF_INET,
 		.sin_port = htons(port),
 		.sin_addr = { 0 }


### PR DESCRIPTION
On OpenBSD, mgba doesn’t build:

    In file included from /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/debugger/gdb-stub.h:13:0,
                     from /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/platform/qt/GDBController.h:12,
                     from /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/platform/qt/Window.h:18,
                     from /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/platform/qt/Window.cpp:6:
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h: In function 'Socket SocketOpenTCP(int, uint32_t)':
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:57:2: sorry, unimplemented: non-trivial designated initializers not supported
      };
      ^
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:57:2: sorry, unimplemented: non-trivial designated initializers not supported
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:57:2: sorry, unimplemented: non-trivial designated initializers not supported
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h: In function 'Socket SocketConnectTCP(int, uint32_t)':
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:77:2: sorry, unimplemented: non-trivial designated initializers not supported
      };
      ^
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:77:2: sorry, unimplemented: non-trivial designated initializers not supported
    /usr/ports/pobj/mgba-0.1.0/mgba-0.1.0/src/util/socket.h:77:2: sorry, unimplemented: non-trivial designated initializers not supported
    ninja: build stopped: subcommand failed.

Initializing another struct member so they don’t get initialized out of order fixes the issue. See OpenBSD’s definition of `sockaddr_in`:

    struct sockaddr_in {
            u_int8_t    sin_len;
            sa_family_t sin_family;
            in_port_t   sin_port;
            struct      in_addr sin_addr;
            int8_t      sin_zero[8];
    };

But I don’t know:
* if the value should be initialized to something other than 0
* if this could cause similar portability issues on non‐OpenBSD platforms