### PR TITLE
GB Serialize: Don't serialize SGB packet

### DIFF
--- a/include/mgba/internal/gb/serialize.h
+++ b/include/mgba/internal/gb/serialize.h
@@ -395,8 +395,7 @@ struct GBSerializedState {
 		uint8_t command;
 		uint8_t bits;
 		GBSerializedSGBFlags flags;
-		uint8_t packet[16];
-		uint32_t reserved[4];
+		uint32_t reserved[8];
 		uint8_t charRam[SGB_SIZE_CHAR_RAM];
 		uint8_t mapRam[SGB_SIZE_MAP_RAM];
 		uint8_t palRam[SGB_SIZE_PAL_RAM];

--- a/src/gb/serialize.c
+++ b/src/gb/serialize.c
@@ -214,8 +214,6 @@ void GBSGBSerialize(struct GB* gb, struct GBSerializedState* state) {
 	flags = GBSerializedSGBFlagsSetRenderMode(flags, gb->video.renderer->sgbRenderMode);
 	STORE_32LE(flags, 0, &state->sgb.flags);
 
-	memcpy(state->sgb.packet, gb->sgbPacket, sizeof(state->sgb.packet));
-
 	if (gb->video.renderer->sgbCharRam) {
 		memcpy(state->sgb.charRam, gb->video.renderer->sgbCharRam, sizeof(state->sgb.charRam));
 	}
@@ -242,8 +240,6 @@ void GBSGBDeserialize(struct GB* gb, const struct GBSerializedState* state) {
 	gb->currentSgbBits = GBSerializedSGBFlagsGetP1Bits(flags);
 	gb->video.renderer->sgbRenderMode = GBSerializedSGBFlagsGetRenderMode(flags);
 
-	memcpy(gb->sgbPacket, state->sgb.packet, sizeof(state->sgb.packet));
-
 	if (!gb->video.renderer->sgbCharRam) {
 		gb->video.renderer->sgbCharRam = anonymousMemoryMap(SGB_SIZE_CHAR_RAM);
 	}
@@ -267,5 +263,4 @@ void GBSGBDeserialize(struct GB* gb, const struct GBSerializedState* state) {
 	memcpy(gb->video.renderer->sgbAttributes, state->sgb.attributes, sizeof(state->sgb.attributes));
 
 	GBVideoWriteSGBPacket(&gb->video, (uint8_t[16]) { (SGB_ATRC_EN << 3) | 1, 0 });
-	GBVideoWriteSGBPacket(&gb->video, gb->sgbPacket);
 }


### PR DESCRIPTION
If the most recent SGB command consisted of multiple packets (like an `ATTR_BLK` command with three or more data sets), the serialized state only contains the last packet.  When it is replayed by loading a save state or rewinding, the packet is (incorrectly) interpreted as a command, causing miscolored graphics:

![rewind](https://user-images.githubusercontent.com/2789460/38160980-4ba18ec6-34f9-11e8-8b2e-cfc57ec70bf6.gif)
