### PR TITLE
man: Silence mgba.6 mandoc warning.

### DIFF
--- a/doc/mgba.6
+++ b/doc/mgba.6
@@ -244,7 +244,7 @@ is used.
 .Bl -tag -width Ds -compact
 .It Pa $XDG_CONFIG_HOME/mgba/config.ini
 Default
-.Xr mgba 6
+.Nm mgba
 configuration file.
 .It Pa portable.ini
 If this file exists in the current directory,


### PR DESCRIPTION
This fixes the following warning found with mandoc's lint feature for the `mgba.6` man page.

In short `mgba.6` contains a cross reference to itself which seems to not be the best practice, `mandoc(1)` suggests using a `.Nm` or `.Fn` macro instead of `.Xr`, but in this case I just removed the `.Xr` macro and added the mgba reference in the existing text which seems to work out. I chose to omit the `(6)` as it seemed silly to have a reference to a man page I was currently reading. :)

Any suggestions are of course welcome.
```
man -Tlint mgba
```
```
man: mgba.6.gz:247:5: WARNING: cross reference to self: Xr mgba 6
```
```
cross reference to self
  (mdoc) An Xr macro refers to a name and section matching the section
  of the present manual page and a name mentioned in an Nm macro in
  the NAME or SYNOPSIS section, or in an Fn or Fo macro in the
  SYNOPSIS. Consider using Nm or Fn instead of Xr.
```
https://man.openbsd.org/mandoc.1