### PR TITLE
GBA Memory: Support for Mo Jie Qi Bing by Vast Fame

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Misc:
  - Debugger: Modularize CLI debugger
  - Core: Clean up some thread state checks
  - Debugger: Make building with debugging aspects optional
+ - GBA Memory: Support for Mo Jie Qi Bing by Vast Fame (taizou)
 
 0.5.1: (2016-10-05)
 Bugfixes:

--- a/src/gba/vfame.c
+++ b/src/gba/vfame.c
@@ -58,7 +58,9 @@ void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize) {
 		return;
 	}
 
-	if (memcmp(INIT_SEQUENCE, &rom[0x57], sizeof(INIT_SEQUENCE)) == 0) {
+	// Most games have the same init sequence in the same place
+	// but LOTR/Mo Jie Qi Bing doesn't, probably because it's based on the Kiki KaiKai engine, so just detect based on its title
+	if (memcmp(INIT_SEQUENCE, &rom[0x57], sizeof(INIT_SEQUENCE)) == 0 || memcmp("\0LORD\0WORD\0\0AKIJ", &((struct GBACartridge*) rom)->title, 16) == 0) {
 		cart->cartType = VFAME_STANDARD;
 		mLOG(GBA_MEM, INFO, "Vast Fame game detected");
 	}
@@ -262,14 +264,18 @@ static uint32_t _modifySramAddress(enum GBAVFameCartType type, uint32_t address,
 }
 
 static int8_t _modifySramValue(enum GBAVFameCartType type, uint8_t value, int mode) {
-	mode = (mode & 0xF) >> 2;
-	if (mode == 0) {
-		return value;
-	} else if (type == VFAME_GEORGE) {
-		return _reorderBits(value, VALUE_REORDERING_GEORGE[mode - 1], 8);
-	} else {
-		return _reorderBits(value, VALUE_REORDERING[mode - 1], 8);
+	int reorderType = (mode & 0xF) >> 2;
+	if (reorderType != 0) {
+		if (type == VFAME_GEORGE) {
+			value = _reorderBits(value, VALUE_REORDERING_GEORGE[reorderType - 1], 8);
+		} else {
+			value = _reorderBits(value, VALUE_REORDERING[reorderType - 1], 8);
+		}
 	}
+	if (mode & 0x80) {
+		value ^= 0xAA;
+	}
+	return value;
 }
 
 // Reorder bits in a byte according to the reordering given


### PR DESCRIPTION
Adds support for a feature of Vast Fame protected carts used by a newly dumped game, Mo Jie Qi Bing (aka Lord of the Rings). 

Also adds detection for this game based on its title, because it's based on Kiki KaiKai Advance and doesn't share the usual initialisation routine used to detect other Vast Fame games.