### PR TITLE
Core Input: Correct a memset size within mInputUnbindHat()

### DIFF
--- a/src/core/input.c
+++ b/src/core/input.c
@@ -563,7 +563,7 @@ void mInputUnbindHat(struct mInputMap* map, uint32_t type, int id) {
 		mInputHatListResize(&impl->hats, -1);
 	} else {
 		struct mInputHatBindings* description = mInputHatListGetPointer(&impl->hats, id);
-		memset(description, -1, sizeof(&description));
+		memset(description, -1, sizeof(*description));
 	}
 }
 


### PR DESCRIPTION
Previously the binding struct wouldn't be fully invalidated.

Do you want me to add an entry to the CHANGES doc for this? (guidelines don't say whether or not to update them).