### PR TITLE
GB Video: Fix windows shifting down by one pixel when rewinding

### DIFF
--- a/src/gb/renderers/software.c
+++ b/src/gb/renderers/software.c
@@ -209,7 +209,7 @@ static void GBVideoSoftwareRendererUpdateWindow(struct GBVideoSoftwareRenderer* 
 			renderer->hasWindow = true;
 		} else {
 			if (!renderer->hasWindow) {
-				renderer->currentWy = renderer->lastY + 1 - renderer->wy;
+				renderer->currentWy = renderer->lastY - renderer->wy;
 			} else {
 				renderer->currentWy += renderer->lastY;
 			}


### PR DESCRIPTION
While rewinding, some areas of the screen (usually status bars and text boxes) shift down by one pixel.  I bisected to a6a6e31169f98 and looked for possible off-by-one errors.  I haven't spent much time reading this part of the code, so I don't know if this patch is the "right" fix, but it seems to resolve the issue.

![offbyone](https://user-images.githubusercontent.com/2789460/38169348-996520fe-359a-11e8-9c47-2f911498cced.gif)

