### PR TITLE
Add 'extern "C"' guards to version.h.

### DIFF
--- a/include/mgba/core/version.h
+++ b/include/mgba/core/version.h
@@ -6,6 +6,10 @@
 #ifndef VERSION_H
 #define VERSION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const char* const gitCommit;
 extern const char* const gitCommitShort;
 extern const char* const gitBranch;
@@ -13,5 +17,9 @@ extern const int gitRevision;
 extern const char* const binaryName;
 extern const char* const projectName;
 extern const char* const projectVersion;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Needed by MSVC. Somehow missed this in last commit.