### PR TITLE
Changes needed for MINIMAL_CORE=3 ...

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -164,8 +164,10 @@ static bool _GBACoreInit(struct mCore* core) {
 	mRTCGenericSourceInit(&core->rtc, core);
 	gba->rtcSource = &core->rtc.d;
 
+#if !defined(MINIMAL_CORE) || MINIMAL_CORE < 3
 	GBAVideoSoftwareRendererCreate(&gbacore->renderer);
 	gbacore->renderer.outputBuffer = NULL;
+#endif
 
 #ifndef DISABLE_THREADING
 	mVideoThreadProxyCreate(&gbacore->threadProxy);
@@ -387,6 +389,7 @@ static void _GBACoreChecksum(const struct mCore* core, void* data, enum mCoreChe
 static void _GBACoreReset(struct mCore* core) {
 	struct GBACore* gbacore = (struct GBACore*) core;
 	struct GBA* gba = (struct GBA*) core->board;
+#if !defined(MINIMAL_CORE) || MINIMAL_CORE < 3
 	if (gbacore->renderer.outputBuffer) {
 		struct GBAVideoRenderer* renderer = &gbacore->renderer.d;
 #ifndef DISABLE_THREADING
@@ -399,6 +402,7 @@ static void _GBACoreReset(struct mCore* core) {
 #endif
 		GBAVideoAssociateRenderer(&gba->video, renderer);
 	}
+#endif
 
 	GBAOverrideApplyDefaults(gba, gbacore->overrides);
 

--- a/src/gba/video.c
+++ b/src/gba/video.c
@@ -215,9 +215,11 @@ static void GBAVideoDummyRendererDeinit(struct GBAVideoRenderer* renderer) {
 }
 
 static uint16_t GBAVideoDummyRendererWriteVideoRegister(struct GBAVideoRenderer* renderer, uint32_t address, uint16_t value) {
+#if !defined(MINIMAL_CORE) || MINIMAL_CORE < 3
 	if (renderer->cache) {
 		GBAVideoCacheWriteVideoRegister(renderer->cache, address, value);
 	}
+#endif
 	switch (address) {
 	case REG_DISPCNT:
 		value &= 0xFFF7;
@@ -257,15 +259,19 @@ static uint16_t GBAVideoDummyRendererWriteVideoRegister(struct GBAVideoRenderer*
 }
 
 static void GBAVideoDummyRendererWriteVRAM(struct GBAVideoRenderer* renderer, uint32_t address) {
+#if !defined(MINIMAL_CORE) || MINIMAL_CORE < 3
 	if (renderer->cache) {
 		mCacheSetWriteVRAM(renderer->cache, address);
 	}
+#endif
 }
 
 static void GBAVideoDummyRendererWritePalette(struct GBAVideoRenderer* renderer, uint32_t address, uint16_t value) {
+#if !defined(MINIMAL_CORE) || MINIMAL_CORE < 3
 	if (renderer->cache) {
 		mCacheSetWritePalette(renderer->cache, address >> 1, mColorFrom555(value));
 	}
+#endif
 }
 
 static void GBAVideoDummyRendererWriteOAM(struct GBAVideoRenderer* renderer, uint32_t oam) {


### PR DESCRIPTION
... to remove even more unneeded extra fluff. Useful
if compiling the library only for GSF playback, for
instance.