### PR TITLE
Fix missing termination in call to SET_INPUT_DESCRIPTORS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Features:
  - Debugging console
  - Improved memory viewer
 Bugfixes:
+ - Libretro: Fix unterminated SET_INPUT_DESCRIPTORS
  - LR35902: Fix core never exiting with certain event patterns
  - GB Timer: Improve DIV reset behavior
  - GBA Memory: Fix misaligned BIOS reads

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -177,7 +177,8 @@ void retro_init(void) {
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Brighten Solar Sensor" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Darken Solar Sensor" }
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Darken Solar Sensor" },
+		{ 0 }
 	};
 	environCallback(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, &inputDescriptors);
 


### PR DESCRIPTION
From https://github.com/libretro/mgba/pull/45