### PR TITLE
GBA SIO: Fix layout of normalControl struct in siocnt union

### DIFF
--- a/include/mgba/internal/gba/sio.h
+++ b/include/mgba/internal/gba/sio.h
@@ -54,9 +54,9 @@ struct GBASIO {
 			unsigned internalSc : 1;
 			unsigned si : 1;
 			unsigned idleSo : 1;
-			unsigned : 4;
-			unsigned start : 1;
 			unsigned : 3;
+			unsigned start : 1;
+			unsigned : 4;
 			unsigned length : 1;
 			unsigned : 1;
 			unsigned irq : 1;


### PR DESCRIPTION
I noticed that the layout of the normalControl struct in [sio.h](https://github.com/mgba-emu/mgba/blob/9942c1d44440d22ad0e7fd5ec58b3bdbe4efd92d/include/mgba/internal/gba/sio.h#L52-L64) is incorrect. According to [GBATEK](http://problemkaputt.de/gbatek.htm#sionormalmode), the first unused section is 3 bits long (bits 4,5,6) and the second is 4 bits long (8,9,10,11). mGBA has 4 bits in the first section unused (bits 4,5,6,7) and 3 in the second section (bits 9,10,11). As a consequence, `sio.normalControl.start` is in the wrong place. A minor bug that doesn't appear to affect mGBA currently, but will be a barrier to work on the wireless adapter.