### PR TITLE
Fix Python build libraries

### DIFF
--- a/src/platform/python/_builder.py
+++ b/src/platform/python/_builder.py
@@ -47,7 +47,7 @@ struct mLoggerPy {
 };
 """, include_dirs=[incdir, srcdir],
      extra_compile_args=cppflags,
-     libraries=["mgba"],
+     libraries=["medusa-emu"],
      library_dirs=[bindir],
      sources=[os.path.join(pydir, path) for path in ["vfs-py.c", "log.c"]])
 


### PR DESCRIPTION
Before fix:

```
/usr/bin/ld: cannot find -lmgba
collect2: error: ld returned 1 exit status
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
python/CMakeFiles/medusa-emu-py.dir/build.make:62: recipe for target 'python/build/lib/medusa-emu/__init__.py' failed
make[2]: *** [python/build/lib/medusa-emu/__init__.py] Error 1
CMakeFiles/Makefile2:159: recipe for target 'python/CMakeFiles/medusa-emu-py.dir/all' failed
make[1]: *** [python/CMakeFiles/medusa-emu-py.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
```