### PR TITLE
Add warning if the user is trying to set a software breakpoint in the BIOS region

### DIFF
--- a/src/arm/debugger/debugger.c
+++ b/src/arm/debugger/debugger.c
@@ -126,6 +126,10 @@ bool ARMDebuggerSetSoftwareBreakpoint(struct mDebuggerPlatform* d, uint32_t addr
 		return false;
 	}
 
+	if (address >= 0x3FFF) {
+		mLOG(DEBUGGER, WARN, "Software breakpoints are not supported in the BIOS region. Ignoring software breakpoint at 0x%X.", address);
+	}
+
 	struct ARMDebugBreakpoint* breakpoint = ARMDebugBreakpointListAppend(&debugger->swBreakpoints);
 	breakpoint->address = address;
 	breakpoint->isSw = true;

--- a/src/feature/commandline.c
+++ b/src/feature/commandline.c
@@ -31,6 +31,7 @@ static const struct option _options[] = {
 	{ "bios",      required_argument, 0, 'b' },
 	{ "cheats",    required_argument, 0, 'c' },
 	{ "frameskip", required_argument, 0, 's' },
+	{ "loglevel",  required_argument, 0, 'l' },
 #ifdef USE_EDITLINE
 	{ "debug",     no_argument, 0, 'd' },
 #endif
@@ -211,6 +212,7 @@ void usage(const char* arg0, const char* extraOptions) {
 	puts("\nGeneric options:");
 	puts("  -b, --bios FILE     GBA BIOS file to use");
 	puts("  -c, --cheats FILE   Apply cheat codes from a file");
+	puts("  -l, --loglevel N    Set log level to N (default is 0)");
 #ifdef USE_EDITLINE
 	puts("  -d, --debug         Use command-line debugger");
 #endif


### PR DESCRIPTION
Related to https://github.com/mgba-emu/mgba/issues/550

This adds a warning message indicating that you can't have a software breakpoint in the BIOS region. It also fixes a related issue: there appears to be a complete implementation of a log level flag, and so I added it to the help text which prints out when running mgba from the command line.