### PR TITLE
Qt: Switch to the C++11 connect() syntax.

### DIFF
--- a/src/platform/qt/AssetTile.cpp
+++ b/src/platform/qt/AssetTile.cpp
@@ -32,7 +32,7 @@ AssetTile::AssetTile(QWidget* parent)
 	m_ui.color->setDimensions(QSize(1, 1));
 	m_ui.color->setSize(50);
 
-	connect(m_ui.preview, SIGNAL(indexPressed(int)), this, SLOT(selectColor(int)));
+	connect(m_ui.preview, &Swatch::indexPressed, this, &AssetTile::selectColor);
 
 	const QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 

--- a/src/platform/qt/AssetView.cpp
+++ b/src/platform/qt/AssetView.cpp
@@ -20,9 +20,10 @@ AssetView::AssetView(GameController* controller, QWidget* parent)
 	m_updateTimer.setInterval(1);
 	connect(&m_updateTimer, SIGNAL(timeout()), this, SLOT(updateTiles()));
 
-	connect(m_controller, SIGNAL(frameAvailable(const uint32_t*)), &m_updateTimer, SLOT(start()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(close()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), &m_updateTimer, SLOT(stop()));
+	connect(m_controller, &GameController::frameAvailable, &m_updateTimer,
+	        static_cast<void(QTimer::*)()>(&QTimer::start));
+	connect(m_controller, &GameController::gameStopped, this, &AssetView::close);
+	connect(m_controller, &GameController::gameStopped, &m_updateTimer, &QTimer::stop);
 }
 
 void AssetView::updateTiles(bool force) {

--- a/src/platform/qt/CheatsView.cpp
+++ b/src/platform/qt/CheatsView.cpp
@@ -31,12 +31,12 @@ CheatsView::CheatsView(GameController* controller, QWidget* parent)
 	m_ui.cheatList->installEventFilter(this);
 	m_ui.cheatList->setModel(&m_model);
 
-	connect(m_ui.load, SIGNAL(clicked()), this, SLOT(load()));
-	connect(m_ui.save, SIGNAL(clicked()), this, SLOT(save()));
-	connect(m_ui.addSet, SIGNAL(clicked()), this, SLOT(addSet()));
-	connect(m_ui.remove, SIGNAL(clicked()), this, SLOT(removeSet()));
-	connect(controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(close()));
-	connect(controller, SIGNAL(stateLoaded(mCoreThread*)), &m_model, SLOT(invalidated()));
+	connect(m_ui.load, &QPushButton::clicked, this, &CheatsView::load);
+	connect(m_ui.save, &QPushButton::clicked, this, &CheatsView::save);
+	connect(m_ui.addSet, &QPushButton::clicked, this, &CheatsView::addSet);
+	connect(m_ui.remove, &QPushButton::clicked, this, &CheatsView::removeSet);
+	connect(controller, &GameController::gameStopped, this, &CheatsView::close);
+	connect(controller, &GameController::stateLoaded, &m_model, &CheatsModel::invalidated);
 
 	QPushButton* add;
 	switch (controller->platform()) {

--- a/src/platform/qt/ConfigController.cpp
+++ b/src/platform/qt/ConfigController.cpp
@@ -76,14 +76,12 @@ void ConfigOption::setValue(const char* value) {
 }
 
 void ConfigOption::setValue(const QVariant& value) {
-	QPair<QAction*, QVariant> action;
-	foreach (action, m_actions) {
+	for (QPair<QAction*, QVariant>& action : m_actions) {
 		bool signalsEnabled = action.first->blockSignals(true);
 		action.first->setChecked(value == action.second);
 		action.first->blockSignals(signalsEnabled);
 	}
-	std::function<void(const QVariant&)> slot;
-	foreach(slot, m_slots.values()) {
+	for (std::function<void(const QVariant&)>& slot : m_slots.values()) {
 		slot(value);
 	}
 }

--- a/src/platform/qt/DebuggerConsole.cpp
+++ b/src/platform/qt/DebuggerConsole.cpp
@@ -17,10 +17,10 @@ DebuggerConsole::DebuggerConsole(DebuggerConsoleController* controller, QWidget*
 {
 	m_ui.setupUi(this);
 
-	connect(m_ui.prompt, SIGNAL(returnPressed()), this, SLOT(postLine()));
-	connect(controller, SIGNAL(log(const QString&)), this, SLOT(log(const QString&)));
-	connect(m_ui.breakpoint, SIGNAL(clicked()), controller, SLOT(attach()));
-	connect(m_ui.breakpoint, SIGNAL(clicked()), controller, SLOT(breakInto()));
+	connect(m_ui.prompt, &QLineEdit::returnPressed, this, &DebuggerConsole::postLine);
+	connect(controller, &DebuggerConsoleController::log, this, &DebuggerConsole::log);
+	connect(m_ui.breakpoint, &QAbstractButton::clicked, controller, &DebuggerController::attach);
+	connect(m_ui.breakpoint, &QAbstractButton::clicked, controller, &DebuggerController::breakInto);
 }
 
 void DebuggerConsole::log(const QString& line) {

--- a/src/platform/qt/DebuggerController.cpp
+++ b/src/platform/qt/DebuggerController.cpp
@@ -30,7 +30,7 @@ void DebuggerController::attach() {
 		mDebuggerEnter(m_debugger, DEBUGGER_ENTER_ATTACHED, 0);
 	} else {
 		QObject::disconnect(m_autoattach);
-		m_autoattach = connect(m_gameController, SIGNAL(gameStarted(mCoreThread*, const QString&)), this, SLOT(attach()));
+		m_autoattach = connect(m_gameController, &GameController::gameStarted, this, &DebuggerController::attach);
 	}
 }
 

--- a/src/platform/qt/Display.cpp
+++ b/src/platform/qt/Display.cpp
@@ -63,7 +63,7 @@ Display::Display(QWidget* parent)
 #elif defined(M_CORE_GBA)
 	setMinimumSize(VIDEO_HORIZONTAL_PIXELS, VIDEO_VERTICAL_PIXELS);
 #endif
-	connect(&m_mouseTimer, SIGNAL(timeout()), this, SIGNAL(hideCursor()));
+	connect(&m_mouseTimer, &QTimer::timeout, this, &Display::hideCursor);
 	m_mouseTimer.setSingleShot(true);
 	m_mouseTimer.setInterval(MOUSE_DISAPPEAR_TIMER);
 	setMouseTracking(true);

--- a/src/platform/qt/DisplayGL.cpp
+++ b/src/platform/qt/DisplayGL.cpp
@@ -68,7 +68,7 @@ void DisplayGL::startDrawing(mCoreThread* thread) {
 	m_gl->context()->doneCurrent();
 	m_gl->context()->moveToThread(m_drawThread);
 	m_painter->moveToThread(m_drawThread);
-	connect(m_drawThread, SIGNAL(started()), m_painter, SLOT(start()));
+	connect(m_drawThread, &QThread::started, m_painter, &PainterGL::start);
 	m_drawThread->start();
 	mCoreSyncSetVideoSync(&m_context->sync, false);
 

--- a/src/platform/qt/GBAKeyEditor.cpp
+++ b/src/platform/qt/GBAKeyEditor.cpp
@@ -56,7 +56,8 @@ GBAKeyEditor::GBAKeyEditor(InputController* controller, int type, const QString&
 #ifdef BUILD_SDL
 	if (type == SDL_BINDING_BUTTON) {
 		m_profileSelect = new QComboBox(this);
-		connect(m_profileSelect, SIGNAL(currentIndexChanged(int)), this, SLOT(selectGamepad(int)));
+		connect(m_profileSelect, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+		        this, &GBAKeyEditor::selectGamepad);
 
 		updateJoysticks();
 
@@ -90,7 +91,7 @@ GBAKeyEditor::GBAKeyEditor(InputController* controller, int type, const QString&
 
 		QPushButton* updateJoysticksButton = new QPushButton(tr("Refresh"));
 		layout->addWidget(updateJoysticksButton);
-		connect(updateJoysticksButton, SIGNAL(pressed()), this, SLOT(updateJoysticks()));
+		connect(updateJoysticksButton, &QAbstractButton::pressed, this, &GBAKeyEditor::updateJoysticks);
 	}
 #endif
 
@@ -99,7 +100,7 @@ GBAKeyEditor::GBAKeyEditor(InputController* controller, int type, const QString&
 	m_buttons->setLayout(layout);
 
 	QPushButton* setAll = new QPushButton(tr("Set all"));
-	connect(setAll, SIGNAL(pressed()), this, SLOT(setAll()));
+	connect(setAll, &QAbstractButton::pressed, this, &GBAKeyEditor::setAll);
 	layout->addWidget(setAll);
 
 	layout->setSpacing(6);
@@ -118,9 +119,9 @@ GBAKeyEditor::GBAKeyEditor(InputController* controller, int type, const QString&
 	};
 
 	for (auto& key : m_keyOrder) {
-		connect(key, SIGNAL(valueChanged(int)), this, SLOT(setNext()));
-		connect(key, SIGNAL(axisChanged(int, int)), this, SLOT(setNext()));
-		connect(key, SIGNAL(hatChanged(int, int)), this, SLOT(setNext()));
+		connect(key, &KeyEditor::valueChanged, this, &GBAKeyEditor::setNext);
+		connect(key, &KeyEditor::axisChanged, this, &GBAKeyEditor::setNext);
+		connect(key, &KeyEditor::hatChanged, this, &GBAKeyEditor::setNext);
 		key->installEventFilter(this);
 	}
 

--- a/src/platform/qt/GDBWindow.cpp
+++ b/src/platform/qt/GDBWindow.cpp
@@ -38,12 +38,12 @@ GDBWindow::GDBWindow(GDBController* controller, QWidget* parent)
 
 	m_portEdit = new QLineEdit("2345");
 	m_portEdit->setMaxLength(5);
-	connect(m_portEdit, SIGNAL(textChanged(const QString&)), this, SLOT(portChanged(const QString&)));
+	connect(m_portEdit, &QLineEdit::textChanged, this, &GDBWindow::portChanged);
 	settingsGrid->addWidget(m_portEdit, 0, 1, Qt::AlignLeft);
 
 	m_bindAddressEdit = new QLineEdit("0.0.0.0");
 	m_bindAddressEdit->setMaxLength(15);
-	connect(m_bindAddressEdit, SIGNAL(textChanged(const QString&)), this, SLOT(bindAddressChanged(const QString&)));
+	connect(m_bindAddressEdit, &QLineEdit::textChanged, this, &GDBWindow::bindAddressChanged);
 	settingsGrid->addWidget(m_bindAddressEdit, 1, 1, Qt::AlignLeft);
 
 	QHBoxLayout* buttons = new QHBoxLayout;
@@ -57,9 +57,9 @@ GDBWindow::GDBWindow(GDBController* controller, QWidget* parent)
 
 	mainSegment->addLayout(buttons);
 
-	connect(m_gdbController, SIGNAL(listening()), this, SLOT(started()));
-	connect(m_gdbController, SIGNAL(listenFailed()), this, SLOT(failed()));
-	connect(m_breakButton, SIGNAL(clicked()), controller, SLOT(breakInto()));
+	connect(m_gdbController, &GDBController::listening, this, &GDBWindow::started);
+	connect(m_gdbController, &GDBController::listenFailed, this, &GDBWindow::failed);
+	connect(m_breakButton, &QAbstractButton::clicked, controller, &DebuggerController::breakInto);
 
 	if (m_gdbController->isAttached()) {
 		started();
@@ -103,9 +103,9 @@ void GDBWindow::started() {
 	m_bindAddressEdit->setEnabled(false);
 	m_startStopButton->setText(tr("Stop"));
 	m_breakButton->setEnabled(true);
-	disconnect(m_startStopButton, SIGNAL(clicked()), m_gdbController, SLOT(listen()));
-	connect(m_startStopButton, SIGNAL(clicked()), m_gdbController, SLOT(detach()));
-	connect(m_startStopButton, SIGNAL(clicked()), this, SLOT(stopped()));
+	disconnect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &GDBController::listen);
+	connect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &DebuggerController::detach);
+	connect(m_startStopButton, &QAbstractButton::clicked, this, &GDBWindow::stopped);
 }
 
 void GDBWindow::stopped() {
@@ -113,9 +113,9 @@ void GDBWindow::stopped() {
 	m_bindAddressEdit->setEnabled(true);
 	m_startStopButton->setText(tr("Start"));
 	m_breakButton->setEnabled(false);
-	disconnect(m_startStopButton, SIGNAL(clicked()), m_gdbController, SLOT(detach()));
-	disconnect(m_startStopButton, SIGNAL(clicked()), this, SLOT(stopped()));
-	connect(m_startStopButton, SIGNAL(clicked()), m_gdbController, SLOT(listen()));
+	disconnect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &DebuggerController::detach);
+	disconnect(m_startStopButton, &QAbstractButton::clicked, this, &GDBWindow::stopped);
+	connect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &GDBController::listen);
 }
 
 void GDBWindow::failed() {

--- a/src/platform/qt/GIFView.cpp
+++ b/src/platform/qt/GIFView.cpp
@@ -22,14 +22,15 @@ GIFView::GIFView(QWidget* parent)
 {
 	m_ui.setupUi(this);
 
-	connect(m_ui.start, SIGNAL(clicked()), this, SLOT(startRecording()));
-	connect(m_ui.stop, SIGNAL(clicked()), this, SLOT(stopRecording()));
+	connect(m_ui.start, &QAbstractButton::clicked, this, &GIFView::startRecording);
+	connect(m_ui.stop, &QAbstractButton::clicked, this, &GIFView::stopRecording);
 
-	connect(m_ui.selectFile, SIGNAL(clicked()), this, SLOT(selectFile()));
-	connect(m_ui.filename, SIGNAL(textChanged(const QString&)), this, SLOT(setFilename(const QString&)));
+	connect(m_ui.selectFile, &QAbstractButton::clicked, this, &GIFView::selectFile);
+	connect(m_ui.filename, &QLineEdit::textChanged, this, &GIFView::setFilename);
 
-	connect(m_ui.frameskip, SIGNAL(valueChanged(int)), this, SLOT(updateDelay()));
-	connect(m_ui.delayAuto, SIGNAL(clicked(bool)), this, SLOT(updateDelay()));
+	connect(m_ui.frameskip, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+	        this, &GIFView::updateDelay);
+	connect(m_ui.delayAuto, &QAbstractButton::clicked, this, &GIFView::updateDelay);
 
 	ImageMagickGIFEncoderInit(&m_encoder);
 }

--- a/src/platform/qt/GameController.cpp
+++ b/src/platform/qt/GameController.cpp
@@ -277,10 +277,10 @@ GameController::GameController(QObject* parent)
 
 	m_threadContext.userData = this;
 
-	connect(this, SIGNAL(gamePaused(mCoreThread*)), m_audioProcessor, SLOT(pause()));
-	connect(this, SIGNAL(gameStarted(mCoreThread*, const QString&)), m_audioProcessor, SLOT(setInput(mCoreThread*)));
-	connect(this, SIGNAL(frameAvailable(const uint32_t*)), this, SLOT(pollEvents()));
-	connect(this, SIGNAL(frameAvailable(const uint32_t*)), this, SLOT(updateAutofire()));
+	connect(this, &GameController::gamePaused, m_audioProcessor, &AudioProcessor::pause);
+	connect(this, &GameController::gameStarted, m_audioProcessor, &AudioProcessor::setInput);
+	connect(this, &GameController::frameAvailable, this, &GameController::pollEvents);
+	connect(this, &GameController::frameAvailable, this, &GameController::updateAutofire);
 }
 
 GameController::~GameController() {
@@ -939,8 +939,8 @@ void GameController::loadState(int slot) {
 		}
 		mCoreLoadStateNamed(context->core, controller->m_backupLoadState, controller->m_saveStateFlags);
 		if (mCoreLoadState(context->core, controller->m_stateSlot, controller->m_loadStateFlags)) {
-			controller->frameAvailable(controller->m_drawContext);
-			controller->stateLoaded(context);
+			emit controller->frameAvailable(controller->m_drawContext);
+			emit controller->stateLoaded(context);
 		}
 	});
 }
@@ -1108,8 +1108,8 @@ void GameController::reloadAudioDriver() {
 	if (sampleRate) {
 		m_audioProcessor->requestSampleRate(sampleRate);
 	}
-	connect(this, SIGNAL(gamePaused(mCoreThread*)), m_audioProcessor, SLOT(pause()));
-	connect(this, SIGNAL(gameStarted(mCoreThread*, const QString&)), m_audioProcessor, SLOT(setInput(mCoreThread*)));
+	connect(this, &GameController::gamePaused, m_audioProcessor, &AudioProcessor::pause);
+	connect(this, &GameController::gameStarted, m_audioProcessor, &AudioProcessor::setInput);
 	if (isLoaded()) {
 		m_audioProcessor->setInput(&m_threadContext);
 		startAudio();

--- a/src/platform/qt/IOViewer.cpp
+++ b/src/platform/qt/IOViewer.cpp
@@ -1040,9 +1040,10 @@ IOViewer::IOViewer(GameController* controller, QWidget* parent)
 	const QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 	m_ui.regValue->setFont(font);
 
-	connect(m_ui.buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(buttonPressed(QAbstractButton*)));
-	connect(m_ui.buttonBox, SIGNAL(rejected()), this, SLOT(close()));
-	connect(m_ui.regSelect, SIGNAL(currentIndexChanged(int)), this, SLOT(selectRegister()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::clicked, this, &IOViewer::buttonPressed);
+	connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
+	connect(m_ui.regSelect, &QComboBox::currentTextChanged,
+	        this, static_cast<void (IOViewer::*)()>(&IOViewer::selectRegister));
 
 	m_b[0] = m_ui.b0;
 	m_b[1] = m_ui.b1;
@@ -1062,7 +1063,7 @@ IOViewer::IOViewer(GameController* controller, QWidget* parent)
 	m_b[15] = m_ui.bF;
 
 	for (int i = 0; i < 16; ++i) {
-		connect(m_b[i], SIGNAL(toggled(bool)), this, SLOT(bitFlipped()));
+		connect(m_b[i], &QAbstractButton::toggled, this, &IOViewer::bitFlipped);
 	}
 
 	selectRegister(0);
@@ -1128,8 +1129,8 @@ void IOViewer::selectRegister(unsigned address) {
 				QCheckBox* check = new QCheckBox;
 				check->setEnabled(!ri.readonly);
 				box->addWidget(check, i, 1, Qt::AlignRight);
-				connect(check, SIGNAL(toggled(bool)), m_b[ri.start], SLOT(setChecked(bool)));
-				connect(m_b[ri.start], SIGNAL(toggled(bool)), check, SLOT(setChecked(bool)));
+				connect(check, &QAbstractButton::toggled, m_b[ri.start], &QAbstractButton::setChecked);
+				connect(m_b[ri.start], &QAbstractButton::toggled, check, &QAbstractButton::setChecked);
 			} else if (ri.items.empty()) {
 				QSpinBox* sbox = new QSpinBox;
 				sbox->setEnabled(!ri.readonly);

--- a/src/platform/qt/LoadSaveState.cpp
+++ b/src/platform/qt/LoadSaveState.cpp
@@ -57,7 +57,7 @@ LoadSaveState::LoadSaveState(GameController* controller, QWidget* parent)
 	}
 
 	QAction* escape = new QAction(this);
-	escape->connect(escape, SIGNAL(triggered()), this, SLOT(close()));
+	connect(escape, &QAction::triggered, this, &QWidget::close);
 	escape->setShortcut(QKeySequence("Esc"));
 	escape->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 	addAction(escape);

--- a/src/platform/qt/LogController.cpp
+++ b/src/platform/qt/LogController.cpp
@@ -14,10 +14,10 @@ LogController::LogController(int levels, QObject* parent)
 	, m_logLevel(levels)
 {
 	if (this != &s_global) {
-		connect(&s_global, SIGNAL(logPosted(int, int, const QString&)), this, SLOT(postLog(int, int, const QString&)));
-		connect(this, SIGNAL(levelsSet(int)), &s_global, SLOT(setLevels(int)));
-		connect(this, SIGNAL(levelsEnabled(int)), &s_global, SLOT(enableLevels(int)));
-		connect(this, SIGNAL(levelsDisabled(int)), &s_global, SLOT(disableLevels(int)));
+		connect(&s_global, &LogController::logPosted, this, &LogController::postLog);
+		connect(this, &LogController::levelsSet, &s_global, &LogController::setLevels);
+		connect(this, &LogController::levelsEnabled, &s_global, &LogController::enableLevels);
+		connect(this, &LogController::levelsDisabled, &s_global, &LogController::disableLevels);
 	}
 }
 

--- a/src/platform/qt/LogView.cpp
+++ b/src/platform/qt/LogView.cpp
@@ -39,12 +39,13 @@ LogView::LogView(LogController* log, QWidget* parent)
 	connect(m_ui.levelGameError, &QAbstractButton::toggled, [this](bool set) {
 		setLevel(mLOG_GAME_ERROR, set);
 	});
-	connect(m_ui.clear, SIGNAL(clicked()), this, SLOT(clear()));
-	connect(m_ui.maxLines, SIGNAL(valueChanged(int)), this, SLOT(setMaxLines(int)));
+	connect(m_ui.clear, &QAbstractButton::clicked, this, &LogView::clear);
+	connect(m_ui.maxLines, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+	        this, &LogView::setMaxLines);
 	m_ui.maxLines->setValue(DEFAULT_LINE_LIMIT);
 
-	connect(log, SIGNAL(logPosted(int, int, const QString&)), this, SLOT(postLog(int, int, const QString&)));
-	connect(log, SIGNAL(levelsSet(int)), this, SLOT(setLevels(int)));
+	connect(log, &LogController::logPosted, this, &LogView::postLog);
+	connect(log, &LogController::levelsSet, this, &LogView::setLevels);
 	connect(log, &LogController::levelsEnabled, [this](int level) {
 		bool s = blockSignals(true);
 		setLevel(level, true);
@@ -55,8 +56,8 @@ LogView::LogView(LogController* log, QWidget* parent)
 		setLevel(level, false);
 		blockSignals(s);
 	});
-	connect(this, SIGNAL(levelsEnabled(int)), log, SLOT(enableLevels(int)));
-	connect(this, SIGNAL(levelsDisabled(int)), log, SLOT(disableLevels(int)));
+	connect(this, &LogView::levelsEnabled, log, &LogController::enableLevels);
+	connect(this, &LogView::levelsDisabled, log, &LogController::disableLevels);
 }
 
 void LogView::postLog(int level, int category, const QString& log) {

--- a/src/platform/qt/MemoryModel.cpp
+++ b/src/platform/qt/MemoryModel.cpp
@@ -49,22 +49,22 @@ MemoryModel::MemoryModel(QWidget* parent)
 
 	QAction* copy = new QAction(tr("Copy selection"), this);
 	copy->setShortcut(QKeySequence::Copy);
-	connect(copy, SIGNAL(triggered()), this, SLOT(copy()));
+	connect(copy, &QAction::triggered, this, &MemoryModel::copy);
 	addAction(copy);
 
 	QAction* save = new QAction(tr("Save selection"), this);
 	save->setShortcut(QKeySequence::Save);
-	connect(save, SIGNAL(triggered()), this, SLOT(save()));
+	connect(save, &QAction::triggered, this, &MemoryModel::save);
 	addAction(save);
 
 	QAction* paste = new QAction(tr("Paste"), this);
 	paste->setShortcut(QKeySequence::Paste);
-	connect(paste, SIGNAL(triggered()), this, SLOT(paste()));
+	connect(paste, &QAction::triggered, this, &MemoryModel::paste);
 	addAction(paste);
 
 	QAction* load = new QAction(tr("Load"), this);
 	load->setShortcut(QKeySequence::Open);
-	connect(load, SIGNAL(triggered()), this, SLOT(load()));
+	connect(load, &QAction::triggered, this, &MemoryModel::load);
 	addAction(load);
 
 	static QString arg("%0");
@@ -128,7 +128,7 @@ void MemoryModel::setAlignment(int width) {
 	viewport()->update();
 }
 
-void MemoryModel::loadTBL(const QString& path) {
+void MemoryModel::loadTBLFromPath(const QString& path) {
 	VFile* vf = VFileDevice::open(path, O_RDONLY);
 	if (!vf) {
 		return;
@@ -143,7 +143,7 @@ void MemoryModel::loadTBL() {
 	if (filename.isNull()) {
 		return;
 	}
-	loadTBL(filename);
+	loadTBLFromPath(filename);
 }
 
 void MemoryModel::jumpToAddress(const QString& hex) {

--- a/src/platform/qt/MemoryModel.h
+++ b/src/platform/qt/MemoryModel.h
@@ -43,7 +43,7 @@ public slots:
 	void jumpToAddress(const QString& hex);
 	void jumpToAddress(uint32_t);
 
-	void loadTBL(const QString& path);
+	void loadTBLFromPath(const QString& path);
 	void loadTBL();
 
 	void copy();

--- a/src/platform/qt/MemoryView.cpp
+++ b/src/platform/qt/MemoryView.cpp
@@ -81,8 +81,10 @@ MemoryView::MemoryView(GameController* controller, QWidget* parent)
 		break;
 	}
 
-	connect(m_ui.regions, SIGNAL(currentIndexChanged(int)), this, SLOT(setIndex(int)));
-	connect(m_ui.segments, SIGNAL(valueChanged(int)), this, SLOT(setSegment(int)));
+	connect(m_ui.regions, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+	        this, &MemoryView::setIndex);
+	connect(m_ui.segments, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+	        this, &MemoryView::setSegment);
 
 	if (info) {
 		for (size_t i = 0; info[i].name; ++i) {
@@ -93,22 +95,23 @@ MemoryView::MemoryView(GameController* controller, QWidget* parent)
 	connect(m_ui.width8, &QAbstractButton::clicked, [this]() { m_ui.hexfield->setAlignment(1); });
 	connect(m_ui.width16, &QAbstractButton::clicked, [this]() { m_ui.hexfield->setAlignment(2); });
 	connect(m_ui.width32, &QAbstractButton::clicked, [this]() { m_ui.hexfield->setAlignment(4); });
-	connect(m_ui.setAddress, SIGNAL(valueChanged(const QString&)), m_ui.hexfield, SLOT(jumpToAddress(const QString&)));
-	connect(m_ui.hexfield, SIGNAL(selectionChanged(uint32_t, uint32_t)), this, SLOT(updateSelection(uint32_t, uint32_t)));
+	connect(m_ui.setAddress, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+	        m_ui.hexfield, static_cast<void (MemoryModel::*)(uint32_t)>(&MemoryModel::jumpToAddress));
+	connect(m_ui.hexfield, &MemoryModel::selectionChanged, this, &MemoryView::updateSelection);
 
-	connect(controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(close()));
+	connect(controller, &GameController::gameStopped, this, &QWidget::close);
 
-	connect(controller, SIGNAL(frameAvailable(const uint32_t*)), this, SLOT(update()));
-	connect(controller, SIGNAL(gamePaused(mCoreThread*)), this, SLOT(update()));
-	connect(controller, SIGNAL(stateLoaded(mCoreThread*)), this, SLOT(update()));
-	connect(controller, SIGNAL(rewound(mCoreThread*)), this, SLOT(update()));
+	connect(controller, &GameController::frameAvailable, this, &MemoryView::update);
+	connect(controller, &GameController::gamePaused, this, &MemoryView::update);
+	connect(controller, &GameController::stateLoaded, this, &MemoryView::update);
+	connect(controller, &GameController::rewound, this, &MemoryView::update);
 
-	connect(m_ui.copy, SIGNAL(clicked()), m_ui.hexfield, SLOT(copy()));
-	connect(m_ui.save, SIGNAL(clicked()), m_ui.hexfield, SLOT(save()));
-	connect(m_ui.paste, SIGNAL(clicked()), m_ui.hexfield, SLOT(paste()));
-	connect(m_ui.load, SIGNAL(clicked()), m_ui.hexfield, SLOT(load()));
+	connect(m_ui.copy, &QAbstractButton::clicked, m_ui.hexfield, &MemoryModel::copy);
+	connect(m_ui.save, &QAbstractButton::clicked, m_ui.hexfield, &MemoryModel::save);
+	connect(m_ui.paste, &QAbstractButton::clicked, m_ui.hexfield, &MemoryModel::paste);
+	connect(m_ui.load, &QAbstractButton::clicked, m_ui.hexfield, &MemoryModel::load);
 
-	connect(m_ui.loadTBL, SIGNAL(clicked()), m_ui.hexfield, SLOT(loadTBL()));
+	connect(m_ui.loadTBL, &QAbstractButton::clicked, m_ui.hexfield, &MemoryModel::loadTBL);
 }
 
 void MemoryView::setIndex(int index) {

--- a/src/platform/qt/MessagePainter.cpp
+++ b/src/platform/qt/MessagePainter.cpp
@@ -21,7 +21,7 @@ MessagePainter::MessagePainter(QObject* parent)
 	m_messageFont.setFamily("Source Code Pro");
 	m_messageFont.setStyleHint(QFont::Monospace);
 	m_messageFont.setPixelSize(13);
-	connect(&m_messageTimer, SIGNAL(timeout()), this, SLOT(clearMessage()));
+	connect(&m_messageTimer, &QTimer::timeout, this, &MessagePainter::clearMessage);
 	m_messageTimer.setSingleShot(true);
 	m_messageTimer.setInterval(5000);
 

--- a/src/platform/qt/ObjView.cpp
+++ b/src/platform/qt/ObjView.cpp
@@ -46,13 +46,13 @@ ObjView::ObjView(GameController* controller, QWidget* parent)
 	m_ui.transform->setFont(font);
 	m_ui.mode->setFont(font);
 
-	connect(m_ui.tiles, SIGNAL(indexPressed(int)), this, SLOT(translateIndex(int)));
-	connect(m_ui.objId, SIGNAL(valueChanged(int)), this, SLOT(selectObj(int)));
+	connect(m_ui.tiles, &TilePainter::indexPressed, this, &ObjView::translateIndex);
+	connect(m_ui.objId, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ObjView::selectObj);
 	connect(m_ui.magnification, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [this]() {
 		updateTiles(true);
 	});
 #ifdef USE_PNG
-	connect(m_ui.exportButton, SIGNAL(clicked()), this, SLOT(exportObj()));
+	connect(m_ui.exportButton, &QAbstractButton::clicked, this, &ObjView::exportObj);
 #else
 	m_ui.exportButton->setVisible(false);
 #endif

--- a/src/platform/qt/OverrideView.cpp
+++ b/src/platform/qt/OverrideView.cpp
@@ -56,8 +56,8 @@ OverrideView::OverrideView(GameController* controller, ConfigController* config,
 #endif
 	m_ui.setupUi(this);
 
-	connect(controller, SIGNAL(gameStarted(mCoreThread*, const QString&)), this, SLOT(gameStarted(mCoreThread*)));
-	connect(controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(gameStopped()));
+	connect(controller, &GameController::gameStarted, this, &OverrideView::gameStarted);
+	connect(controller, &GameController::gameStopped, this, &OverrideView::gameStopped);
 
 	connect(m_ui.hwAutodetect, &QAbstractButton::toggled, [this] (bool enabled) {
 		m_ui.hwRTC->setEnabled(!enabled);
@@ -67,19 +67,19 @@ OverrideView::OverrideView(GameController* controller, ConfigController* config,
 		m_ui.hwRumble->setEnabled(!enabled);
 	});
 
-	connect(m_ui.savetype, SIGNAL(currentIndexChanged(int)), this, SLOT(updateOverrides()));
-	connect(m_ui.hwAutodetect, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwRTC, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwGyro, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwLight, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwTilt, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwRumble, SIGNAL(clicked()), this, SLOT(updateOverrides()));
-	connect(m_ui.hwGBPlayer, SIGNAL(clicked()), this, SLOT(updateOverrides()));
+	connect(m_ui.savetype, &QComboBox::currentTextChanged, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwAutodetect, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwRTC, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwGyro, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwLight, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwTilt, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwRumble, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
+	connect(m_ui.hwGBPlayer, &QAbstractButton::clicked, this, &OverrideView::updateOverrides);
 
-	connect(m_ui.gbModel, SIGNAL(currentIndexChanged(int)), this, SLOT(updateOverrides()));
-	connect(m_ui.mbc, SIGNAL(currentIndexChanged(int)), this, SLOT(updateOverrides()));
+	connect(m_ui.gbModel, &QComboBox::currentTextChanged, this, &OverrideView::updateOverrides);
+	connect(m_ui.mbc, &QComboBox::currentTextChanged, this, &OverrideView::updateOverrides);
 
-	connect(m_ui.tabWidget, SIGNAL(currentChanged(int)), this, SLOT(updateOverrides()));
+	connect(m_ui.tabWidget, &QTabWidget::currentChanged, this, &OverrideView::updateOverrides);
 #ifndef M_CORE_GBA
 	m_ui.tabWidget->removeTab(m_ui.tabWidget->indexOf(m_ui.tabGBA));
 #endif
@@ -87,8 +87,8 @@ OverrideView::OverrideView(GameController* controller, ConfigController* config,
 	m_ui.tabWidget->removeTab(m_ui.tabWidget->indexOf(m_ui.tabGB));
 #endif
 
-	connect(m_ui.buttonBox, SIGNAL(accepted()), this, SLOT(saveOverride()));
-	connect(m_ui.buttonBox, SIGNAL(rejected()), this, SLOT(close()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::accepted, this, &OverrideView::saveOverride);
+	connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
 	m_ui.buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
 
 	if (controller->isLoaded()) {

--- a/src/platform/qt/PaletteView.cpp
+++ b/src/platform/qt/PaletteView.cpp
@@ -30,7 +30,7 @@ PaletteView::PaletteView(GameController* controller, QWidget* parent)
 {
 	m_ui.setupUi(this);
 
-	connect(m_controller, SIGNAL(frameAvailable(const uint32_t*)), this, SLOT(updatePalette()));
+	connect(m_controller, &GameController::frameAvailable, this, &PaletteView::updatePalette);
 	m_ui.bgGrid->setDimensions(QSize(16, 16));
 	m_ui.objGrid->setDimensions(QSize(16, 16));
 	int count = 256;
@@ -56,12 +56,12 @@ PaletteView::PaletteView(GameController* controller, QWidget* parent)
 	m_ui.g->setFont(font);
 	m_ui.b->setFont(font);
 
-	connect(m_ui.bgGrid, SIGNAL(indexPressed(int)), this, SLOT(selectIndex(int)));
+	connect(m_ui.bgGrid, &Swatch::indexPressed, this, &PaletteView::selectIndex);
 	connect(m_ui.objGrid, &Swatch::indexPressed, [this, count] (int index) { selectIndex(index + count); });
 	connect(m_ui.exportBG, &QAbstractButton::clicked, [this, count] () { exportPalette(0, count); });
 	connect(m_ui.exportOBJ, &QAbstractButton::clicked, [this, count] () { exportPalette(count, count); });
 
-	connect(controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(close()));
+	connect(controller, &GameController::gameStopped, this, &QWidget::close);
 }
 
 void PaletteView::updatePalette() {

--- a/src/platform/qt/SensorView.cpp
+++ b/src/platform/qt/SensorView.cpp
@@ -22,10 +22,11 @@ SensorView::SensorView(GameController* controller, InputController* input, QWidg
  {
 	m_ui.setupUi(this);
 
-	connect(m_ui.lightSpin, SIGNAL(valueChanged(int)), this, SLOT(setLuminanceValue(int)));
-	connect(m_ui.lightSlide, SIGNAL(valueChanged(int)), this, SLOT(setLuminanceValue(int)));
+	connect(m_ui.lightSpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+	        this, &SensorView::setLuminanceValue);
+	connect(m_ui.lightSlide, &QAbstractSlider::valueChanged, this, &SensorView::setLuminanceValue);
 
-	connect(m_ui.timeNoOverride, SIGNAL(clicked()), controller, SLOT(setRealTime()));
+	connect(m_ui.timeNoOverride, &QAbstractButton::clicked, controller, &GameController::setRealTime);
 	connect(m_ui.timeFixed, &QRadioButton::clicked, [controller, this] () {
 		controller->setFixedTime(m_ui.time->dateTime());
 	});
@@ -39,10 +40,10 @@ SensorView::SensorView(GameController* controller, InputController* input, QWidg
 		m_ui.time->setDateTime(QDateTime::currentDateTime());
 	});
 
-	connect(m_controller, SIGNAL(luminanceValueChanged(int)), this, SLOT(luminanceValueChanged(int)));
+	connect(m_controller, &GameController::luminanceValueChanged, this, &SensorView::luminanceValueChanged);
 
 	m_timer.setInterval(2);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateSensors()));
+	connect(&m_timer, &QTimer::timeout, this, &SensorView::updateSensors);
 	if (!m_rotation || !m_rotation->readTiltX || !m_rotation->readTiltY) {
 		m_ui.tilt->hide();
 	} else {

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -140,7 +140,7 @@ SettingsView::SettingsView(ConfigController* controller, InputController* inputC
 	GBAKeyEditor* editor = new GBAKeyEditor(inputController, InputController::KEYBOARD, QString(), this);
 	m_ui.stackedWidget->addWidget(editor);
 	m_ui.tabs->addItem(tr("Keyboard"));
-	connect(m_ui.buttonBox, SIGNAL(accepted()), editor, SLOT(save()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::accepted, editor, &GBAKeyEditor::save);
 
 	GBAKeyEditor* buttonEditor = nullptr;
 #ifdef BUILD_SDL
@@ -149,10 +149,10 @@ SettingsView::SettingsView(ConfigController* controller, InputController* inputC
 	buttonEditor = new GBAKeyEditor(inputController, SDL_BINDING_BUTTON, profile);
 	m_ui.stackedWidget->addWidget(buttonEditor);
 	m_ui.tabs->addItem(tr("Controllers"));
-	connect(m_ui.buttonBox, SIGNAL(accepted()), buttonEditor, SLOT(save()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::accepted, buttonEditor, &GBAKeyEditor::save);
 #endif
 
-	connect(m_ui.buttonBox, SIGNAL(accepted()), this, SLOT(updateConfig()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::accepted, this, &SettingsView::updateConfig);
 	connect(m_ui.buttonBox, &QDialogButtonBox::clicked, [this, editor, buttonEditor](QAbstractButton* button) {
 		if (m_ui.buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole) {
 			updateConfig();

--- a/src/platform/qt/ShaderSelector.cpp
+++ b/src/platform/qt/ShaderSelector.cpp
@@ -37,9 +37,9 @@ ShaderSelector::ShaderSelector(Display* display, ConfigController* config, QWidg
 
 	refreshShaders();
 
-	connect(m_ui.load, SIGNAL(clicked()), this, SLOT(selectShader()));
-	connect(m_ui.unload, SIGNAL(clicked()), this, SLOT(clearShader()));
-	connect(m_ui.buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(buttonPressed(QAbstractButton*)));
+	connect(m_ui.load, &QAbstractButton::clicked, this, &ShaderSelector::selectShader);
+	connect(m_ui.unload, &QAbstractButton::clicked, this, &ShaderSelector::clearShader);
+	connect(m_ui.buttonBox, &QDialogButtonBox::clicked, this, &ShaderSelector::buttonPressed);
 }
 
 ShaderSelector::~ShaderSelector() {
@@ -112,9 +112,9 @@ void ShaderSelector::refreshShaders() {
 		m_ui.author->clear();
 	}
 
-	disconnect(this, SIGNAL(saved()), 0, 0);
-	disconnect(this, SIGNAL(reset()), 0, 0);
-	disconnect(this, SIGNAL(resetToDefault()), 0, 0);
+	disconnect(this, &ShaderSelector::saved, 0, 0);
+	disconnect(this, &ShaderSelector::reset, 0, 0);
+	disconnect(this, &ShaderSelector::resetToDefault, 0, 0);
 
 #if !defined(_WIN32) || defined(USE_EPOXY)
 	if (m_shaders->preprocessShader) {

--- a/src/platform/qt/ShortcutView.cpp
+++ b/src/platform/qt/ShortcutView.cpp
@@ -31,10 +31,10 @@ ShortcutView::ShortcutView(QWidget* parent)
 		m_ui.keyEdit->setValueKey(0);
 		m_ui.keyEdit->blockSignals(signalsBlocked);
 	});
-	connect(m_ui.keyEdit, SIGNAL(valueChanged(int)), this, SLOT(updateButton(int)));
-	connect(m_ui.keyEdit, SIGNAL(axisChanged(int, int)), this, SLOT(updateAxis(int, int)));
-	connect(m_ui.shortcutTable, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(load(const QModelIndex&)));
-	connect(m_ui.clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+	connect(m_ui.keyEdit, &KeyEditor::valueChanged, this, &ShortcutView::updateButton);
+	connect(m_ui.keyEdit, &KeyEditor::axisChanged, this, &ShortcutView::updateAxis);
+	connect(m_ui.shortcutTable, &QAbstractItemView::doubleClicked, this, &ShortcutView::load);
+	connect(m_ui.clearButton, &QAbstractButton::clicked, this, &ShortcutView::clear);
 }
 
 ShortcutView::~ShortcutView() {

--- a/src/platform/qt/TileView.cpp
+++ b/src/platform/qt/TileView.cpp
@@ -25,8 +25,8 @@ TileView::TileView(GameController* controller, QWidget* parent)
 	m_ui.setupUi(this);
 	m_ui.tile->setController(controller);
 
-	connect(m_ui.tiles, SIGNAL(indexPressed(int)), m_ui.tile, SLOT(selectIndex(int)));
-	connect(m_ui.paletteId, SIGNAL(valueChanged(int)), this, SLOT(updatePalette(int)));
+	connect(m_ui.tiles, &TilePainter::indexPressed, m_ui.tile, &AssetTile::selectIndex);
+	connect(m_ui.paletteId, &QAbstractSlider::valueChanged, this, &TileView::updatePalette);
 
 	int max = 1024;
 	int boundary = 1024;

--- a/src/platform/qt/VideoView.cpp
+++ b/src/platform/qt/VideoView.cpp
@@ -75,12 +75,12 @@ VideoView::VideoView(QWidget* parent)
 		s_containerMap["mkv"] = "matroska";
 	}
 
-	connect(m_ui.buttonBox, SIGNAL(rejected()), this, SLOT(close()));
-	connect(m_ui.start, SIGNAL(clicked()), this, SLOT(startRecording()));
-	connect(m_ui.stop, SIGNAL(clicked()), this, SLOT(stopRecording()));
+	connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &VideoView::close);
+	connect(m_ui.start, &QAbstractButton::clicked, this, &VideoView::startRecording);
+	connect(m_ui.stop, &QAbstractButton::clicked, this, &VideoView::stopRecording);
 
-	connect(m_ui.selectFile, SIGNAL(clicked()), this, SLOT(selectFile()));
-	connect(m_ui.filename, SIGNAL(textChanged(const QString&)), this, SLOT(setFilename(const QString&)));
+	connect(m_ui.selectFile, &QAbstractButton::clicked, this, &VideoView::selectFile);
+	connect(m_ui.filename, &QLineEdit::textChanged, this, &VideoView::setFilename);
 
 	connect(m_ui.audio, SIGNAL(activated(const QString&)), this, SLOT(setAudioCodec(const QString&)));
 	connect(m_ui.video, SIGNAL(activated(const QString&)), this, SLOT(setVideoCodec(const QString&)));
@@ -98,7 +98,7 @@ VideoView::VideoView(QWidget* parent)
 	connect(m_ui.wratio, SIGNAL(valueChanged(int)), this, SLOT(setAspectWidth(int)));
 	connect(m_ui.hratio, SIGNAL(valueChanged(int)), this, SLOT(setAspectHeight(int)));
 
-	connect(m_ui.showAdvanced, SIGNAL(clicked(bool)), this, SLOT(showAdvanced(bool)));
+	connect(m_ui.showAdvanced, &QAbstractButton::clicked, this, &VideoView::showAdvanced);
 
 	FFmpegEncoderInit(&m_encoder);
 

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -145,13 +145,13 @@ Window::Window(ConfigController* config, int playerId, QWidget* parent)
 	m_screenWidget->setLockIntegerScaling(false);
 	setCentralWidget(m_screenWidget);
 
-	connect(m_controller, SIGNAL(gameStarted(mCoreThread*, const QString&)), this, SLOT(gameStarted(mCoreThread*, const QString&)));
-	connect(m_controller, SIGNAL(gameStarted(mCoreThread*, const QString&)), &m_inputController, SLOT(suspendScreensaver()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_display, SLOT(stopDrawing()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), this, SLOT(gameStopped()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), &m_inputController, SLOT(resumeScreensaver()));
-	connect(m_controller, SIGNAL(stateLoaded(mCoreThread*)), m_display, SLOT(forceDraw()));
-	connect(m_controller, SIGNAL(rewound(mCoreThread*)), m_display, SLOT(forceDraw()));
+	connect(m_controller, &GameController::gameStarted, this, &Window::gameStarted);
+	connect(m_controller, &GameController::gameStarted, &m_inputController, &InputController::suspendScreensaver);
+	connect(m_controller, &GameController::gameStopped, m_display, &Display::stopDrawing);
+	connect(m_controller, &GameController::gameStopped, this, &Window::gameStopped);
+	connect(m_controller, &GameController::gameStopped, &m_inputController, &InputController::resumeScreensaver);
+	connect(m_controller, &GameController::stateLoaded, m_display, &Display::forceDraw);
+	connect(m_controller, &GameController::rewound, m_display, &Display::forceDraw);
 	connect(m_controller, &GameController::gamePaused, [this](mCoreThread* context) {
 		unsigned width, height;
 		context->core->desiredVideoDimensions(context->core, &width, &height);
@@ -162,38 +162,38 @@ Window::Window(ConfigController* config, int playerId, QWidget* parent)
 		m_screenWidget->setPixmap(pixmap);
 		m_screenWidget->setLockAspectRatio(width, height);
 	});
-	connect(m_controller, SIGNAL(gamePaused(mCoreThread*)), m_display, SLOT(pauseDrawing()));
+	connect(m_controller, &GameController::gamePaused, m_display, &Display::pauseDrawing);
 #ifndef Q_OS_MAC
-	connect(m_controller, SIGNAL(gamePaused(mCoreThread*)), menuBar(), SLOT(show()));
+	connect(m_controller, &GameController::gamePaused, menuBar(), &QWidget::show);
 	connect(m_controller, &GameController::gameUnpaused, [this]() {
 		if(isFullScreen()) {
 			menuBar()->hide();
 		}
 	});
 #endif
-	connect(m_controller, SIGNAL(gamePaused(mCoreThread*)), &m_inputController, SLOT(resumeScreensaver()));
-	connect(m_controller, SIGNAL(gameUnpaused(mCoreThread*)), m_display, SLOT(unpauseDrawing()));
-	connect(m_controller, SIGNAL(gameUnpaused(mCoreThread*)), &m_inputController, SLOT(suspendScreensaver()));
-	connect(m_controller, SIGNAL(postLog(int, int, const QString&)), &m_log, SLOT(postLog(int, int, const QString&)));
-	connect(m_controller, SIGNAL(frameAvailable(const uint32_t*)), this, SLOT(recordFrame()));
-	connect(m_controller, SIGNAL(frameAvailable(const uint32_t*)), m_display, SLOT(framePosted(const uint32_t*)));
-	connect(m_controller, SIGNAL(gameCrashed(const QString&)), this, SLOT(gameCrashed(const QString&)));
-	connect(m_controller, SIGNAL(gameFailed()), this, SLOT(gameFailed()));
-	connect(m_controller, SIGNAL(unimplementedBiosCall(int)), this, SLOT(unimplementedBiosCall(int)));
-	connect(m_controller, SIGNAL(statusPosted(const QString&)), m_display, SLOT(showMessage(const QString&)));
-	connect(&m_log, SIGNAL(levelsSet(int)), m_controller, SLOT(setLogLevel(int)));
-	connect(&m_log, SIGNAL(levelsEnabled(int)), m_controller, SLOT(enableLogLevel(int)));
-	connect(&m_log, SIGNAL(levelsDisabled(int)), m_controller, SLOT(disableLogLevel(int)));
-	connect(this, SIGNAL(startDrawing(mCoreThread*)), m_display, SLOT(startDrawing(mCoreThread*)), Qt::QueuedConnection);
-	connect(this, SIGNAL(shutdown()), m_display, SLOT(stopDrawing()));
-	connect(this, SIGNAL(shutdown()), m_controller, SLOT(closeGame()));
-	connect(this, SIGNAL(shutdown()), m_logView, SLOT(hide()));
-	connect(this, SIGNAL(shutdown()), m_shaderView, SLOT(hide()));
-	connect(this, SIGNAL(audioBufferSamplesChanged(int)), m_controller, SLOT(setAudioBufferSamples(int)));
-	connect(this, SIGNAL(sampleRateChanged(unsigned)), m_controller, SLOT(setAudioSampleRate(unsigned)));
-	connect(this, SIGNAL(fpsTargetChanged(float)), m_controller, SLOT(setFPSTarget(float)));
-	connect(&m_fpsTimer, SIGNAL(timeout()), this, SLOT(showFPS()));
-	connect(&m_focusCheck, SIGNAL(timeout()), this, SLOT(focusCheck()));
+	connect(m_controller, &GameController::gamePaused, &m_inputController, &InputController::resumeScreensaver);
+	connect(m_controller, &GameController::gameUnpaused, m_display, &Display::unpauseDrawing);
+	connect(m_controller, &GameController::gameUnpaused, &m_inputController, &InputController::suspendScreensaver);
+	connect(m_controller, &GameController::postLog, &m_log, &LogController::postLog);
+	connect(m_controller, &GameController::frameAvailable, this, &Window::recordFrame);
+	connect(m_controller, &GameController::frameAvailable, m_display, &Display::framePosted);
+	connect(m_controller, &GameController::gameCrashed, this, &Window::gameCrashed);
+	connect(m_controller, &GameController::gameFailed, this, &Window::gameFailed);
+	connect(m_controller, &GameController::unimplementedBiosCall, this, &Window::unimplementedBiosCall);
+	connect(m_controller, &GameController::statusPosted, m_display, &Display::showMessage);
+	connect(&m_log, &LogController::levelsSet, m_controller, &GameController::setLogLevel);
+	connect(&m_log, &LogController::levelsEnabled, m_controller, &GameController::enableLogLevel);
+	connect(&m_log, &LogController::levelsDisabled, m_controller, &GameController::disableLogLevel);
+	connect(this, &Window::startDrawing, m_display, &Display::startDrawing, Qt::QueuedConnection);
+	connect(this, &Window::shutdown, m_display, &Display::stopDrawing);
+	connect(this, &Window::shutdown, m_controller, &GameController::closeGame);
+	connect(this, &Window::shutdown, m_logView, &QWidget::hide);
+	connect(this, &Window::shutdown, m_shaderView, &QWidget::hide);
+	connect(this, &Window::audioBufferSamplesChanged, m_controller, &GameController::setAudioBufferSamples);
+	connect(this, &Window::sampleRateChanged, m_controller, &GameController::setAudioSampleRate);
+	connect(this, &Window::fpsTargetChanged, m_controller, &GameController::setFPSTarget);
+	connect(&m_fpsTimer, &QTimer::timeout, this, &Window::showFPS);
+	connect(&m_focusCheck, &QTimer::timeout, this, &Window::focusCheck);
 	connect(m_display, &Display::hideCursor, [this]() {
 		if (static_cast<QStackedLayout*>(m_screenWidget->layout())->currentWidget() == m_display) {
 			m_screenWidget->setCursor(Qt::BlankCursor);
@@ -202,7 +202,7 @@ Window::Window(ConfigController* config, int playerId, QWidget* parent)
 	connect(m_display, &Display::showCursor, [this]() {
 		m_screenWidget->unsetCursor();
 	});
-	connect(&m_inputController, SIGNAL(profileLoaded(const QString&)), m_shortcutController, SLOT(loadProfile(const QString&)));
+	connect(&m_inputController, &InputController::profileLoaded, m_shortcutController, &ShortcutController::loadProfile);
 
 	m_log.setLevels(mLOG_WARN | mLOG_ERROR | mLOG_FATAL);
 	m_fpsTimer.setInterval(FPS_TIMER_INTERVAL);
@@ -452,8 +452,8 @@ void Window::selectPatch() {
 }
 
 void Window::openView(QWidget* widget) {
-	connect(this, SIGNAL(shutdown()), widget, SLOT(close()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), widget, SLOT(close()));
+	connect(this, &Window::shutdown, widget, &QWidget::close);
+	connect(m_controller, &GameController::gameStopped, widget, &QWidget::close);
 	widget->setAttribute(Qt::WA_DeleteOnClose);
 	widget->show();
 }
@@ -474,10 +474,10 @@ void Window::exportSharkport() {
 
 void Window::openSettingsWindow() {
 	SettingsView* settingsWindow = new SettingsView(m_config, &m_inputController, m_shortcutController);
-	connect(settingsWindow, SIGNAL(biosLoaded(int, const QString&)), m_controller, SLOT(loadBIOS(int, const QString&)));
-	connect(settingsWindow, SIGNAL(audioDriverChanged()), m_controller, SLOT(reloadAudioDriver()));
-	connect(settingsWindow, SIGNAL(displayDriverChanged()), this, SLOT(mustRestart()));
-	connect(settingsWindow, SIGNAL(pathsChanged()), this, SLOT(reloadConfig()));
+	connect(settingsWindow, &SettingsView::biosLoaded, m_controller, &GameController::loadBIOS);
+	connect(settingsWindow, &SettingsView::audioDriverChanged, m_controller, &GameController::reloadAudioDriver);
+	connect(settingsWindow, &SettingsView::displayDriverChanged, this, &Window::mustRestart);
+	connect(settingsWindow, &SettingsView::pathsChanged, this, &Window::reloadConfig);
 	openView(settingsWindow);
 }
 
@@ -513,17 +513,17 @@ std::function<void()> Window::openTView() {
 void Window::openVideoWindow() {
 	if (!m_videoView) {
 		m_videoView = new VideoView();
-		connect(m_videoView, SIGNAL(recordingStarted(mAVStream*)), m_controller, SLOT(setAVStream(mAVStream*)));
-		connect(m_videoView, SIGNAL(recordingStopped()), m_controller, SLOT(clearAVStream()), Qt::DirectConnection);
-		connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_videoView, SLOT(stopRecording()));
-		connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_videoView, SLOT(close()));
+		connect(m_videoView, &VideoView::recordingStarted, m_controller, &GameController::setAVStream);
+		connect(m_videoView, &VideoView::recordingStopped, m_controller, &GameController::clearAVStream, Qt::DirectConnection);
+		connect(m_controller, &GameController::gameStopped, m_videoView, &VideoView::stopRecording);
+		connect(m_controller, &GameController::gameStopped, m_videoView, &QWidget::close);
 		connect(m_controller, &GameController::gameStarted, [this]() {
 			m_videoView->setNativeResolution(m_controller->screenDimensions());
 		});
 		if (m_controller->isLoaded()) {
 			m_videoView->setNativeResolution(m_controller->screenDimensions());
 		}
-		connect(this, SIGNAL(shutdown()), m_videoView, SLOT(close()));
+		connect(this, &Window::shutdown, m_videoView, &QWidget::close);
 	}
 	m_videoView->show();
 }
@@ -533,11 +533,11 @@ void Window::openVideoWindow() {
 void Window::openGIFWindow() {
 	if (!m_gifView) {
 		m_gifView = new GIFView();
-		connect(m_gifView, SIGNAL(recordingStarted(mAVStream*)), m_controller, SLOT(setAVStream(mAVStream*)));
-		connect(m_gifView, SIGNAL(recordingStopped()), m_controller, SLOT(clearAVStream()), Qt::DirectConnection);
-		connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_gifView, SLOT(stopRecording()));
-		connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_gifView, SLOT(close()));
-		connect(this, SIGNAL(shutdown()), m_gifView, SLOT(close()));
+		connect(m_gifView, &GIFView::recordingStarted, m_controller, &GameController::setAVStream);
+		connect(m_gifView, &GIFView::recordingStopped, m_controller, &GameController::clearAVStream, Qt::DirectConnection);
+		connect(m_controller, &GameController::gameStopped, m_gifView, &GIFView::stopRecording);
+		connect(m_controller, &GameController::gameStopped, m_gifView, &QWidget::close);
+		connect(this, &Window::shutdown, m_gifView, &QWidget::close);
 	}
 	m_gifView->show();
 }
@@ -730,11 +730,11 @@ void Window::gameStarted(mCoreThread* context, const QString& fname) {
 		return;
 	}
 	MutexUnlock(&context->stateMutex);
-	foreach (QAction* action, m_gameActions) {
+	for (QAction* action : m_gameActions) {
 		action->setDisabled(false);
 	}
 #ifdef M_CORE_GBA
-	foreach (QAction* action, m_gbaActions) {
+	for (QAction* action : m_gbaActions) {
 		action->setDisabled(context->core->platform(context->core) != PLATFORM_GBA);
 	}
 #endif
@@ -800,11 +800,11 @@ void Window::gameStarted(mCoreThread* context, const QString& fname) {
 
 void Window::gameStopped() {
 #ifdef M_CORE_GBA
-	foreach (QAction* action, m_gbaActions) {
+	for (QAction* action : m_gbaActions) {
 		action->setDisabled(false);
 	}
 #endif
-	foreach (QAction* action, m_gameActions) {
+	for (QAction* action : m_gameActions) {
 		action->setDisabled(true);
 	}
 	setWindowFilePath(QString());
@@ -863,7 +863,7 @@ void Window::tryMakePortable() {
 	                                       tr("This will make the emulator load its configuration from the same directory as the executable. Do you want to continue?"),
 	                                       QMessageBox::Yes | QMessageBox::Cancel, this, Qt::Sheet);
 	confirm->setAttribute(Qt::WA_DeleteOnClose);
-	connect(confirm->button(QMessageBox::Yes), SIGNAL(clicked()), m_config, SLOT(makePortable()));
+	connect(confirm->button(QMessageBox::Yes), &QAbstractButton::clicked, m_config, &ConfigController::makePortable);
 	confirm->show();
 }
 
@@ -945,8 +945,8 @@ void Window::openStateWindow(LoadSave ls) {
 	}
 	bool wasPaused = m_controller->isPaused();
 	m_stateWindow = new LoadSaveState(m_controller);
-	connect(this, SIGNAL(shutdown()), m_stateWindow, SLOT(close()));
-	connect(m_controller, SIGNAL(gameStopped(mCoreThread*)), m_stateWindow, SLOT(close()));
+	connect(this, &Window::shutdown, m_stateWindow, &QWidget::close);
+	connect(m_controller, &GameController::gameStopped, m_stateWindow, &QWidget::close);
 	connect(m_stateWindow, &LoadSaveState::closed, [this]() {
 		detachWidget(m_stateWindow);
 		m_stateWindow = nullptr;
@@ -1024,13 +1024,13 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_shortcutController->addMenu(quickSaveMenu);
 
 	QAction* quickLoad = new QAction(tr("Load recent"), quickLoadMenu);
-	connect(quickLoad, SIGNAL(triggered()), m_controller, SLOT(loadState()));
+	connect(quickLoad, &QAction::triggered, m_controller, &GameController::loadState);
 	m_gameActions.append(quickLoad);
 	m_nonMpActions.append(quickLoad);
 	addControlledAction(quickLoadMenu, quickLoad, "quickLoad");
 
 	QAction* quickSave = new QAction(tr("Save recent"), quickSaveMenu);
-	connect(quickSave, SIGNAL(triggered()), m_controller, SLOT(saveState()));
+	connect(quickSave, &QAction::triggered, m_controller, &GameController::saveState);
 	m_gameActions.append(quickSave);
 	m_nonMpActions.append(quickSave);
 	addControlledAction(quickSaveMenu, quickSave, "quickSave");
@@ -1040,14 +1040,14 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	QAction* undoLoadState = new QAction(tr("Undo load state"), quickLoadMenu);
 	undoLoadState->setShortcut(tr("F11"));
-	connect(undoLoadState, SIGNAL(triggered()), m_controller, SLOT(loadBackupState()));
+	connect(undoLoadState, &QAction::triggered, m_controller, &GameController::loadBackupState);
 	m_gameActions.append(undoLoadState);
 	m_nonMpActions.append(undoLoadState);
 	addControlledAction(quickLoadMenu, undoLoadState, "undoLoadState");
 
 	QAction* undoSaveState = new QAction(tr("Undo save state"), quickSaveMenu);
 	undoSaveState->setShortcut(tr("Shift+F11"));
-	connect(undoSaveState, SIGNAL(triggered()), m_controller, SLOT(saveBackupState()));
+	connect(undoSaveState, &QAction::triggered, m_controller, &GameController::saveBackupState);
 	m_gameActions.append(undoSaveState);
 	m_nonMpActions.append(undoSaveState);
 	addControlledAction(quickSaveMenu, undoSaveState, "undoSaveState");
@@ -1075,13 +1075,13 @@ void Window::setupMenu(QMenuBar* menubar) {
 #ifdef M_CORE_GBA
 	fileMenu->addSeparator();
 	QAction* importShark = new QAction(tr("Import GameShark Save"), fileMenu);
-	connect(importShark, SIGNAL(triggered()), this, SLOT(importSharkport()));
+	connect(importShark, &QAction::triggered, this, &Window::importSharkport);
 	m_gameActions.append(importShark);
 	m_gbaActions.append(importShark);
 	addControlledAction(fileMenu, importShark, "importShark");
 
 	QAction* exportShark = new QAction(tr("Export GameShark Save"), fileMenu);
-	connect(exportShark, SIGNAL(triggered()), this, SLOT(exportSharkport()));
+	connect(exportShark, &QAction::triggered, this, &Window::exportSharkport);
 	m_gameActions.append(exportShark);
 	m_gbaActions.append(exportShark);
 	addControlledAction(fileMenu, exportShark, "exportShark");
@@ -1099,7 +1099,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 #endif
 
 	QAction* about = new QAction(tr("About"), fileMenu);
-	connect(about, SIGNAL(triggered()), this, SLOT(openAboutScreen()));
+	connect(about, &QAction::triggered, this, &Window::openAboutScreen);
 	fileMenu->addAction(about);
 
 #ifndef Q_OS_MAC
@@ -1110,18 +1110,18 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_shortcutController->addMenu(emulationMenu);
 	QAction* reset = new QAction(tr("&Reset"), emulationMenu);
 	reset->setShortcut(tr("Ctrl+R"));
-	connect(reset, SIGNAL(triggered()), m_controller, SLOT(reset()));
+	connect(reset, &QAction::triggered, m_controller, &GameController::reset);
 	m_gameActions.append(reset);
 	addControlledAction(emulationMenu, reset, "reset");
 
 	QAction* shutdown = new QAction(tr("Sh&utdown"), emulationMenu);
-	connect(shutdown, SIGNAL(triggered()), m_controller, SLOT(closeGame()));
+	connect(shutdown, &QAction::triggered, m_controller, &GameController::closeGame);
 	m_gameActions.append(shutdown);
 	addControlledAction(emulationMenu, shutdown, "shutdown");
 
 #ifdef M_CORE_GBA
 	QAction* yank = new QAction(tr("Yank game pak"), emulationMenu);
-	connect(yank, SIGNAL(triggered()), m_controller, SLOT(yankPak()));
+	connect(yank, &QAction::triggered, m_controller, &GameController::yankPak);
 	m_gameActions.append(yank);
 	m_gbaActions.append(yank);
 	addControlledAction(emulationMenu, yank, "yank");
@@ -1132,7 +1132,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 	pause->setChecked(false);
 	pause->setCheckable(true);
 	pause->setShortcut(tr("Ctrl+P"));
-	connect(pause, SIGNAL(triggered(bool)), m_controller, SLOT(setPaused(bool)));
+	connect(pause, &QAction::triggered, m_controller, &GameController::setPaused);
 	connect(m_controller, &GameController::gamePaused, [this, pause]() {
 		pause->setChecked(true);
 	});
@@ -1142,7 +1142,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	QAction* frameAdvance = new QAction(tr("&Next frame"), emulationMenu);
 	frameAdvance->setShortcut(tr("Ctrl+N"));
-	connect(frameAdvance, SIGNAL(triggered()), m_controller, SLOT(frameAdvance()));
+	connect(frameAdvance, &QAction::triggered, m_controller, &GameController::frameAdvance);
 	m_gameActions.append(frameAdvance);
 	addControlledAction(emulationMenu, frameAdvance, "frameAdvance");
 
@@ -1182,7 +1182,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	QAction* rewind = new QAction(tr("Re&wind"), emulationMenu);
 	rewind->setShortcut(tr("~"));
-	connect(rewind, SIGNAL(triggered()), m_controller, SLOT(rewind()));
+	connect(rewind, &QAction::triggered, m_controller, &GameController::rewind);
 	m_gameActions.append(rewind);
 	m_nonMpActions.append(rewind);
 	addControlledAction(emulationMenu, rewind, "rewind");
@@ -1215,11 +1215,11 @@ void Window::setupMenu(QMenuBar* menubar) {
 	QMenu* solarMenu = emulationMenu->addMenu(tr("Solar sensor"));
 	m_shortcutController->addMenu(solarMenu);
 	QAction* solarIncrease = new QAction(tr("Increase solar level"), solarMenu);
-	connect(solarIncrease, SIGNAL(triggered()), m_controller, SLOT(increaseLuminanceLevel()));
+	connect(solarIncrease, &QAction::triggered, m_controller, &GameController::increaseLuminanceLevel);
 	addControlledAction(solarMenu, solarIncrease, "increaseLuminanceLevel");
 
 	QAction* solarDecrease = new QAction(tr("Decrease solar level"), solarMenu);
-	connect(solarDecrease, SIGNAL(triggered()), m_controller, SLOT(decreaseLuminanceLevel()));
+	connect(solarDecrease, &QAction::triggered, m_controller, &GameController::decreaseLuminanceLevel);
 	addControlledAction(solarMenu, solarDecrease, "decreaseLuminanceLevel");
 
 	QAction* maxSolar = new QAction(tr("Brightest solar level"), solarMenu);
@@ -1309,7 +1309,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_config->updateOption("frameskip");
 
 	QAction* shaderView = new QAction(tr("Shader options..."), avMenu);
-	connect(shaderView, SIGNAL(triggered()), m_shaderView, SLOT(show()));
+	connect(shaderView, &QAction::triggered, m_shaderView, &QWidget::show);
 	if (!m_display->supportsShaders()) {
 		shaderView->setEnabled(false);
 	}
@@ -1347,31 +1347,31 @@ void Window::setupMenu(QMenuBar* menubar) {
 #ifdef USE_PNG
 	QAction* screenshot = new QAction(tr("Take &screenshot"), avMenu);
 	screenshot->setShortcut(tr("F12"));
-	connect(screenshot, SIGNAL(triggered()), m_controller, SLOT(screenshot()));
+	connect(screenshot, &QAction::triggered, m_controller, &GameController::screenshot);
 	m_gameActions.append(screenshot);
 	addControlledAction(avMenu, screenshot, "screenshot");
 #endif
 
 #ifdef USE_FFMPEG
 	QAction* recordOutput = new QAction(tr("Record output..."), avMenu);
-	connect(recordOutput, SIGNAL(triggered()), this, SLOT(openVideoWindow()));
+	connect(recordOutput, &QAction::triggered, this, &Window::openVideoWindow);
 	addControlledAction(avMenu, recordOutput, "recordOutput");
 	m_gameActions.append(recordOutput);
 #endif
 
 #ifdef USE_MAGICK
 	QAction* recordGIF = new QAction(tr("Record GIF..."), avMenu);
-	connect(recordGIF, SIGNAL(triggered()), this, SLOT(openGIFWindow()));
+	connect(recordGIF, &QAction::triggered, this, &Window::openGIFWindow);
 	addControlledAction(avMenu, recordGIF, "recordGIF");
 #endif
 
 	QAction* recordVL = new QAction(tr("Record video log..."), avMenu);
-	connect(recordVL, SIGNAL(triggered()), this, SLOT(startVideoLog()));
+	connect(recordVL, &QAction::triggered, this, &Window::startVideoLog);
 	addControlledAction(avMenu, recordVL, "recordVL");
 	m_gameActions.append(recordVL);
 
 	QAction* stopVL = new QAction(tr("Stop video log"), avMenu);
-	connect(stopVL, SIGNAL(triggered()), m_controller, SLOT(endVideoLog()));
+	connect(stopVL, &QAction::triggered, m_controller, &GameController::endVideoLog);
 	addControlledAction(avMenu, stopVL, "stopVL");
 	m_gameActions.append(stopVL);
 
@@ -1385,7 +1385,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 	QMenu* toolsMenu = menubar->addMenu(tr("&Tools"));
 	m_shortcutController->addMenu(toolsMenu);
 	QAction* viewLogs = new QAction(tr("View &logs..."), toolsMenu);
-	connect(viewLogs, SIGNAL(triggered()), m_logView, SLOT(show()));
+	connect(viewLogs, &QAction::triggered, m_logView, &QWidget::show);
 	addControlledAction(toolsMenu, viewLogs, "viewLogs");
 
 	QAction* overrides = new QAction(tr("Game &overrides..."), toolsMenu);
@@ -1409,13 +1409,13 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 #ifdef USE_DEBUGGERS
 	QAction* consoleWindow = new QAction(tr("Open debugger console..."), toolsMenu);
-	connect(consoleWindow, SIGNAL(triggered()), this, SLOT(consoleOpen()));
+	connect(consoleWindow, &QAction::triggered, this, &Window::consoleOpen);
 	addControlledAction(toolsMenu, consoleWindow, "debuggerWindow");
 #endif
 
 #ifdef USE_GDB_STUB
 	QAction* gdbWindow = new QAction(tr("Start &GDB server..."), toolsMenu);
-	connect(gdbWindow, SIGNAL(triggered()), this, SLOT(gdbOpen()));
+	connect(gdbWindow, &QAction::triggered, this, &Window::gdbOpen);
 	m_gbaActions.append(gdbWindow);
 	addControlledAction(toolsMenu, gdbWindow, "gdbWindow");
 #endif
@@ -1513,7 +1513,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_config->updateOption("preload");
 
 	QAction* exitFullScreen = new QAction(tr("Exit fullscreen"), frameMenu);
-	connect(exitFullScreen, SIGNAL(triggered()), this, SLOT(exitFullScreen()));
+	connect(exitFullScreen, &QAction::triggered, this, &Window::exitFullScreen);
 	exitFullScreen->setShortcut(QKeySequence("Esc"));
 	addHiddenAction(frameMenu, exitFullScreen, "exitFullScreen");
 
@@ -1580,7 +1580,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 		m_controller->setAutofire(GBA_KEY_LEFT, false);
 	}, QKeySequence(), tr("Autofire Left"), "autofireLeft");
 
-	foreach (QAction* action, m_gameActions) {
+	for (QAction* action : m_gameActions) {
 		action->setDisabled(true);
 	}
 }


### PR DESCRIPTION
A few connect()s have not been migrated because the best way to migrate them requires somewhat invasive changes. Other than that, everything has been moved over.

~~The FFmpeg/GIF export changes **have not been tested** and are almost certainly busted because I don't have FFmpeg or ImageMagick here to test, so don't merge until Travis passes.~~ Fixed now.