### PR TITLE
Qt: Reset button status after turning off autofire

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugfixes:
  - Debugger: Fix GDB breakpoints
  - Wii: Fix framelimiting after a slowdown
  - PSP2: Fix gyroscope direction
+ - Qt: Fix hanging key press after disabling autofire
 Misc:
  - 3DS: Use blip_add_delta_fast for a small speed improvement
  - OpenGL: Log shader compilation failure

--- a/src/platform/qt/GameController.cpp
+++ b/src/platform/qt/GameController.cpp
@@ -665,6 +665,11 @@ void GameController::setAutofire(int key, bool enable) {
 	if (key >= GBA_KEY_MAX || key < 0) {
 		return;
 	}
+
+	if (!enable && m_autofireStatus[key]) {
+		keyReleased(key);
+	}
+
 	m_autofire[key] = enable;
 	m_autofireStatus[key] = 0;
 }


### PR DESCRIPTION
When disabling the autofire option the key is sometimes left in the pressed status, causing it to ignore further button presses. This change forces the key to be released in those cases.