### PR TITLE
GB Video: Fix SGB border transparency

### DIFF
--- a/src/gb/renderers/software.c
+++ b/src/gb/renderers/software.c
@@ -75,25 +75,25 @@ static void _regenerateSGBBorder(struct GBVideoSoftwareRenderer* renderer) {
 			tileData[3] = renderer->d.sgbCharRam[(SGBBgAttributesGetTile(mapData) * 16 + localY) * 2 + 0x11];
 
 			size_t base = y * renderer->outputBufferStride + x;
-			int p = SGBBgAttributesGetPalette(mapData) * 0x10;
+			int paletteBase = SGBBgAttributesGetPalette(mapData) * 0x10;
+			int colorSelector;
+
 			if (SGBBgAttributesIsXFlip(mapData)) {
-				renderer->outputBuffer[base + 0] = renderer->palette[p | ((tileData[0] >> 0) & 0x1) | ((tileData[1] << 1) & 0x2) | ((tileData[2] << 2) & 0x4) | ((tileData[3] << 3) & 0x8)];
-				renderer->outputBuffer[base + 1] = renderer->palette[p | ((tileData[0] >> 1) & 0x1) | ((tileData[1] >> 0) & 0x2) | ((tileData[2] << 1) & 0x4) | ((tileData[3] << 2) & 0x8)];
-				renderer->outputBuffer[base + 2] = renderer->palette[p | ((tileData[0] >> 2) & 0x1) | ((tileData[1] >> 1) & 0x2) | ((tileData[2] >> 0) & 0x4) | ((tileData[3] << 1) & 0x8)];
-				renderer->outputBuffer[base + 3] = renderer->palette[p | ((tileData[0] >> 3) & 0x1) | ((tileData[1] >> 2) & 0x2) | ((tileData[2] >> 1) & 0x4) | ((tileData[3] >> 0) & 0x8)];
-				renderer->outputBuffer[base + 4] = renderer->palette[p | ((tileData[0] >> 4) & 0x1) | ((tileData[1] >> 3) & 0x2) | ((tileData[2] >> 2) & 0x4) | ((tileData[3] >> 1) & 0x8)];
-				renderer->outputBuffer[base + 5] = renderer->palette[p | ((tileData[0] >> 5) & 0x1) | ((tileData[1] >> 4) & 0x2) | ((tileData[2] >> 3) & 0x4) | ((tileData[3] >> 2) & 0x8)];
-				renderer->outputBuffer[base + 6] = renderer->palette[p | ((tileData[0] >> 6) & 0x1) | ((tileData[1] >> 5) & 0x2) | ((tileData[2] >> 4) & 0x4) | ((tileData[3] >> 3) & 0x8)];
-				renderer->outputBuffer[base + 7] = renderer->palette[p | ((tileData[0] >> 7) & 0x1) | ((tileData[1] >> 6) & 0x2) | ((tileData[2] >> 5) & 0x4) | ((tileData[3] >> 4) & 0x8)];
+				for (i = 0; i < 8; ++i) {
+					colorSelector = (tileData[0] >> i & 0x1) << 0 | (tileData[1] >> i & 0x1) << 1 | (tileData[2] >> i & 0x1) << 2 | (tileData[3] >> i & 0x1) << 3;
+					// The first color of every palette is transparent
+					if (colorSelector) {
+						renderer->outputBuffer[base + i] = renderer->palette[paletteBase | colorSelector];
+					}
+				}
 			} else {
-				renderer->outputBuffer[base + 0] = renderer->palette[p | ((tileData[0] >> 7) & 0x1) | ((tileData[1] >> 6) & 0x2) | ((tileData[2] >> 5) & 0x4) | ((tileData[3] >> 4) & 0x8)];
-				renderer->outputBuffer[base + 1] = renderer->palette[p | ((tileData[0] >> 6) & 0x1) | ((tileData[1] >> 5) & 0x2) | ((tileData[2] >> 4) & 0x4) | ((tileData[3] >> 3) & 0x8)];
-				renderer->outputBuffer[base + 2] = renderer->palette[p | ((tileData[0] >> 5) & 0x1) | ((tileData[1] >> 4) & 0x2) | ((tileData[2] >> 3) & 0x4) | ((tileData[3] >> 2) & 0x8)];
-				renderer->outputBuffer[base + 3] = renderer->palette[p | ((tileData[0] >> 4) & 0x1) | ((tileData[1] >> 3) & 0x2) | ((tileData[2] >> 2) & 0x4) | ((tileData[3] >> 1) & 0x8)];
-				renderer->outputBuffer[base + 4] = renderer->palette[p | ((tileData[0] >> 3) & 0x1) | ((tileData[1] >> 2) & 0x2) | ((tileData[2] >> 1) & 0x4) | ((tileData[3] >> 0) & 0x8)];
-				renderer->outputBuffer[base + 5] = renderer->palette[p | ((tileData[0] >> 2) & 0x1) | ((tileData[1] >> 1) & 0x2) | ((tileData[2] >> 0) & 0x4) | ((tileData[3] << 1) & 0x8)];
-				renderer->outputBuffer[base + 6] = renderer->palette[p | ((tileData[0] >> 1) & 0x1) | ((tileData[1] >> 0) & 0x2) | ((tileData[2] << 1) & 0x4) | ((tileData[3] << 2) & 0x8)];
-				renderer->outputBuffer[base + 7] = renderer->palette[p | ((tileData[0] >> 0) & 0x1) | ((tileData[1] << 1) & 0x2) | ((tileData[2] << 2) & 0x4) | ((tileData[3] << 3) & 0x8)];
+				for (i = 7; i >= 0; --i) {
+					colorSelector = (tileData[0] >> i & 0x1) << 0 | (tileData[1] >> i & 0x1) << 1 | (tileData[2] >> i & 0x1) << 2 | (tileData[3] >> i & 0x1) << 3;
+
+					if (colorSelector) {
+						renderer->outputBuffer[base + 7 - i] = renderer->palette[paletteBase | colorSelector];
+					}
+				}
 			}
 		}
 	}

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -438,7 +438,9 @@ bool retro_load_game(const struct retro_game_info* game) {
 	core->init(core);
 	core->setAVStream(core, &stream);
 
-	outputBuffer = malloc(256 * 224 * BYTES_PER_PIXEL);
+	size_t size = 256 * 224 * BYTES_PER_PIXEL;
+	outputBuffer = malloc(size);
+	memset(outputBuffer, 0xFF, size);
 	core->setVideoBuffer(core, outputBuffer, 256);
 
 	core->setAudioBufferSize(core, SAMPLES);


### PR DESCRIPTION
This fixes an issue with Pokemon Blue's SGB border:

![bad](https://user-images.githubusercontent.com/2789460/37873220-51031334-304a-11e8-8097-e60858ae80f2.png) ![good](https://user-images.githubusercontent.com/2789460/37873221-56356b4a-304a-11e8-867e-8ea021b3d25f.png)

According to the [Pan Docs](http://problemkaputt.de/pandocs.htm#sgbcolorpalettesoverview), "Color 0 of each of the eight palettes is transparent, causing the backdrop color to be displayed instead".  The output buffer needed to be initialized to white for this border to display correctly, which also has a nice side effect of preventing a border of garbage from briefly displaying before boot:

![junk](https://user-images.githubusercontent.com/2789460/37873278-e841ce74-304b-11e8-8019-71106ca25dbe.png)

I updated the libretro version to initialize the output buffer; the Qt version already initializes its buffer to all 1s.  I haven't tried any other platforms, so they may also need to be be updated.

Thanks for taking the time to look at these changes, and thank you for making this wonderful emulator!
