### PR TITLE
Fix GDB stub reporting of CPSR

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -321,11 +321,29 @@ static void _readGPRs(struct GDBStub* stub, const char* message) {
 	UNUSED(message);
 	int r;
 	int i = 0;
+
+	// General purpose registers
 	for (r = 0; r < ARM_PC; ++r) {
 		_int2hex32(cpu->gprs[r], &stub->outgoing[i]);
 		i += 8;
 	}
+
+	// Program counter
 	_int2hex32(cpu->gprs[ARM_PC] - (cpu->cpsr.t ? WORD_SIZE_THUMB : WORD_SIZE_ARM), &stub->outgoing[i]);
+	i += 8;
+
+	// Floating point registers, unused on the GBA (8 of them, 24 bits each)
+	for (r = 0; r < 8 * 3; ++r) {
+		_int2hex32(0, &stub->outgoing[i]);
+		i += 8;
+	}
+
+	// Floating point status, unused on the GBA (32 bits)
+	_int2hex32(0, &stub->outgoing[i]);
+	i += 8;
+
+	// CPU status
+	_int2hex32(cpu->cpsr.packed, &stub->outgoing[i]);
 	i += 8;
 
 	stub->outgoing[i] = 0;


### PR DESCRIPTION
First of all, thanks for developing this neat piece of software! Now, to the patch.

The GDB stub in mgba has a critical problem (has nobody come across this before ? am I the only one using it ;) ?). The 'g' request needs to return the cpu status register for the ARM remote GDB protocol, otherwise debugger interfaces such as IDA cannot detect whether the CPU is in ARM or THUMB mode (the 'T' bit). In particular, if you don't return anything, IDA just assumes that it is always in ARM mode, and then destroys all of the instructions in your disassembly which use THUMB by forcing them to be decoded as ARM (even if the analysis thinks they should be THUMB). 

This patch fixes that.