### PR TITLE
GB: Fix GBC games running on GBA with BIOS

### DIFF
--- a/src/gb/gb.c
+++ b/src/gb/gb.c
@@ -555,6 +555,10 @@ void GBUnmapBIOS(struct GB* gb) {
 		free(gb->memory.romBase);
 		gb->memory.romBase = gb->memory.rom;
 	}
+	// XXX: Force AGB registers for AGB-mode
+	if (gb->model == GB_MODEL_AGB && gb->cpu->pc == 0x100) {
+		gb->cpu->b = 1;
+	}
 }
 
 void GBDetectModel(struct GB* gb) {

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -66,7 +66,7 @@ static void _reloadSettings(void) {
 	enum GBModel model;
 	const char* modelName;
 
-	var.key = "mgba_model";
+	var.key = "mgba_gb_model";
 	var.value = 0;
 	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
 		if (strcmp(var.value, "Game Boy") == 0) {
@@ -75,6 +75,8 @@ static void _reloadSettings(void) {
 			model = GB_MODEL_SGB;
 		} else if (strcmp(var.value, "Game Boy Color") == 0) {
 			model = GB_MODEL_CGB;
+		} else if (strcmp(var.value, "Game Boy Advance") == 0) {
+			model = GB_MODEL_AGB;
 		} else {
 			model = GB_MODEL_AUTODETECT;
 		}
@@ -140,7 +142,7 @@ void retro_set_environment(retro_environment_t env) {
 	struct retro_variable vars[] = {
 		{ "mgba_solar_sensor_level", "Solar sensor level; 0|1|2|3|4|5|6|7|8|9|10" },
 		{ "mgba_allow_opposing_directions", "Allow opposing directional input; OFF|ON" },
-		{ "mgba_model", "Game Boy model (requires restart); Autodetect|Game Boy|Super Game Boy|Game Boy Color" },
+		{ "mgba_gb_model", "Game Boy model (requires restart); Autodetect|Game Boy|Super Game Boy|Game Boy Color|Game Boy Advance" },
 		{ "mgba_use_bios", "Use BIOS file if found (requires restart); ON|OFF" },
 		{ "mgba_skip_bios", "Skip BIOS intro (requires restart); OFF|ON" },
 		{ "mgba_sgb_borders", "Use Super Game Boy borders (requires restart); ON|OFF" },
@@ -482,6 +484,7 @@ bool retro_load_game(const struct retro_game_info* game) {
 		}
 
 		switch (gb->model) {
+		case GB_MODEL_AGB:
 		case GB_MODEL_CGB:
 			biosName = "gbc_bios.bin";
 			break;


### PR DESCRIPTION
If the Game Boy Color model is set to Game Boy Advance, it only works as expected if the "Use BIOS" option is false or "Skip BIOS" is true.  `GBSkipBIOS` sets register B to 1 (which games can use to determine if they are running on a GBA), but register B never gets set when loading a real boot ROM.

Maybe there's a better approach (and I'd be happy to change this if there is), but this patches the GBC boot ROM to load 1 into B when the model is set to GBA.  There are two bytes of `NOOP` near the end of the main routine, which gives us exactly enough room to add the new instruction without compromising anything else.  It's almost too good to be a coincidence, and makes me wonder if the GBA contains a modified GBC boot ROM that works exactly like this...

Anyway, I tested this with Oracle of Ages, which uses a brighter color palette and opens a new shop when run on a GBA:

![gbc](https://user-images.githubusercontent.com/2789460/37944661-1354be96-31af-11e8-92f6-3bd8e717434a.png) ![gba](https://user-images.githubusercontent.com/2789460/37944665-1661f20c-31af-11e8-98a9-c902af092bfe.png)
