### PR TITLE
[Wii] Fix garbage flash at startup, and other minor things

### DIFF
--- a/src/platform/wii/main.c
+++ b/src/platform/wii/main.c
@@ -112,12 +112,13 @@ static void reconfigureScreen(struct mCore* core, GXRModeObj* vmode) {
 	VIDEO_SetBlack(true);
 	VIDEO_Configure(vmode);
 	VIDEO_SetNextFramebuffer(framebuffer[whichFb]);
-	VIDEO_SetBlack(false);
 	VIDEO_Flush();
 	VIDEO_WaitVSync();
 	if (vmode->viTVMode & VI_NON_INTERLACE) {
 		VIDEO_WaitVSync();
 	}
+	vmode->viWidth = 704;
+	VIDEO_SetBlack(false);
 	GX_SetViewport(0, 0, vmode->fbWidth, vmode->efbHeight, 0, 1);
 
 	f32 yscale = GX_GetYScaleFactor(vmode->efbHeight, vmode->xfbHeight);
@@ -431,7 +432,7 @@ static void _audioDMA(void) {
 static void _drawStart(void) {
 	u32 level = 0;
 	_CPU_ISR_Disable(level);
-	if (referenceRetraceCount >= retraceCount) {
+	if (referenceRetraceCount > retraceCount) {
 		if (frameLimiter) {
 			VIDEO_WaitVSync();
 		}


### PR DESCRIPTION
I'd like to have the pixel accurate image stretched like that because it's supposed to be as close as square pixels you can get on GC/Wii, but it causes some problems, the interface is no longer overscan safe and I don't know the proper way to fix it. Without this change output looks too thin in PA mode.

The retraceCount change, I don't understand it but changing it to just be > makes games slightly faster, in FFVI I would notice audio crackling without this change.