### PR TITLE
Unpause the emulator when resetting.

### DIFF
--- a/src/platform/qt/GameController.cpp
+++ b/src/platform/qt/GameController.cpp
@@ -474,6 +474,7 @@ void GameController::setPaused(bool paused) {
 }
 
 void GameController::reset() {
+	setPaused(false);
 	GBAThreadReset(&m_threadContext);
 }
 


### PR DESCRIPTION
mgba-qt hangs if you reset the emulator while it is paused.  Subsequently unpausing the emulator does not resolve the hang, although reloading the rom does.

The immediate cause of the hang is that the CPU thread is waiting for the audioRequiredCond condition in GBASyncProduceAudio.  This condition never gets raised because AudioProcessorSDL has paused the audio.  Because the thread's state was set to THREAD_RUNNING by the reset, none of the unpause handlers will get called.

I've solved this by unpausing the emulator before resetting it.