### PR TITLE
Doc: Improve notes for MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,15 @@ This will build and install mGBA into `/usr/bin` and `/usr/lib`. Dependencies th
 
 #### Windows developer building
 
-To build on Windows for development, using MSYS2 is recommended. Follow the installation steps found on their [website](https://msys2.github.io). Make sure you're running the 32-bit version ("MinGW-w64 Win32 Shell") and run this additional command (including the braces) to install the needed dependencies (please note that this involves downloading over 500MiB of packages, so it will take a long time):
+To build on Windows for development, using MSYS2 is recommended. Follow the installation steps found on their [website](https://msys2.github.io). Make sure you're running the 32-bit version ("MinGW-w64 Win32 Shell") (or the 64-bit version "MinGW-w64 Win64 Shell" if you want to build for x86_64) and run this additional command (including the braces) to install the needed dependencies (please note that this involves downloading over 500MiB of packages, so it will take a long time):
+
+For x86 (32 bit) builds:
 
 	pacman -Sy mingw-w64-i686-{cmake,ffmpeg,gcc,gdb,imagemagick,libzip,pkg-config,qt5,SDL2}
+
+For x86_64 (64 bit) builds:
+
+	pacman -Sy mingw-w64-x86_64-{cmake,ffmpeg,gcc,gdb,imagemagick,libzip,pkg-config,qt5,SDL2}
 
 Check out the source code by running this command:
 
@@ -112,7 +118,7 @@ Then finally build it by running these commands:
 	cmake .. -G "MSYS Makefiles"
 	make
 
-Please note that this build of mGBA for Windows is not suitable for distribution, due to the scattering of DLLs it needs to run, but is perfect for development.
+Please note that this build of mGBA for Windows is not suitable for distribution, due to the scattering of DLLs it needs to run, but is perfect for development. However, if distributing such a build is desired (e.g. for testing on machines that don't have the MSYS2 environment installed), a tool called "[Dependency Walker](http://dependencywalker.com)" can be used to see which additional DLL files need to be shipped with the mGBA executable.
 
 ### Dependencies
 


### PR DESCRIPTION
This adds the commands you need to use if you want to build for x86_64 (64-bit) with MSYS2. It also adds a link to the tool called "Dependency Walker" which is able to tell you which additional DDLs you have to ship if you *really* want to distribute a MSYS2-compiled mGBA binary for testing purposes.

I use the 64 bit version of MSYS2/MinGW-w64 myself, so all commands are verified by myself.