### PR TITLE
Disable BIOS by default

### DIFF
--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -378,9 +378,6 @@
          <property name="text">
           <string>Use BIOS file</string>
          </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
         </widget>
        </item>
        <item row="3" column="0" colspan="2">


### PR DESCRIPTION
Since BIOS files will never be included, the only people who will ever use them are people who add their own. Those people are already in the settings page, adding their BIOS files. For plug-and-play users, the emulated BIOS should be default.