### PR TITLE
GB Audio: Fix handling of the Game Boy's unsigned samples

### DIFF
--- a/src/gb/audio.c
+++ b/src/gb/audio.c
@@ -576,46 +576,46 @@ void GBAudioUpdateFrame(struct GBAudio* audio, struct mTiming* timing) {
 
 void GBAudioSamplePSG(struct GBAudio* audio, int16_t* left, int16_t* right) {
 	int dcOffset = audio->style == GB_AUDIO_GBA ? 0 : 0x8;
-	int sampleLeft = dcOffset;
-	int sampleRight = dcOffset;
+	int sampleLeft = 0;
+	int sampleRight = 0;
 
 	if (audio->playingCh1 && !audio->forceDisableCh[0]) {
 		if (audio->ch1Left) {
-			sampleLeft -= audio->ch1.sample;
+			sampleLeft += audio->ch1.sample - dcOffset;
 		}
 
 		if (audio->ch1Right) {
-			sampleRight -= audio->ch1.sample;
+			sampleRight += audio->ch1.sample - dcOffset;
 		}
 	}
 
 	if (audio->playingCh2 && !audio->forceDisableCh[1]) {
 		if (audio->ch2Left) {
-			sampleLeft -=  audio->ch2.sample;
+			sampleLeft += audio->ch2.sample - dcOffset;
 		}
 
 		if (audio->ch2Right) {
-			sampleRight -= audio->ch2.sample;
+			sampleRight += audio->ch2.sample - dcOffset;
 		}
 	}
 
 	if (audio->playingCh3 && !audio->forceDisableCh[2]) {
 		if (audio->ch3Left) {
-			sampleLeft -= audio->ch3.sample;
+			sampleLeft += audio->ch3.sample - dcOffset;
 		}
 
 		if (audio->ch3Right) {
-			sampleRight -= audio->ch3.sample;
+			sampleRight += audio->ch3.sample - dcOffset;
 		}
 	}
 
 	if (audio->playingCh4 && !audio->forceDisableCh[3]) {
 		if (audio->ch4Left) {
-			sampleLeft -= audio->ch4.sample;
+			sampleLeft += audio->ch4.sample - dcOffset;
 		}
 
 		if (audio->ch4Right) {
-			sampleRight -= audio->ch4.sample;
+			sampleRight += audio->ch4.sample - dcOffset;
 		}
 	}
 


### PR DESCRIPTION
I _believe_ this to be correct.  It fixes some confusing behavior I saw while trying to get a long sample to play (by repeatedly editing the wavetable and doing a delicate dance to pause it just long enough).  It now matches SameBoy, at least for my purposes.  :)  And the waveform is no longer upside-down!

I listened to a couple songs in Oracle of Ages and Pokémon Crystal, and they sound _very slightly_ more crackly, but this is the Game Boy, so that's just as likely to be more correct.  mGBA with this patch is still not as crackly as SameBoy, which I'm told has very good APU emulation.

The one thing that confuses me is how this worked _at all_ before when playing multiple channels.  The sound should've been offset by 8 * (number of channels - 1), which seems...  significant?  I compared before/after recordings and the difference looks basically like white noise, so maybe it's imperceptible in most cases.