### PR TITLE
Qt: Fix installation path of XDG desktop file

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -167,7 +167,7 @@ install(TARGETS ${BINARY_NAME}-qt
 if(UNIX AND NOT APPLE)
 	find_program(DESKTOP_FILE_INSTALL desktop-file-install)
 	if(DESKTOP_FILE_INSTALL)
-		install(CODE "execute_process(COMMAND ${DESKTOP_FILE_INSTALL} \"${CMAKE_SOURCE_DIR}/res/mgba-qt.desktop\" --dir \"$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/applications/\")")
+		install(CODE "execute_process(COMMAND ${DESKTOP_FILE_INSTALL} \"${CMAKE_SOURCE_DIR}/res/mgba-qt.desktop\" --dir \"${CMAKE_INSTALL_DATADIR}/applications/\")")
 	endif()
 endif()
 if(UNIX)


### PR DESCRIPTION
Without this, the desktop file gets installed outside the DESTDIR prefix.