### PR TITLE
CMake/Linux: Enforce linking with -pthreads for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,10 @@ elseif(UNIX)
 
 	if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		add_definitions(-D_GNU_SOURCE)
+
+		if(BUILD_STATIC)
+			link_libraries(-pthread)
+		endif()
 	endif()
 	if(NOT APPLE AND NOT HAIKU)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")


### PR DESCRIPTION
This should fix https://github.com/mgba-emu/mgba/issues/909.

With this change, I can build a static and shared build of mGBA Qt on my Linux system. I also compiled it successfully with MSYS2. However, I don't know if there is a more elegant solution than this... I think this needs some more testing, especially on the *nix systems.