### PR TITLE
Don't include internal zip library when USE_MINIZIP is defined.

### DIFF
--- a/src/util/vfs/vfs-zip.c
+++ b/src/util/vfs/vfs-zip.c
@@ -34,7 +34,11 @@ enum {
 	BLOCK_SIZE = 1024
 };
 #else
+#ifdef USE_MINIZIP
+#include <minizip/unzip.h>
+#else
 #include "third-party/zlib/contrib/minizip/unzip.h"
+#endif
 #include "util/memory.h"
 
 struct VDirEntryZip {


### PR DESCRIPTION
According to CmakeLists.txt file USE_MINIZIP enables linking against system
minizip library but the code in src/util/vfs/vfs-zip.c doesn't reflect that.