### PR TITLE
GBA: Add override for Touhoumon MMW and WL

### DIFF
--- a/src/gba/overrides.c
+++ b/src/gba/overrides.c
@@ -182,6 +182,12 @@ static const struct GBACartridgeOverride _overrides[] = {
 
 	// Aging cartridge
 	{ "TCHK", SAVEDATA_EEPROM, HW_NONE, IDLE_LOOP_NONE, false },
+	
+	// Touhoumon Marisa's Magic World
+	{ "AIME", SAVEDATA_FLASH1M, HW_RTC, IDLE_LOOP_NONE, false },
+
+	// Touhoumon World Link
+	{ "AICE", SAVEDATA_FLASH1M, HW_RTC, 0x80008C6, false },
 
 	{ { 0, 0, 0, 0 }, 0, 0, IDLE_LOOP_NONE, false }
 };


### PR DESCRIPTION
Hacks from Ruby and Emerald respectively, they use a custom Game ID (AICE and AIME).
Activating rtc in game overrides works, but you have to activate it every time you exit and reopen the emulator.
Not sure if this change is acceptable because these are hacks and here are only licensed games.
If this change is unacceptable a possible workaround would be to change in a hex editor the lines TOUHOUMONMMWAIME with POKEMON RUBYAXVE for "Touhoumon Marisa's Magic World" and TOUHOUMON_WLAICE with POKEMON EMERBPEE for "Touhoumon World Link" but I have no knowledge if this can have a side effect (i don't think so).