### PR TITLE
software renderer: Silence -Wlogical-not-parentheses warnings

### DIFF
--- a/src/gba/renderers/software-bg.c
+++ b/src/gba/renderers/software-bg.c
@@ -124,7 +124,7 @@ void GBAVideoSoftwareRendererDrawBackgroundMode3(struct GBAVideoSoftwareRenderer
 		}
 
 		uint32_t current = *pixel;
-		if (!objwinSlowPath || !(current & FLAG_OBJWIN) != objwinOnly) {
+		if (!objwinSlowPath || (!(current & FLAG_OBJWIN)) != objwinOnly) {
 			unsigned mergedFlags = flags;
 			if (current & FLAG_OBJWIN) {
 				mergedFlags = objwinFlags;
@@ -166,7 +166,7 @@ void GBAVideoSoftwareRendererDrawBackgroundMode4(struct GBAVideoSoftwareRenderer
 		if (color && IS_WRITABLE(current)) {
 			if (!objwinSlowPath) {
 				_compositeBlendNoObjwin(renderer, pixel, palette[color] | flags, current);
-			} else if (objwinForceEnable || !(current & FLAG_OBJWIN) == objwinOnly) {
+			} else if (objwinForceEnable || (!(current & FLAG_OBJWIN)) == objwinOnly) {
 				color_t* currentPalette = (current & FLAG_OBJWIN) ? objwinPalette : palette;
 				unsigned mergedFlags = flags;
 				if (current & FLAG_OBJWIN) {
@@ -213,7 +213,7 @@ void GBAVideoSoftwareRendererDrawBackgroundMode5(struct GBAVideoSoftwareRenderer
 		}
 
 		uint32_t current = *pixel;
-		if (!objwinSlowPath || !(current & FLAG_OBJWIN) != objwinOnly) {
+		if (!objwinSlowPath || (!(current & FLAG_OBJWIN)) != objwinOnly) {
 			unsigned mergedFlags = flags;
 			if (current & FLAG_OBJWIN) {
 				mergedFlags = objwinFlags;

--- a/src/gba/renderers/software-private.h
+++ b/src/gba/renderers/software-private.h
@@ -84,7 +84,7 @@ static inline void _compositeNoBlendNoObjwin(struct GBAVideoSoftwareRenderer* re
 }
 
 #define COMPOSITE_16_OBJWIN(BLEND)                                                                              \
-	if (objwinForceEnable || !(current & FLAG_OBJWIN) == objwinOnly) {                                          \
+	if (objwinForceEnable || (!(current & FLAG_OBJWIN)) == objwinOnly) {                                          \
 		unsigned color = (current & FLAG_OBJWIN) ? objwinPalette[paletteData | pixelData] : palette[pixelData]; \
 		unsigned mergedFlags = flags; \
 		if (current & FLAG_OBJWIN) { \
@@ -97,7 +97,7 @@ static inline void _compositeNoBlendNoObjwin(struct GBAVideoSoftwareRenderer* re
 	_composite ## BLEND ## NoObjwin(renderer, pixel, palette[pixelData] | flags, current);
 
 #define COMPOSITE_256_OBJWIN(BLEND) \
-	if (objwinForceEnable || !(current & FLAG_OBJWIN) == objwinOnly) { \
+	if (objwinForceEnable || (!(current & FLAG_OBJWIN)) == objwinOnly) { \
 		unsigned color = (current & FLAG_OBJWIN) ? objwinPalette[pixelData] : palette[pixelData]; \
 		unsigned mergedFlags = flags; \
 		if (current & FLAG_OBJWIN) { \


### PR DESCRIPTION
Silences a load of warnings when compiling with GCC 5.2.1