### PR TITLE
Wii: Fix garbage during autoboot

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Bugfixes:
  - GB Timer: Minor accuracy improvements
  - GB Audio: Clock frame events on DIV
  - GBA: Fix SharkPort saves for EEPROM games
+ - Wii: Fix garbage during autoboot
 Misc:
  - GBA Timer: Use global cycles for timers
  - GBA: Extend oddly-sized ROMs to full address space (fixes mgba.io/i/722)

--- a/src/platform/wii/main.c
+++ b/src/platform/wii/main.c
@@ -512,7 +512,9 @@ int main(int argc, char* argv[]) {
 		for (i = 0; runner.keySources[i].id; ++i) {
 			mInputMapLoad(&runner.params.keyMap, runner.keySources[i].id, mCoreConfigGetInput(&runner.config));
 		}
+		VIDEO_SetBlack(true);
 		mGUIRun(&runner, argv[1]);
+		VIDEO_SetBlack(false);
 	} else {
 		mGUIRunloop(&runner);
 	}


### PR DESCRIPTION
Specifically when autobooting from the system menu via a forwarder, while the ROM is loading a(usually pink) horizontal bar will show up at the bottom of the screen until the game starts.

If I boot the forwarder from the hbc, the horizontal bar never appears but there are still some noticeable green dots all over the screen.