### PR TITLE
Libretro: Allow choosing the Game Boy model

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -63,6 +63,27 @@ static void _reloadSettings(void) {
 	};
 
 	struct retro_variable var;
+	enum GBModel model;
+	const char* modelName;
+
+	var.key = "mgba_model";
+	var.value = 0;
+	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+		if (strcmp(var.value, "Game Boy") == 0) {
+			model = GB_MODEL_DMG;
+		} else if (strcmp(var.value, "Super Game Boy") == 0) {
+			model = GB_MODEL_SGB;
+		} else if (strcmp(var.value, "Game Boy Color") == 0) {
+			model = GB_MODEL_CGB;
+		} else {
+			model = GB_MODEL_AUTODETECT;
+		}
+
+		modelName = GBModelToName(model);
+		mCoreConfigSetDefaultValue(&core->config, "gb.model", modelName);
+		mCoreConfigSetDefaultValue(&core->config, "sgb.model", modelName);
+		mCoreConfigSetDefaultValue(&core->config, "cgb.model", modelName);
+	}
 
 	var.key = "mgba_use_bios";
 	var.value = 0;
@@ -119,6 +140,7 @@ void retro_set_environment(retro_environment_t env) {
 	struct retro_variable vars[] = {
 		{ "mgba_solar_sensor_level", "Solar sensor level; 0|1|2|3|4|5|6|7|8|9|10" },
 		{ "mgba_allow_opposing_directions", "Allow opposing directional input; OFF|ON" },
+		{ "mgba_model", "Game Boy model (requires restart); Autodetect|Game Boy|Super Game Boy|Game Boy Color" },
 		{ "mgba_use_bios", "Use BIOS file if found (requires restart); ON|OFF" },
 		{ "mgba_skip_bios", "Skip BIOS intro (requires restart); OFF|ON" },
 		{ "mgba_sgb_borders", "Use Super Game Boy borders (requires restart); ON|OFF" },

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -320,7 +320,7 @@ void retro_run(void) {
 	videoCallback(outputBuffer, width, height, BYTES_PER_PIXEL * 256);
 }
 
-void static _setupMaps(struct mCore* core) {
+static void _setupMaps(struct mCore* core) {
 #ifdef M_CORE_GBA
 	if (core->platform(core) == PLATFORM_GBA) {
 		struct GBA* gba = core->board;


### PR DESCRIPTION
This adds a switch in RetroArch to force the Game Boy model to Game Boy, Game Boy Color, or Super Game Boy.  The default setting is "Autodetect," which preserves the current behavior of selecting the most appropriate model for the current game.

In order to support running DMG games with one of the Game Boy Color's built-in palettes, the RetroArch core will now also attempt to load the BIOS for the selected Game Boy model.