### PR TITLE
SDL: Exit the application when the escape key is pressed

### DIFF
--- a/src/platform/sdl/sdl-events.c
+++ b/src/platform/sdl/sdl-events.c
@@ -465,11 +465,9 @@ static void _mSDLHandleKeypress(struct mCoreThread* context, struct mSDLPlayer* 
 			context->frameCallback = _pauseAfterFrame;
 			mCoreThreadUnpause(context);
 			return;
-#ifdef BUILD_PANDORA
 		case SDLK_ESCAPE:
 			mCoreThreadEnd(context);
 			return;
-#endif
 		default:
 			if ((event->keysym.mod & GUI_MOD) && (event->keysym.mod & GUI_MOD) == event->keysym.mod) {
 				switch (event->keysym.sym) {


### PR DESCRIPTION
While SDL2 will quit the application when Alt+F4 is pressed, SDL1 does not. This makes it difficult to exit the application when it was started in full-screen.

This was tested with Linux and X11, although this behavior may differ on other platforms.