### PR TITLE
Qt: screen rotation

### DIFF
--- a/src/platform/opengl/gl.c
+++ b/src/platform/opengl/gl.c
@@ -80,9 +80,9 @@ void GBAGLContextDrawFrame(struct VideoBackend* v) {
 	glTexCoordPointer(2, GL_INT, 0, _glTexCoords);
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
+	glRotatef(v->rotation, 0.f, 0.f, 1.f);
 	glOrtho(0, VIDEO_HORIZONTAL_PIXELS, VIDEO_VERTICAL_PIXELS, 0, 0, 1);
 	glMatrixMode(GL_MODELVIEW);
-	glLoadIdentity();
 	glBindTexture(GL_TEXTURE_2D, context->tex);
 	if (v->filter) {
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/src/platform/qt/Display.cpp
+++ b/src/platform/qt/Display.cpp
@@ -70,6 +70,10 @@ void Display::filter(bool filter) {
 	m_filter = filter;
 }
 
+void Display::rotate(int ang) {
+	m_rotation = ang;
+}
+
 void Display::showMessage(const QString& message) {
 	m_messagePainter.showMessage(message);
 	if (!isDrawing()) {

--- a/src/platform/qt/Display.h
+++ b/src/platform/qt/Display.h
@@ -33,6 +33,7 @@ public:
 	static void setDriver(Driver driver) { s_driver = driver; }
 
 	bool isAspectRatioLocked() const { return m_lockAspectRatio; }
+	int getRotation() const { return m_rotation; }
 	bool isFiltered() const { return m_filter; }
 
 	virtual bool isDrawing() const = 0;
@@ -51,6 +52,7 @@ public slots:
 	virtual void forceDraw() = 0;
 	virtual void lockAspectRatio(bool lock);
 	virtual void filter(bool filter);
+	virtual void rotate(int ang);
 	virtual void framePosted(const uint32_t*) = 0;
 	virtual void setShaders(struct VDir*) = 0;
 	virtual void clearShaders() = 0;
@@ -70,6 +72,7 @@ private:
 	MessagePainter m_messagePainter;
 	bool m_lockAspectRatio;
 	bool m_filter;
+	int m_rotation;
 	QTimer m_mouseTimer;
 };
 

--- a/src/platform/qt/DisplayGL.cpp
+++ b/src/platform/qt/DisplayGL.cpp
@@ -71,12 +71,13 @@ void DisplayGL::startDrawing(GBAThread* thread) {
 	m_painter->moveToThread(m_drawThread);
 	connect(m_drawThread, SIGNAL(started()), m_painter, SLOT(start()));
 	m_drawThread->start();
-	GBASyncSetVideoSync(&m_context->sync, false);
 
+	GBASyncSetVideoSync(&m_context->sync, false);
 	lockAspectRatio(isAspectRatioLocked());
 	filter(isFiltered());
 	messagePainter()->resize(size(), isAspectRatioLocked(), devicePixelRatio());
 	resizePainter();
+	rotate(getRotation());
 }
 
 void DisplayGL::stopDrawing() {
@@ -137,6 +138,13 @@ void DisplayGL::filter(bool filter) {
 	Display::filter(filter);
 	if (m_drawThread) {
 		QMetaObject::invokeMethod(m_painter, "filter", Q_ARG(bool, filter));
+	}
+}
+
+void DisplayGL::rotate(int ang) {
+	Display::rotate(ang);
+	if (m_drawThread) {
+		QMetaObject::invokeMethod(m_painter, "rotate", Q_ARG(int, ang));
 	}
 }
 
@@ -262,6 +270,13 @@ void PainterGL::setMessagePainter(MessagePainter* messagePainter) {
 
 void PainterGL::resize(const QSize& size) {
 	m_size = size;
+	if (m_started && !m_active) {
+		forceDraw();
+	}
+}
+
+void PainterGL::rotate(int ang) {
+	m_backend->rotation = ang;
 	if (m_started && !m_active) {
 		forceDraw();
 	}

--- a/src/platform/qt/DisplayGL.h
+++ b/src/platform/qt/DisplayGL.h
@@ -57,6 +57,7 @@ public slots:
 	void forceDraw() override;
 	void lockAspectRatio(bool lock) override;
 	void filter(bool filter) override;
+	void rotate(int ang) override;
 	void framePosted(const uint32_t*) override;
 	void setShaders(struct VDir*) override;
 	void clearShaders() override;
@@ -96,6 +97,7 @@ public slots:
 	void pause();
 	void unpause();
 	void resize(const QSize& size);
+	void rotate(int ang);
 	void lockAspectRatio(bool lock);
 	void filter(bool filter);
 

--- a/src/platform/qt/DisplayQt.cpp
+++ b/src/platform/qt/DisplayQt.cpp
@@ -34,6 +34,10 @@ void DisplayQt::filter(bool filter) {
 	update();
 }
 
+void DisplayQt::rotate(int angle) {
+	update();
+}
+
 void DisplayQt::framePosted(const uint32_t* buffer) {
 	update();
 	if (const_cast<const QImage&>(m_backing).bits() == reinterpret_cast<const uchar*>(buffer)) {

--- a/src/platform/qt/DisplayQt.h
+++ b/src/platform/qt/DisplayQt.h
@@ -33,6 +33,7 @@ public slots:
 	void forceDraw() override { update(); }
 	void lockAspectRatio(bool lock) override;
 	void filter(bool filter) override;
+	void rotate(int ang) override;
 	void framePosted(const uint32_t*) override;
 	void setShaders(struct VDir*) override {}
 	void clearShaders() override {}

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -200,6 +200,8 @@ void Window::rotateFrame(int angleDeg) {
 
 	m_screenWidget->setSizeHint(newSize);
 	m_rotation = angleDeg;
+	newSize -= m_screenWidget->size();
+	newSize += size();
 	resize(newSize);
 	m_display->rotate(angleDeg);
 }

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -49,6 +49,7 @@ public:
 	void argumentsPassed(GBAArguments*);
 
 	void resizeFrame(int width, int height);
+	void rotateFrame(int angleDeg);
 
 signals:
 	void startDrawing(GBAThread*);
@@ -170,6 +171,7 @@ private:
 	ShortcutController* m_shortcutController;
 	int m_playerId;
 	bool m_fullscreenOnStart;
+	int m_rotation;
 
 	bool m_hitUnimplementedBiosCall;
 

--- a/src/platform/video-backend.h
+++ b/src/platform/video-backend.h
@@ -30,6 +30,7 @@ struct VideoBackend {
 
 	bool filter;
 	bool lockAspectRatio;
+	int rotation;
 };
 
 struct VideoShader {


### PR DESCRIPTION
We're a group of three Computer Science and Engineering students from [Faculdade de Engenharia da Universidade do Porto](http://fe.up.pt) (FEUP). Earlier this semester we had to pick an active open-source project on GitHub as a study subject for a software engineering course. 

Since we're all into retrogaming, Pokemon and other Nintendo games, choosing a Game Boy Advance console emulator sounded like a no-brainer to us. We were given several assignments throughout the whole semester, mostly reports about software development processes, software verification and validation and requirements elicitation, for which we  [forked](https://github.com/cassos/mgba) your repository.

For the very last assignment we were asked to effectively contribute to this project by developing a new feature or improving an existing one as proof of concept for "software evolution". We decided to implement a screen rotation feature, as described on issues #179 and #162, and here's our attempt at it. Currently we only managed to implement it under Qt & OpenGL, as we weren't asked to make much bigger changes to the code. We're not planning in developing this feature any further, but you can still reuse our code for any purposes in the future.

![mgba-rotation1](https://cloud.githubusercontent.com/assets/9061906/11768521/c3f73ab4-a1c7-11e5-987a-8d0ba131ba8a.PNG)

![mgba-rotation2](https://cloud.githubusercontent.com/assets/9061906/11768522/d92793c0-a1c7-11e5-9b2b-dae59a3f634b.PNG)