### PR TITLE
VBA Console Print

### DIFF
--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -315,3 +315,17 @@ void ARMRunFake(struct ARMCore* cpu, uint32_t opcode) {
 	cpu->prefetch[1] = cpu->prefetch[0];
 	cpu->prefetch[0] = opcode;
 }
+
+void ARMDebugPrint(struct ARMCore* cpu, uint32_t address)
+{
+	while (true) {
+		char c = cpu->memory.load8(cpu, address, NULL);
+
+		if (!c) {
+			break;
+		}
+
+		putchar(c);
+		address++;
+	}
+}

--- a/src/arm/arm.h
+++ b/src/arm/arm.h
@@ -174,5 +174,6 @@ void ARMRaiseUndefined(struct ARMCore*);
 void ARMRun(struct ARMCore* cpu);
 void ARMRunLoop(struct ARMCore* cpu);
 void ARMRunFake(struct ARMCore* cpu, uint32_t opcode);
+void ARMDebugPrint(struct ARMCore* cpu, uint32_t address);
 
 #endif

--- a/src/arm/isa-arm.c
+++ b/src/arm/isa-arm.c
@@ -435,8 +435,12 @@ DEFINE_ALU_INSTRUCTION_ARM(ADC, ARM_ADDITION_S(n, cpu->shifterOperand, cpu->gprs
 	int32_t n = cpu->gprs[rn];
 	cpu->gprs[rd] = n + cpu->shifterOperand + cpu->cpsr.c;)
 
-DEFINE_ALU_INSTRUCTION_ARM(AND, ARM_NEUTRAL_S(cpu->gprs[rn], cpu->shifterOperand, cpu->gprs[rd]),
-	cpu->gprs[rd] = cpu->gprs[rn] & cpu->shifterOperand;)
+DEFINE_ALU_INSTRUCTION_ARM(AND,
+	ARM_NEUTRAL_S(cpu->gprs[rn], cpu->shifterOperand, cpu->gprs[rd]),
+	cpu->gprs[rd] = cpu->gprs[rn] & cpu->shifterOperand;
+	if ((uint32_t) cpu->gprs[0] == 0xC0DED00D && rd == rn && !rd) {
+		ARMDebugPrint(cpu, cpu->gprs[2]);
+	})
 
 DEFINE_ALU_INSTRUCTION_ARM(BIC, ARM_NEUTRAL_S(cpu->gprs[rn], cpu->shifterOperand, cpu->gprs[rd]),
 	cpu->gprs[rd] = cpu->gprs[rn] & ~cpu->shifterOperand;)

--- a/src/arm/isa-thumb.c
+++ b/src/arm/isa-thumb.c
@@ -80,7 +80,7 @@ DEFINE_IMMEDIATE_5_INSTRUCTION_THUMB(LSR1,
 	}
 	THUMB_NEUTRAL_S( , , cpu->gprs[rd]);)
 
-DEFINE_IMMEDIATE_5_INSTRUCTION_THUMB(ASR1, 
+DEFINE_IMMEDIATE_5_INSTRUCTION_THUMB(ASR1,
 	if (!immediate) {
 		cpu->cpsr.c = ARM_SIGN(cpu->gprs[rm]);
 		if (cpu->cpsr.c) {
@@ -138,7 +138,12 @@ DEFINE_DATA_FORM_3_INSTRUCTION_THUMB(SUB2, THUMB_SUBTRACTION(cpu->gprs[rd], cpu-
 		int rn = (opcode >> 3) & 0x0007; \
 		BODY;)
 
-DEFINE_DATA_FORM_5_INSTRUCTION_THUMB(AND, cpu->gprs[rd] = cpu->gprs[rd] & cpu->gprs[rn]; THUMB_NEUTRAL_S( , , cpu->gprs[rd]))
+DEFINE_DATA_FORM_5_INSTRUCTION_THUMB(AND,
+	cpu->gprs[rd] = cpu->gprs[rd] & cpu->gprs[rn];
+	if ((uint32_t) cpu->gprs[0] == 0xC0DED00D && rd == rn && !rd) {
+		ARMDebugPrint(cpu, cpu->gprs[2]);
+	}
+	THUMB_NEUTRAL_S( , , cpu->gprs[rd]))
 DEFINE_DATA_FORM_5_INSTRUCTION_THUMB(EOR, cpu->gprs[rd] = cpu->gprs[rd] ^ cpu->gprs[rn]; THUMB_NEUTRAL_S( , , cpu->gprs[rd]))
 DEFINE_DATA_FORM_5_INSTRUCTION_THUMB(LSL2,
 	int rs = cpu->gprs[rn] & 0xFF;


### PR DESCRIPTION
libgba implements various ways of printing to the console, but the only one that seems to work in VBA is the [mappy print](https://github.com/devkitPro/libgba/blob/master/src/mappy_print.c). This works by checking for a `and r0, r0` where `r0` is `0xC0DED00D` before printing the null-terminated string at the address in `r2`. While this is not ideal, it seems to be the only way to get debug console printing working in both VBA and mGBA.