### PR TITLE
SDL: Move Raspberry Pi initialisation code to a separate file

### DIFF
--- a/src/platform/sdl/CMakeLists.txt
+++ b/src/platform/sdl/CMakeLists.txt
@@ -60,7 +60,7 @@ set(MAIN_SRC ${CMAKE_SOURCE_DIR}/src/platform/sdl/main.c)
 
 if(BUILD_RASPI)
 	add_definitions(-DBUILD_RASPI)
-	list(APPEND PLATFORM_SRC ${CMAKE_SOURCE_DIR}/src/platform/opengl/gles2.c ${CMAKE_SOURCE_DIR}/src/platform/sdl/gl-common.c)
+	list(APPEND PLATFORM_SRC ${CMAKE_SOURCE_DIR}/src/platform/opengl/gles2.c ${CMAKE_SOURCE_DIR}/src/platform/sdl/gl-common.c ${CMAKE_SOURCE_DIR}/src/platform/sdl/rpi-common.c)
 	list(APPEND MAIN_SRC ${CMAKE_SOURCE_DIR}/src/platform/sdl/gles2-sdl.c)
 	set(OPENGLES2_LIBRARY "-lEGL -lGLESv2 -lbcm_host")
 	set(BUILD_GLES2 ON CACHE BOOL "Using OpenGL|ES 2" FORCE)

--- a/src/platform/sdl/gles2-sdl.c
+++ b/src/platform/sdl/gles2-sdl.c
@@ -6,6 +6,9 @@
 #include "main.h"
 
 #include "gl-common.h"
+#ifdef BUILD_RASPI
+#include "rpi-common.h"
+#endif
 
 #include <mgba/core/core.h>
 #include <mgba/core/thread.h>
@@ -26,74 +29,7 @@ void mSDLGLES2Create(struct mSDLRenderer* renderer) {
 
 bool mSDLGLES2Init(struct mSDLRenderer* renderer) {
 #ifdef BUILD_RASPI
-	bcm_host_init();
-	renderer->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-	int major, minor;
-	if (EGL_FALSE == eglInitialize(renderer->display, &major, &minor)) {
-		printf("Failed to initialize EGL");
-		return false;
-	}
-
-	if (EGL_FALSE == eglBindAPI(EGL_OPENGL_ES_API)) {
-		printf("Failed to get GLES API");
-		return false;
-	}
-
-	const EGLint requestConfig[] = {
-		EGL_RED_SIZE, 5,
-		EGL_GREEN_SIZE, 5,
-		EGL_BLUE_SIZE, 5,
-		EGL_ALPHA_SIZE, 1,
-		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-		EGL_NONE
-	};
-
-	EGLConfig config;
-	EGLint numConfigs;
-
-	if (EGL_FALSE == eglChooseConfig(renderer->display, requestConfig, &config, 1, &numConfigs)) {
-		printf("Failed to choose EGL config\n");
-		return false;
-	}
-
-	const EGLint contextAttributes[] = {
-		EGL_CONTEXT_CLIENT_VERSION, 2,
-		EGL_NONE
-	};
-
-	int dispWidth = 240, dispHeight = 160, adjWidth;
-	renderer->context = eglCreateContext(renderer->display, config, EGL_NO_CONTEXT, contextAttributes);
-	graphics_get_display_size(0, &dispWidth, &dispHeight);
-	adjWidth = dispHeight / 2 * 3;
-
-	DISPMANX_DISPLAY_HANDLE_T display = vc_dispmanx_display_open(0);
-	DISPMANX_UPDATE_HANDLE_T update = vc_dispmanx_update_start(0);
-
-	VC_RECT_T destRect = {
-		.x = (dispWidth - adjWidth) / 2,
-		.y = 0,
-		.width = adjWidth,
-		.height = dispHeight
-	};
-
-	VC_RECT_T srcRect = {
-		.x = 0,
-		.y = 0,
-		.width = 240 << 16,
-		.height = 160 << 16
-	};
-
-	DISPMANX_ELEMENT_HANDLE_T element = vc_dispmanx_element_add(update, display, 0, &destRect, 0, &srcRect, DISPMANX_PROTECTION_NONE, 0, 0, 0);
-	vc_dispmanx_update_submit_sync(update);
-
-	renderer->window.element = element;
-	renderer->window.width = dispWidth;
-	renderer->window.height = dispHeight;
-
-	renderer->surface = eglCreateWindowSurface(renderer->display, config, &renderer->window, 0);
-	if (EGL_FALSE == eglMakeCurrent(renderer->display, renderer->surface, renderer->surface, renderer->context)) {
-		return false;
-	}
+	mRPIGLCommonInit(renderer);
 #else
 	mSDLGLCommonInit(renderer);
 #endif
@@ -112,7 +48,11 @@ bool mSDLGLES2Init(struct mSDLRenderer* renderer) {
 	renderer->gl2.d.lockAspectRatio = renderer->lockAspectRatio;
 	renderer->gl2.d.lockIntegerScaling = renderer->lockIntegerScaling;
 	renderer->gl2.d.filter = renderer->filter;
+#ifdef BUILD_RASPI
+	renderer->gl2.d.swap = mRPIGLCommonSwap;
+#else
 	renderer->gl2.d.swap = mSDLGLCommonSwap;
+#endif
 	renderer->gl2.d.init(&renderer->gl2.d, 0);
 	renderer->gl2.d.setDimensions(&renderer->gl2.d, renderer->width, renderer->height);
 
@@ -147,11 +87,7 @@ void mSDLGLES2Runloop(struct mSDLRenderer* renderer, void* user) {
 		}
 		mCoreSyncWaitFrameEnd(&context->impl->sync);
 		v->drawFrame(v);
-#ifdef BUILD_RASPI
-		eglSwapBuffers(renderer->display, renderer->surface);
-#else
 		v->swap(v);
-#endif
 	}
 }
 
@@ -160,10 +96,10 @@ void mSDLGLES2Deinit(struct mSDLRenderer* renderer) {
 		renderer->gl2.d.deinit(&renderer->gl2.d);
 	}
 #ifdef BUILD_RASPI
-	eglMakeCurrent(renderer->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-	eglDestroySurface(renderer->display, renderer->surface);
-	eglDestroyContext(renderer->display, renderer->context);
-	eglTerminate(renderer->display);
+	eglMakeCurrent(renderer->eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	eglDestroySurface(renderer->eglDisplay, renderer->eglSurface);
+	eglDestroyContext(renderer->eglDisplay, renderer->eglContext);
+	eglTerminate(renderer->eglDisplay);
 	bcm_host_deinit();
 #elif SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_GL_DeleteContext(renderer->glCtx);

--- a/src/platform/sdl/main.h
+++ b/src/platform/sdl/main.h
@@ -81,10 +81,10 @@ struct mSDLRenderer {
 #endif
 
 #ifdef BUILD_RASPI
-	EGLDisplay display;
-	EGLSurface surface;
-	EGLContext context;
-	EGL_DISPMANX_WINDOW_T window;
+	EGLDisplay eglDisplay;
+	EGLSurface eglSurface;
+	EGLContext eglContext;
+	EGL_DISPMANX_WINDOW_T eglWindow;
 #endif
 
 #ifdef BUILD_PANDORA

--- a/src/platform/sdl/rpi-common.c
+++ b/src/platform/sdl/rpi-common.c
@@ -1,0 +1,84 @@
+/* Copyright (c) 2013-2015 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "main.h"
+
+#include <mgba/core/version.h>
+
+void mRPIGLCommonSwap(struct VideoBackend* context) {
+	struct mSDLRenderer* renderer = (struct mSDLRenderer*) context->user;
+	eglSwapBuffers(renderer->eglDisplay, renderer->eglSurface);
+}
+
+void mRPIGLCommonInit(struct mSDLRenderer* renderer) {
+	bcm_host_init();
+	renderer->eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+	int major, minor;
+	if (EGL_FALSE == eglInitialize(renderer->eglDisplay, &major, &minor)) {
+		printf("Failed to initialize EGL");
+		return false;
+	}
+
+	if (EGL_FALSE == eglBindAPI(EGL_OPENGL_ES_API)) {
+		printf("Failed to get GLES API");
+		return false;
+	}
+
+	const EGLint requestConfig[] = {
+		EGL_RED_SIZE, 5,
+		EGL_GREEN_SIZE, 5,
+		EGL_BLUE_SIZE, 5,
+		EGL_ALPHA_SIZE, 1,
+		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_NONE
+	};
+
+	EGLConfig config;
+	EGLint numConfigs;
+
+	if (EGL_FALSE == eglChooseConfig(renderer->eglDisplay, requestConfig, &config, 1, &numConfigs)) {
+		printf("Failed to choose EGL config\n");
+		return false;
+	}
+
+	const EGLint contextAttributes[] = {
+		EGL_CONTEXT_CLIENT_VERSION, 2,
+		EGL_NONE
+	};
+
+	int dispWidth = 240, dispHeight = 160, adjWidth;
+	renderer->eglContext = eglCreateContext(renderer->eglDisplay, config, EGL_NO_CONTEXT, contextAttributes);
+	graphics_get_display_size(0, &dispWidth, &dispHeight);
+	adjWidth = dispHeight / 2 * 3;
+
+	DISPMANX_DISPLAY_HANDLE_T display = vc_dispmanx_display_open(0);
+	DISPMANX_UPDATE_HANDLE_T update = vc_dispmanx_update_start(0);
+
+	VC_RECT_T destRect = {
+		.x = (dispWidth - adjWidth) / 2,
+		.y = 0,
+		.width = adjWidth,
+		.height = dispHeight
+	};
+
+	VC_RECT_T srcRect = {
+		.x = 0,
+		.y = 0,
+		.width = 240 << 16,
+		.height = 160 << 16
+	};
+
+	DISPMANX_ELEMENT_HANDLE_T element = vc_dispmanx_element_add(update, display, 0, &destRect, 0, &srcRect, DISPMANX_PROTECTION_NONE, 0, 0, 0);
+	vc_dispmanx_update_submit_sync(update);
+
+	renderer->eglWindow.element = element;
+	renderer->eglWindow.width = dispWidth;
+	renderer->eglWindow.height = dispHeight;
+
+	renderer->eglSurface = eglCreateWindowSurface(renderer->eglDisplay, config, &renderer->eglWindow, 0);
+	if (EGL_FALSE == eglMakeCurrent(renderer->eglDisplay, renderer->eglSurface, renderer->eglSurface, renderer->eglContext)) {
+		return false;
+	}
+}

--- a/src/platform/sdl/rpi-common.h
+++ b/src/platform/sdl/rpi-common.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2013-2015 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef SDL_RPI_COMMON_H
+#define SDL_RPI_COMMON_H
+
+#include <mgba-util/common.h>
+
+CXX_GUARD_START
+
+#include "main.h"
+
+void mRPIGLCommonSwap(struct VideoBackend* context);
+void mRPIGLCommonInit(struct mSDLRenderer* renderer);
+
+CXX_GUARD_END
+
+#endif


### PR DESCRIPTION
I'm not sure if this works, or if it's even needed anymore since we now support SDL2, but moving this to a separate file makes things easier to maintain.