### PR TITLE
Fix undefined symbols when compiling libretro core as debug build

### DIFF
--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -625,7 +625,9 @@ static void _mCoreLog(struct mLogger* logger, int category, enum mLogLevel level
 	printf("\n");
 	struct mCoreThread* thread = mCoreThreadGet();
 	if (thread && level == mLOG_FATAL) {
+#ifndef DISABLE_THREADING
 		mCoreThreadMarkCrashed(thread);
+#endif
 	}
 }
 

--- a/src/gb/core.c
+++ b/src/gb/core.c
@@ -812,6 +812,7 @@ static void _GBCoreEnableAudioChannel(struct mCore* core, size_t id, bool enable
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBCoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBCore* gbcore = (struct GBCore*) core;
 	struct GB* gb = core->board;
@@ -834,6 +835,7 @@ static void _GBCoreEndVideoLog(struct mCore* core) {
 	free(gbcore->proxyRenderer.logger);
 	gbcore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBCoreCreate(void) {
 	struct GBCore* gbcore = malloc(sizeof(*gbcore));

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -825,6 +825,7 @@ static void _GBACoreEnableAudioChannel(struct mCore* core, size_t id, bool enabl
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBACoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBACore* gbacore = (struct GBACore*) core;
 	struct GBA* gba = core->board;
@@ -851,6 +852,7 @@ static void _GBACoreEndVideoLog(struct mCore* core) {
 	free(gbacore->proxyRenderer.logger);
 	gbacore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBACoreCreate(void) {
 	struct GBACore* gbacore = malloc(sizeof(*gbacore));


### PR DESCRIPTION
When building with `cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBRETRO=1` the resulting lib has undefined symbols that cause issues when loading the libretro core in GDB.

~~~
$ ldd -r mgba_libretro.so
undefined symbol: GBAVideoProxyRendererCreate (./mgba_libretro.so)
undefined symbol: GBAVideoProxyRendererUnshim (./mgba_libretro.so)
undefined symbol: GBAVideoProxyRendererShim (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererCreate (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererUnshim (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererShim (./mgba_libretro.so)
undefined symbol: mVideoLogContextInitialState (./mgba_libretro.so)
undefined symbol: mVideoLoggerAddChannel (./mgba_libretro.so)
undefined symbol: mVideoLoggerAttachChannel (./mgba_libretro.so)
undefined symbol: mVideoLoggerRendererCreate (./mgba_libretro.so)
undefined symbol: mCoreThreadMarkCrashed (./mgba_libretro.so)
~~~

`_GBCoreStartVideoLog` and `_GBCoreEndVideoLog` are unused when `MINIMAL_CORE` is defined and they pull in some undefined symbols (video logger and video proxy renderer).
Second issue is that `_mCoreLog` uses `mCoreThreadMarkCrashed` which is undefined when `DISABLE_THREADING` is defined. (an alternative fix would be to ifdef the usage in `_mCoreLog`)

I've tried to fix this in https://github.com/libretro/mgba/pull/80 first, but since it issue exists also in upstream mgba let's try to fix it here.