### PR TITLE
 	Qt: Show native directory separators in the GUI.

### DIFF
--- a/src/platform/qt/GBAApp.cpp
+++ b/src/platform/qt/GBAApp.cpp
@@ -163,7 +163,7 @@ QString GBAApp::getOpenFileName(QWidget* owner, const QString& title, const QStr
 	QString filename = QFileDialog::getOpenFileName(owner, title, m_configController.getOption("lastDirectory"), filter);
 	continueAll(paused);
 	if (!filename.isEmpty()) {
-		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().path());
+		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().canonicalPath());
 	}
 	return filename;
 }
@@ -174,7 +174,7 @@ QString GBAApp::getSaveFileName(QWidget* owner, const QString& title, const QStr
 	QString filename = QFileDialog::getSaveFileName(owner, title, m_configController.getOption("lastDirectory"), filter);
 	continueAll(paused);
 	if (!filename.isEmpty()) {
-		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().path());
+		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().canonicalPath());
 	}
 	return filename;
 }
@@ -185,21 +185,9 @@ QString GBAApp::getOpenDirectoryName(QWidget* owner, const QString& title) {
 	QString filename = QFileDialog::getExistingDirectory(owner, title, m_configController.getOption("lastDirectory"));
 	continueAll(paused);
 	if (!filename.isEmpty()) {
-		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().path());
+		m_configController.setOption("lastDirectory", QFileInfo(filename).dir().canonicalPath());
 	}
 	return filename;
-}
-
-QFileDialog* GBAApp::getOpenFileDialog(QWidget* owner, const QString& title, const QString& filter) {
-	FileDialog* dialog = new FileDialog(this, owner, title, filter);
-	dialog->setAcceptMode(QFileDialog::AcceptOpen);
-	return dialog;
-}
-
-QFileDialog* GBAApp::getSaveFileDialog(QWidget* owner, const QString& title, const QString& filter) {
-	FileDialog* dialog = new FileDialog(this, owner, title, filter);
-	dialog->setAcceptMode(QFileDialog::AcceptSave);
-	return dialog;
 }
 
 QString GBAApp::dataDir() {
@@ -240,24 +228,6 @@ bool GBAApp::reloadGameDB() {
 	return false;
 }
 #endif
-
-GBAApp::FileDialog::FileDialog(GBAApp* app, QWidget* parent, const QString& caption, const QString& filter)
-	: QFileDialog(parent, caption, app->m_configController.getOption("lastDirectory"), filter)
-	, m_app(app)
-{
-}
-
-int GBAApp::FileDialog::exec() {
-	QList<Window*> paused;
-	m_app->pauseAll(&paused);
-	bool didAccept = QFileDialog::exec() == QDialog::Accepted;
-	QStringList filenames = selectedFiles();
-	if (!filenames.isEmpty()) {
-		m_app->m_configController.setOption("lastDirectory", QFileInfo(filenames[0]).dir().path());
-	}
-	m_app->continueAll(paused);
-	return didAccept;
-}
 
 #ifdef USE_SQLITE3
 GameDBParser::GameDBParser(NoIntroDB* db, QObject* parent)

--- a/src/platform/qt/GBAApp.h
+++ b/src/platform/qt/GBAApp.h
@@ -55,9 +55,6 @@ public:
 	QString getSaveFileName(QWidget* owner, const QString& title, const QString& filter = QString());
 	QString getOpenDirectoryName(QWidget* owner, const QString& title);
 
-	QFileDialog* getOpenFileDialog(QWidget* owner, const QString& title, const QString& filter = QString());
-	QFileDialog* getSaveFileDialog(QWidget* owner, const QString& title, const QString& filter = QString());
-
 	const NoIntroDB* gameDB() const { return m_db; }
 	bool reloadGameDB();
 
@@ -65,16 +62,6 @@ protected:
 	bool event(QEvent*);
 
 private:
-	class FileDialog : public QFileDialog {
-	public:
-		FileDialog(GBAApp* app, QWidget* parent = nullptr, const QString& caption = QString(),
-		           const QString& filter = QString());
-		virtual int exec() override;
-
-	private:
-		GBAApp* m_app;
-	};
-
 	Window* newWindowInternal();
 
 	void pauseAll(QList<Window*>* paused);

--- a/src/platform/qt/GameController.cpp
+++ b/src/platform/qt/GameController.cpp
@@ -407,10 +407,10 @@ void GameController::loadGame(VFile* vf, const QString& path, const QString& bas
 	closeGame();
 	QFileInfo info(base);
 	if (info.isDir()) {
-		m_fname = base + QDir::separator() + path;
+		m_fname = QFileInfo(base + '/' + path).canonicalFilePath();
 		m_fsub = QString();
 	} else {
-		m_fname = base;
+		m_fname = info.canonicalFilePath();
 		m_fsub = path;
 	}
 	m_vf = vf;

--- a/src/platform/qt/ObjView.cpp
+++ b/src/platform/qt/ObjView.cpp
@@ -244,12 +244,8 @@ void ObjView::updateTilesGB(bool force) {
 
 void ObjView::exportObj() {
 	GameController::Interrupter interrupter(m_controller);
-	QFileDialog* dialog = GBAApp::app()->getSaveFileDialog(this, tr("Export sprite"),
-	                                                       tr("Portable Network Graphics (*.png)"));
-	if (!dialog->exec()) {
-		return;
-	}
-	QString filename = dialog->selectedFiles()[0];
+	QString filename = GBAApp::app()->getSaveFileName(this, tr("Export sprite"),
+	                                                  tr("Portable Network Graphics (*.png)"));
 	VFile* vf = VFileDevice::open(filename, O_WRONLY | O_CREAT | O_TRUNC);
 	if (!vf) {
 		LOG(QT, ERROR) << tr("Failed to open output PNG file: %1").arg(filename);

--- a/src/platform/qt/PaletteView.cpp
+++ b/src/platform/qt/PaletteView.cpp
@@ -134,21 +134,16 @@ void PaletteView::exportPalette(int start, int length) {
 	}
 
 	GameController::Interrupter interrupter(m_controller);
-	QFileDialog* dialog = GBAApp::app()->getSaveFileDialog(this, tr("Export palette"),
-	                                                       tr("Windows PAL (*.pal);;Adobe Color Table (*.act)"));
-	if (!dialog->exec()) {
-		return;
-	}
-	QString filename = dialog->selectedFiles()[0];
+	QString filename = GBAApp::app()->getSaveFileName(this, tr("Export palette"),
+	                                                  tr("Windows PAL (*.pal);;Adobe Color Table (*.act)"));
 	VFile* vf = VFileDevice::open(filename, O_WRONLY | O_CREAT | O_TRUNC);
 	if (!vf) {
 		LOG(QT, ERROR) << tr("Failed to open output palette file: %1").arg(filename);
 		return;
 	}
-	QString filter = dialog->selectedNameFilter();
-	if (filter.contains("*.pal")) {
+	if (filename.endsWith(".pal", Qt::CaseInsensitive)) {
 		exportPaletteRIFF(vf, length, &static_cast<GBA*>(m_controller->thread()->core->board)->video.palette[start]);
-	} else if (filter.contains("*.act")) {
+	} else if (filename.endsWith(".act", Qt::CaseInsensitive)) {
 		exportPaletteACT(vf, length, &static_cast<GBA*>(m_controller->thread()->core->board)->video.palette[start]);
 	}
 	vf->close(vf);

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1580,7 +1580,7 @@ void Window::updateMRU() {
 	m_mruMenu->clear();
 	int i = 0;
 	for (const QString& file : m_mruFiles) {
-		QAction* item = new QAction(file, m_mruMenu);
+		QAction* item = new QAction(QDir::toNativeSeparators(file).replace("&", "&&"), m_mruMenu);
 		item->setShortcut(QString("Ctrl+%1").arg(i));
 		connect(item, &QAction::triggered, [this, file]() { m_controller->loadGame(file); });
 		m_mruMenu->addAction(item);


### PR DESCRIPTION
The core still gets '/'s always (it chokes on '\'s), but the Qt
interface always uses the native separators.

In the process of doing this, also removed the custom FileDialog
subclass and made everything use GBAApp::get*FileDialog instead.

Also fixes #552, because I had to change that code anyway.