### PR TITLE
GBA: Zero DebugString buffer when handling messages

### DIFF
--- a/src/gba/gba.c
+++ b/src/gba/gba.c
@@ -525,6 +525,7 @@ void GBADebug(struct GBA* gba, uint16_t flags) {
 		level &= 0x1F;
 		char oolBuf[0x101];
 		strncpy(oolBuf, gba->debugString, sizeof(gba->debugString));
+		memset(gba->debugString, 0, sizeof(gba->debugString));
 		oolBuf[0x100] = '\0';
 		mLog(_mLOG_CAT_GBA_DEBUG(), level, "%s", oolBuf);
 	}


### PR DESCRIPTION
At the moment mGBA doesn't zero the DebugString buffer in [`GBADebug`](https://github.com/mgba-emu/mgba/blob/master/src/gba/gba.c#L521-L532) after copying a message out into `oolBuf`; if I don't either, and happen to use a message which is shorter than the one which came before it, odd things happen.
![2018-08-06](https://user-images.githubusercontent.com/5253816/43691147-7abd4d92-990f-11e8-9788-29aff9a9c22d.png)