### PR TITLE
GBA I/O: SOUNDCNT_HI is readable when sound is off

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -139,6 +139,7 @@ Bugfixes:
  - GBA Savedata: Fix EEPROM writing codepath when savetype is not EEPROM
  - Core: Reroot timing list when (de)scheduling
  - GB Video: Changing LYC while LCDC off doesn't affect STAT (fixes mgba.io/i/1224)
+ - GBA I/O: SOUNDCNT_HI is readable when sound is off
 Misc:
  - mGUI: Add SGB border configuration option
  - mGUI: Add support for different settings types

--- a/src/gba/io.c
+++ b/src/gba/io.c
@@ -841,7 +841,6 @@ uint16_t GBAIORead(struct GBA* gba, uint32_t address) {
 	case REG_SOUND4CNT_LO:
 	case REG_SOUND4CNT_HI:
 	case REG_SOUNDCNT_LO:
-	case REG_SOUNDCNT_HI:
 		if (!GBAudioEnableIsEnable(gba->memory.io[REG_SOUNDCNT_X >> 1])) {
 			// TODO: Is writing allowed when the circuit is disabled?
 			return 0;
@@ -858,6 +857,7 @@ uint16_t GBAIORead(struct GBA* gba, uint32_t address) {
 	case REG_WINOUT:
 	case REG_BLDCNT:
 	case REG_BLDALPHA:
+	case REG_SOUNDCNT_HI:
 	case REG_SOUNDCNT_X:
 	case REG_WAVE_RAM0_LO:
 	case REG_WAVE_RAM0_HI:


### PR DESCRIPTION
Regression in 254721697244411011ab687dad5c18a8c0f2de49 (between 0.3.2 and 0.4.0). This should be allowed according to GBATEK and fixes RavenWorks' Organya player: http://raven.works/projects/cavestory/organya.gba