### PR TITLE
Fix undefined symbols when compiling libretro core as debug build

### DIFF
--- a/src/gb/core.c
+++ b/src/gb/core.c
@@ -746,6 +746,7 @@ static void _GBCoreEnableAudioChannel(struct mCore* core, size_t id, bool enable
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBCoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBCore* gbcore = (struct GBCore*) core;
 	struct GB* gb = core->board;
@@ -768,6 +769,7 @@ static void _GBCoreEndVideoLog(struct mCore* core) {
 	free(gbcore->proxyRenderer.logger);
 	gbcore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBCoreCreate(void) {
 	struct GBCore* gbcore = malloc(sizeof(*gbcore));

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -803,6 +803,7 @@ static void _GBACoreEnableAudioChannel(struct mCore* core, size_t id, bool enabl
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBACoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBACore* gbacore = (struct GBACore*) core;
 	struct GBA* gba = core->board;
@@ -829,6 +830,7 @@ static void _GBACoreEndVideoLog(struct mCore* core) {
 	free(gbacore->proxyRenderer.logger);
 	gbacore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBACoreCreate(void) {
 	struct GBACore* gbacore = malloc(sizeof(*gbacore));


### PR DESCRIPTION
Backport of https://github.com/mgba-emu/mgba/pull/935.