### PR TITLE
Qt: Set OpenGL version to 2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugfixes:
  - PSP2: Actually load screen mode setting
  - Qt: Fix bug in software renderer scaling
  - Debugger: Fix GDB breakpoints
+ - Qt: Set OpenGL version to 2.0
 Misc:
  - 3DS: Use blip_add_delta_fast for a small speed improvement
  - OpenGL: Log shader compilation failure

--- a/src/platform/qt/Display.cpp
+++ b/src/platform/qt/Display.cpp
@@ -29,7 +29,7 @@ Display* Display::create(QWidget* parent) {
 	switch (s_driver) {
 #if defined(BUILD_GL) || defined(BUILD_GLES2) || defined(USE_EPOXY)
 	case Driver::OPENGL:
-		format.setVersion(3, 0);
+		format.setVersion(2, 0);
 		return new DisplayGL(format, parent);
 #endif
 #ifdef BUILD_GL
@@ -43,7 +43,7 @@ Display* Display::create(QWidget* parent) {
 
 	default:
 #if defined(BUILD_GL) || defined(BUILD_GLES2) || defined(USE_EPOXY)
-		format.setVersion(3, 0);
+		format.setVersion(2, 0);
 		return new DisplayGL(format, parent);
 #else
 		return new DisplayQt(parent);


### PR DESCRIPTION
Prior to commit f95be3071abe4393d940cfb14c2aa4f7dd0f1398, the OpenGL renderer was using QGLFormat's default version number, which is 2.0 (see http://code.qt.io/cgit/qt/qtbase.git/tree/src/opengl/qgl_p.h#n79 ).  f95be3071abe4393d940cfb14c2aa4f7dd0f1398 changes this to 3.0.  This causes the OpenGL renderer to display an empty screen when a rom is loaded.