### PR TITLE
GBA Cheats: Fix GameShark ROM patches

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Bugfixes:
  - Windows: Fix Unicode directory handling
  - Qt: Fix changing resolution of software renderer
  - Qt: Fix setting overrides
+ - GBA Cheats: Fix GameShark ROM patches
 Misc:
  - SDL: Remove scancode key input
  - GBA Video: Clean up unused timers

--- a/src/gba/cheats/gameshark.c
+++ b/src/gba/cheats/gameshark.c
@@ -145,7 +145,7 @@ bool GBACheatAddGameSharkRaw(struct GBACheatSet* cheats, uint32_t op1, uint32_t 
 		cheats->incompleteCheat = mCheatListIndex(&cheats->d.list, cheat);
 		break;
 	case GSA_PATCH:
-		cheats->romPatches[0].address = (op1 & 0xFFFFFF) << 1;
+		cheats->romPatches[0].address = BASE_CART0 | ((op1 & 0xFFFFFF) << 1);
 		cheats->romPatches[0].newValue = op2;
 		cheats->romPatches[0].applied = false;
 		cheats->romPatches[0].exists = true;


### PR DESCRIPTION
The address for GameShark ROM patch codes was being incorrectly calculated.  It appears that ActionReplay ROM patch codes were fixed in 3a3b7dffdb9e69763a9567119e45312d4b1453df, but no such fix was made for GameShark codes.