### PR TITLE
Fixed pokemon & kirby link communication errors

### DIFF
--- a/include/mgba-util/common.h
+++ b/include/mgba-util/common.h
@@ -77,6 +77,7 @@ typedef intptr_t ssize_t;
 #define ATOMIC_STORE(DST, SRC) __atomic_store_n(&DST, SRC, __ATOMIC_RELEASE)
 #define ATOMIC_LOAD(DST, SRC) DST = __atomic_load_n(&SRC, __ATOMIC_ACQUIRE)
 #define ATOMIC_ADD(DST, OP) __atomic_add_fetch(&DST, OP, __ATOMIC_RELEASE)
+#define ATOMIC_SUB(DST, OP) __atomic_sub_fetch(&DST, OP, __ATOMIC_RELEASE)
 #define ATOMIC_OR(DST, OP) __atomic_or_fetch(&DST, OP, __ATOMIC_RELEASE)
 #define ATOMIC_AND(DST, OP) __atomic_and_fetch(&DST, OP, __ATOMIC_RELEASE)
 #define ATOMIC_CMPXCHG(DST, EXPECTED, SRC) __atomic_compare_exchange_n(&DST, &EXPECTED, SRC, true,__ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
@@ -85,6 +86,7 @@ typedef intptr_t ssize_t;
 #define ATOMIC_STORE(DST, SRC) DST = SRC
 #define ATOMIC_LOAD(DST, SRC) DST = SRC
 #define ATOMIC_ADD(DST, OP) DST += OP
+#define ATOMIC_SUB(DST, OP) DST -= OP
 #define ATOMIC_OR(DST, OP) DST |= OP
 #define ATOMIC_AND(DST, OP) DST &= OP
 #define ATOMIC_CMPXCHG(DST, EXPECTED, OP) ((DST == EXPECTED) ? ((DST = OP), true) : false)

--- a/include/mgba-util/common.h
+++ b/include/mgba-util/common.h
@@ -81,6 +81,14 @@ typedef intptr_t ssize_t;
 #define ATOMIC_OR(DST, OP) __atomic_or_fetch(&DST, OP, __ATOMIC_RELEASE)
 #define ATOMIC_AND(DST, OP) __atomic_and_fetch(&DST, OP, __ATOMIC_RELEASE)
 #define ATOMIC_CMPXCHG(DST, EXPECTED, SRC) __atomic_compare_exchange_n(&DST, &EXPECTED, SRC, true,__ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+#elif defined _MSC_VER
+#define ATOMIC_STORE(DST, SRC) InterlockedExchange(&DST, SRC)
+#define ATOMIC_LOAD(DST, SRC) DST = InterlockedOrAcquire(&SRC, 0)
+#define ATOMIC_ADD(DST, OP) InterlockedAddRelease(&DST, OP)
+#define ATOMIC_SUB(DST, OP) InterlockedAddRelease(&DST, -OP)
+#define ATOMIC_OR(DST, OP) InterlockedOrRelease(&DST, OP)
+#define ATOMIC_AND(DST, OP) InterlockedAndRelease(&DST, OP)
+#define ATOMIC_CMPXCHG(DST, EXPECTED, SRC) (InterlockedCompareExchange(&DST, SRC, EXPECTED) == EXPECTED)
 #else
 // TODO
 #define ATOMIC_STORE(DST, SRC) DST = SRC

--- a/include/mgba-util/platform/posix/threading.h
+++ b/include/mgba-util/platform/posix/threading.h
@@ -29,6 +29,18 @@ static inline int MutexInit(Mutex* mutex) {
 	return pthread_mutex_init(mutex, 0);
 }
 
+static inline int MutexInitRecursive(Mutex* mutex) {
+	pthread_mutexattr_t attr;
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+
+	int re = pthread_mutex_init(mutex, &attr);
+
+	pthread_mutexattr_destroy(&attr);
+
+	return re;
+}
+
 static inline int MutexDeinit(Mutex* mutex) {
 	return pthread_mutex_destroy(mutex);
 }

--- a/include/mgba-util/platform/windows/threading.h
+++ b/include/mgba-util/platform/windows/threading.h
@@ -22,6 +22,9 @@ static inline int MutexInit(Mutex* mutex) {
 	return GetLastError();
 }
 
+// windows critical section is recursive by default
+#define MutexInitRecursive MutexInit
+
 static inline int MutexDeinit(Mutex* mutex) {
 	DeleteCriticalSection(mutex);
 	return GetLastError();

--- a/include/mgba/core/lockstep.h
+++ b/include/mgba/core/lockstep.h
@@ -35,6 +35,7 @@ struct mLockstep {
 	bool (*wait)(struct mLockstep*, unsigned mask);
 	void (*addCycles)(struct mLockstep*, int id, int32_t cycles);
 	int32_t (*useCycles)(struct mLockstep*, int id, int32_t cycles);
+	int32_t (*unusedCycles)(struct mLockstep*, int id);
 	void (*unload)(struct mLockstep*, int id);
 	void* context;
 #ifndef NDEBUG

--- a/include/mgba/core/lockstep.h
+++ b/include/mgba/core/lockstep.h
@@ -7,6 +7,9 @@
 #define SIO_LOCKSTEP_H
 
 #include <mgba-util/common.h>
+#include <mgba-util/threading.h>
+
+#define MGBA_LOCK_STEP_USE_MUTEX 1
 
 CXX_GUARD_START
 
@@ -19,8 +22,13 @@ enum mLockstepPhase {
 };
 
 struct mLockstep {
+#if MGBA_LOCK_STEP_USE_MUTEX
+	Mutex mutex;
+	Condition cond;
+#endif
+
 	int attached;
-	enum mLockstepPhase transferActive;
+	int32_t transferActive; // must be one of the values in mLockstepPhase
 	int32_t transferCycles;
 
 	bool (*signal)(struct mLockstep*, unsigned mask);
@@ -35,6 +43,7 @@ struct mLockstep {
 };
 
 void mLockstepInit(struct mLockstep*);
+void mLockstepDeinit(struct mLockstep*);
 
 CXX_GUARD_END
 

--- a/include/mgba/internal/gb/sio/lockstep.h
+++ b/include/mgba/internal/gb/sio/lockstep.h
@@ -38,6 +38,7 @@ struct GBSIOLockstepNode {
 };
 
 void GBSIOLockstepInit(struct GBSIOLockstep*);
+void GBSIOLockstepInit2(struct GBSIOLockstep*, bool initBase);
 
 void GBSIOLockstepNodeCreate(struct GBSIOLockstepNode*);
 

--- a/include/mgba/internal/gba/sio/lockstep.h
+++ b/include/mgba/internal/gba/sio/lockstep.h
@@ -42,6 +42,7 @@ struct GBASIOLockstepNode {
 };
 
 void GBASIOLockstepInit(struct GBASIOLockstep*);
+void GBASIOLockstepInit2(struct GBASIOLockstep*, bool initBase);
 
 void GBASIOLockstepNodeCreate(struct GBASIOLockstepNode*);
 

--- a/src/core/lockstep.c
+++ b/src/core/lockstep.c
@@ -13,7 +13,7 @@ void mLockstepInit(struct mLockstep* lockstep) {
 #endif
 
 #if MGBA_LOCK_STEP_USE_MUTEX
-	MutexInit(&lockstep->mutex);
+	MutexInitRecursive(&lockstep->mutex);
 	ConditionInit(&lockstep->cond);
 #endif
 }

--- a/src/core/lockstep.c
+++ b/src/core/lockstep.c
@@ -11,6 +11,18 @@ void mLockstepInit(struct mLockstep* lockstep) {
 #ifndef NDEBUG
 	lockstep->transferId = 0;
 #endif
+
+#if MGBA_LOCK_STEP_USE_MUTEX
+	MutexInit(&lockstep->mutex);
+	ConditionInit(&lockstep->cond);
+#endif
+}
+
+void mLockstepDeinit(struct mLockstep* lockstep) {
+#if MGBA_LOCK_STEP_USE_MUTEX
+	MutexDeinit(&lockstep->mutex);
+	ConditionDeinit(&lockstep->cond);
+#endif
 }
 
 // TODO: Migrate nodes

--- a/src/gb/sio/lockstep.c
+++ b/src/gb/sio/lockstep.c
@@ -17,7 +17,14 @@ static uint8_t GBSIOLockstepNodeWriteSC(struct GBSIODriver* driver, uint8_t valu
 static void _GBSIOLockstepNodeProcessEvents(struct mTiming* timing, void* driver, uint32_t cyclesLate);
 
 void GBSIOLockstepInit(struct GBSIOLockstep* lockstep) {
-	mLockstepInit(&lockstep->d);
+	GBSIOLockstepInit2(lockstep, true);
+}
+
+void GBSIOLockstepInit2(struct GBSIOLockstep* lockstep, bool initBase) {
+	if (initBase) {
+		mLockstepInit(&lockstep->d);
+	}
+
 	lockstep->players[0] = NULL;
 	lockstep->players[1] = NULL;
 	lockstep->pendingSB[0] = 0xFF;

--- a/src/gb/sio/lockstep.c
+++ b/src/gb/sio/lockstep.c
@@ -236,6 +236,8 @@ static uint8_t GBSIOLockstepNodeWriteSC(struct GBSIODriver* driver, uint8_t valu
 			mTimingDeschedule(&driver->p->p->timing, &driver->p->event);
 			mTimingDeschedule(&driver->p->p->timing, &node->event);
 			mTimingSchedule(&driver->p->p->timing, &node->event, 0);
+		} else {
+			mLOG(GB_SIO, FATAL, "GBSIOLockstepNodeWriteSC() failed to write to masterClaimed\n");
 		}
 	}
 	return value;

--- a/src/gba/sio/lockstep.c
+++ b/src/gba/sio/lockstep.c
@@ -35,7 +35,14 @@ static uint16_t GBASIOLockstepNodeNormalWriteRegister(struct GBASIODriver* drive
 static void _GBASIOLockstepNodeProcessEvents(struct mTiming* timing, void* driver, uint32_t cyclesLate);
 
 void GBASIOLockstepInit(struct GBASIOLockstep* lockstep) {
-	mLockstepInit(&lockstep->d);
+	GBASIOLockstepInit2(lockstep, true);
+}
+
+void GBASIOLockstepInit2(struct GBASIOLockstep* lockstep, bool initBase) {
+	if (initBase) {
+		mLockstepInit(&lockstep->d);
+	}
+
 	lockstep->players[0] = 0;
 	lockstep->players[1] = 0;
 	lockstep->players[2] = 0;

--- a/src/platform/qt/MultiplayerController.cpp
+++ b/src/platform/qt/MultiplayerController.cpp
@@ -213,12 +213,12 @@ bool MultiplayerController::attachGame(CoreController* controller) {
 		switch (controller->platform()) {
 #ifdef M_CORE_GBA
 		case PLATFORM_GBA:
-			GBASIOLockstepInit(&m_gbaLockstep);
+			GBASIOLockstepInit2(&m_gbaLockstep, false);
 			break;
 #endif
 #ifdef M_CORE_GB
 		case PLATFORM_GB:
-			GBSIOLockstepInit(&m_gbLockstep);
+			GBSIOLockstepInit2(&m_gbLockstep, false);
 			break;
 #endif
 		default:

--- a/src/platform/qt/MultiplayerController.cpp
+++ b/src/platform/qt/MultiplayerController.cpp
@@ -145,6 +145,14 @@ MultiplayerController::MultiplayerController() {
 		RELEASE_CONTROLLER(controller, lockstep);
 		return cycles;
 	};
+	m_lockstep.unusedCycles= [](mLockstep* lockstep, int id) {
+		MultiplayerController* controller = static_cast<MultiplayerController*>(lockstep->context);
+		ACQUIRE_CONTROLLER(controller, lockstep);
+		Player* player = &controller->m_players[id];
+		auto cycles = player->cyclesPosted;
+		RELEASE_CONTROLLER(controller, lockstep);
+		return cycles;
+	};
 	m_lockstep.unload = [](mLockstep* lockstep, int id) {
 		MultiplayerController* controller = static_cast<MultiplayerController*>(lockstep->context);
 		ACQUIRE_CONTROLLER(controller, lockstep);

--- a/src/platform/qt/MultiplayerController.cpp
+++ b/src/platform/qt/MultiplayerController.cpp
@@ -29,15 +29,6 @@ using namespace QGBA;
 #define CORE_THREAD_STOP_WAITING(player, lockstep) mCoreThreadStopWaiting(player->controller->thread());
 #endif // MGBA_LOCK_STEP_USE_MUTEX
 
-#if MGBA_LOCK_STEP_USE_MUTEX
-MultiplayerController::Player::CondtionWrapper::CondtionWrapper(){
-	ConditionInit(&this->cond);
-}
-MultiplayerController::Player::CondtionWrapper::~CondtionWrapper() {
-	ConditionDeinit(&this->cond);
-}
-#endif // MGBA_LOCK_STEP_USE_MUTEX
-
 MultiplayerController::Player::Player(
 	CoreController* _controller,
 	GBSIOLockstepNode* _gbNode,
@@ -53,9 +44,6 @@ MultiplayerController::Player::Player(
 	cyclesPosted(_cyclesPosted),
 	waitMask(_waitMask)
 {
-#if MGBA_LOCK_STEP_USE_MUTEX
-	this->condWrapper.reset(new CondtionWrapper());
-#endif
 }
 
 MultiplayerController::Player::~Player() {

--- a/src/platform/qt/MultiplayerController.h
+++ b/src/platform/qt/MultiplayerController.h
@@ -17,6 +17,8 @@
 #include <mgba/internal/gb/sio/lockstep.h>
 #endif
 
+#include <memory>
+
 struct GBSIOLockstepNode;
 struct GBASIOLockstepNode;
 
@@ -29,6 +31,7 @@ Q_OBJECT
 
 public:
 	MultiplayerController();
+	~MultiplayerController();
 
 	bool attachGame(CoreController*);
 	void detachGame(CoreController*);
@@ -42,12 +45,33 @@ signals:
 
 private:
 	struct Player {
+		Player(
+			CoreController* _controller,
+			GBSIOLockstepNode* _gbNode,
+			GBASIOLockstepNode* _gbaNode,
+			int _awake,
+			int32_t _cyclesPosted,
+			unsigned _waitMask
+		);
+
+		~Player();
+
 		CoreController* controller;
 		GBSIOLockstepNode* gbNode;
 		GBASIOLockstepNode* gbaNode;
 		int awake;
 		int32_t cyclesPosted;
 		unsigned waitMask;
+
+#if MGBA_LOCK_STEP_USE_MUTEX
+		struct CondtionWrapper {
+			CondtionWrapper();
+			~CondtionWrapper();
+
+			Condition cond;
+		};
+		std::shared_ptr<CondtionWrapper> condWrapper;
+#endif
 	};
 	union {
 		mLockstep m_lockstep;

--- a/src/platform/qt/MultiplayerController.h
+++ b/src/platform/qt/MultiplayerController.h
@@ -62,16 +62,6 @@ private:
 		int awake;
 		int32_t cyclesPosted;
 		unsigned waitMask;
-
-#if MGBA_LOCK_STEP_USE_MUTEX
-		struct CondtionWrapper {
-			CondtionWrapper();
-			~CondtionWrapper();
-
-			Condition cond;
-		};
-		std::shared_ptr<CondtionWrapper> condWrapper;
-#endif
 	};
 	union {
 		mLockstep m_lockstep;

--- a/src/util/ring-fifo.c
+++ b/src/util/ring-fifo.c
@@ -7,6 +7,18 @@
 
 #include <mgba-util/memory.h>
 
+#if defined _MSC_VER
+#undef ATOMIC_STORE
+#undef ATOMIC_LOAD
+
+#define ATOMIC_STORE(DST, SRC) InterlockedExchangePointer(&DST, SRC)
+#define ATOMIC_LOAD(DST, SRC) atomic_load(&DST, &SRC)
+static void atomic_load(const void** DST, void* volatile * SRC) {
+	void* srcVal = *SRC;
+	*DST = InterlockedCompareExchangePointer(SRC, srcVal, srcVal);
+}
+#endif
+
 void RingFIFOInit(struct RingFIFO* buffer, size_t capacity) {
 	buffer->data = anonymousMemoryMap(capacity);
 	buffer->capacity = capacity;


### PR DESCRIPTION
Basically, let slaves wait until they use all added cycles from `addCycles` callback before signalling master to continue.

Also added macro switch to allow switching between using mutex vs using atomic ops for lockstep.