### PR TITLE
Qt: Fix software renderer scaling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Bugfixes:
  - GBA Serialize: Savestates now properly store prefetch
  - PSP2: Fix accelerometer range
  - PSP2: Actually load screen mode setting
+ - Qt: Fix bug in software renderer scaling
 Misc:
  - 3DS: Use blip_add_delta_fast for a small speed improvement
  - OpenGL: Log shader compilation failure

--- a/src/platform/qt/DisplayQt.cpp
+++ b/src/platform/qt/DisplayQt.cpp
@@ -62,7 +62,7 @@ void DisplayQt::paintEvent(QPaintEvent*) {
 	QSize ds = s;
 	if (isAspectRatioLocked()) {
 		if (s.width() * m_height > s.height() * m_width) {
-			ds.setWidth(s.height() * m_width / 2);
+			ds.setWidth(s.height() * m_width / m_height);
 		} else if (s.width() * m_height < s.height() * m_width) {
 			ds.setHeight(s.width() * m_height / m_width);
 		}


### PR DESCRIPTION
When the aspect ratio is locked and the window's aspect ratio is wider than the game boy's, the Qt software renderer divides the width by 2 instead of the game boy's height.  As a result, the video is way too wide.

Here's what it looks like without this fix:

![mgba_without_my_aspect_ratio_fix](https://cloud.githubusercontent.com/assets/3129682/17456646/e7138580-5b93-11e6-936d-abf2daf67430.png)

Here's what it looks like with this fix:

![mgba_with_my_aspect_ratio_fix](https://cloud.githubusercontent.com/assets/3129682/17456648/f36cc864-5b93-11e6-8bf9-a06184022614.png)
