### PR TITLE
Python: Add runtime library search path

### DIFF
--- a/src/platform/python/_builder.py
+++ b/src/platform/python/_builder.py
@@ -9,6 +9,7 @@ pydir = os.path.dirname(os.path.abspath(__file__))
 srcdir = os.path.join(pydir, "..", "..")
 incdir = os.path.join(pydir, "..", "..", "..", "include")
 bindir = os.environ.get("BINDIR", os.path.join(os.getcwd(), ".."))
+libdir = os.environ.get("LIBDIR")
 
 cpp = shlex.split(os.environ.get("CPP", "cc -E"))
 cppflags = shlex.split(os.environ.get("CPPFLAGS", ""))
@@ -52,6 +53,7 @@ ffi.set_source("mgba._pylib", """
      extra_compile_args=cppflags,
      libraries=["mgba"],
      library_dirs=[bindir],
+     runtime_library_dirs=[libdir],
      sources=[os.path.join(pydir, path) for path in ["vfs-py.c", "core.c", "log.c", "sio.c"]])
 
 preprocessed = subprocess.check_output(cpp + ["-fno-inline", "-P"] + cppflags + [os.path.join(pydir, "_builder.h")], universal_newlines=True)

--- a/src/platform/python/setup.py.in
+++ b/src/platform/python/setup.py.in
@@ -4,6 +4,7 @@ import os
 import sys
 
 os.environ["BINDIR"] = "${CMAKE_BINARY_DIR}"
+os.environ["LIBDIR"] = "${CMAKE_INSTALL_PREFIX}/${LIBDIR}"
 os.environ["CPPFLAGS"] = " ".join([d for d in "${INCLUDE_FLAGS}".split(";") if d])
 
 classifiers = [


### PR DESCRIPTION
OS: Debian 10 "buster"

Currently, if libmgba is installed to a path which is not on the system's library search path, importing the python library fails:

```
Python 3.6.5rc1 (default, Mar 14 2018, 06:54:23) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mgba
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/callie/.local/lib/python3.6/site-packages/mgba/__init__.py", line 6, in <module>
    from ._pylib import ffi, lib
ImportError: libmgba.so.0.7: cannot open shared object file: No such file or directory
```

This PR adds the lib install directory of the build as a runtime library search path, solving the issue.