### PR TITLE
SDL: Fix search package

### DIFF
--- a/src/platform/cmake/FindSDL2.cmake
+++ b/src/platform/cmake/FindSDL2.cmake
@@ -1,6 +1,6 @@
-# SDL2_LIBRARY, the name of the library to link against
+# SDL2_LIBRARIES, the name of the library to link against
 # SDL2_FOUND, if false, do not try to link to SDL2
-# SDL2_INCLUDE_DIR, where to find SDL.h
+# SDL2_INCLUDE_DIRS, where to find SDL.h
 #
 # This module responds to the the flag:
 # SDL2_BUILDING_LIBRARY
@@ -8,7 +8,7 @@
 # only applications need main().
 # Otherwise, it is assumed you are building an application and this
 # module will attempt to locate and set the the proper link flags
-# as part of the returned SDL2_LIBRARY variable.
+# as part of the returned SDL2_LIBRARIES variable.
 #
 # Don't forget to include SDLmain.h and SDLmain.m your project for the
 # OS X framework based version. (Other versions link to -lSDL2main which
@@ -16,13 +16,13 @@
 # module will automatically add the -framework Cocoa on your behalf.
 #
 #
-# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
-# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# Additional Note: If you see an empty SDL2_LIBRARIES_TEMP in your configuration
+# and no SDL2_LIBRARIES, it means CMake did not find your SDL2 library
 # (SDL2.dll, libsdl2.so, SDL2.framework, etc).
-# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Set SDL2_LIBRARIES_TEMP to point to your SDL2 library, and configure again.
 # Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
-# as appropriate. These values are used to generate the final SDL2_LIBRARY
-# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+# as appropriate. These values are used to generate the final SDL2_LIBRARIES
+# variable, but when these values are unset, SDL2_LIBRARIES does not get created.
 #
 #
 # $SDL2DIR is an environment variable that would
@@ -42,7 +42,7 @@
 #
 # On OSX, this will prefer the Framework version (if found) over others.
 # People will have to manually change the cache values of
-# SDL2_LIBRARY to override this selection or set the CMake environment
+# SDL2_LIBRARIES to override this selection or set the CMake environment
 # CMAKE_INCLUDE_PATH to modify the search paths.
 #
 # Note that the header path has changed from SDL2/SDL.h to just SDL.h
@@ -94,23 +94,23 @@ SET(SDL2_SEARCH_PATHS
   ${SDL2_PATH}
 )
 
-FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+FIND_PATH(SDL2_INCLUDE_DIRS SDL.h
   HINTS
   $ENV{SDL2DIR}
   PATH_SUFFIXES include/SDL2 include
-  PATHS ${SDL2_SEARCH_PATHS} ${SDL2_LIBRARY_TEMP}/../..
+  PATHS ${SDL2_SEARCH_PATHS} ${SDL2_LIBRARIES_TEMP}/../..
 )
 
-FIND_LIBRARY(SDL2_LIBRARY_TEMP
+FIND_LIBRARY(SDL2_LIBRARIES_TEMP
   NAMES SDL2
   HINTS
   $ENV{SDL2DIR}
   PATH_SUFFIXES lib64 lib
-  PATHS ${SDL2_SEARCH_PATHS} ${SDL2_INCLUDE_DIR}/../..
+  PATHS ${SDL2_SEARCH_PATHS} ${SDL2_INCLUDE_DIRS}/../..
 )
 
 IF(NOT SDL2_BUILDING_LIBRARY)
-  IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+  IF(NOT ${SDL2_INCLUDE_DIRS} MATCHES ".framework")
     # Non-OS X framework versions expect you to also dynamically link to
     # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
     # seem to provide SDL2main for compatibility even though they don't
@@ -122,7 +122,7 @@ IF(NOT SDL2_BUILDING_LIBRARY)
       PATH_SUFFIXES lib64 lib
       PATHS ${SDL2_SEARCH_PATHS}
     )
-  ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+  ENDIF(NOT ${SDL2_INCLUDE_DIRS} MATCHES ".framework")
 ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
 # SDL2 may require threads on your system.
@@ -140,11 +140,11 @@ IF(MINGW)
   SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
 ENDIF(MINGW)
 
-IF(SDL2_LIBRARY_TEMP)
+IF(SDL2_LIBRARIES_TEMP)
   # For SDL2main
   IF(NOT SDL2_BUILDING_LIBRARY)
     IF(SDL2MAIN_LIBRARY)
-      SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+      SET(SDL2_LIBRARIES_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARIES_TEMP})
     ENDIF(SDL2MAIN_LIBRARY)
   ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
@@ -155,27 +155,27 @@ IF(SDL2_LIBRARY_TEMP)
   # So I use a temporary variable until the end so I can set the
   # "real" variable in one-shot.
   IF(APPLE)
-    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+    SET(SDL2_LIBRARIES_TEMP ${SDL2_LIBRARIES_TEMP} "-framework Cocoa")
   ENDIF(APPLE)
 
   # For threads, as mentioned Apple doesn't need this.
   # In fact, there seems to be a problem if I used the Threads package
   # and try using this line, so I'm just skipping it entirely for OS X.
   IF(NOT APPLE)
-    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+    SET(SDL2_LIBRARIES_TEMP ${SDL2_LIBRARIES_TEMP} ${CMAKE_THREAD_LIBS_INIT})
   ENDIF(NOT APPLE)
 
   # For MinGW library
   IF(MINGW)
-    SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+    SET(SDL2_LIBRARIES_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARIES_TEMP})
   ENDIF(MINGW)
 
   # Set the final string here so the GUI reflects the final state.
-  SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+  SET(SDL2_LIBRARIES ${SDL2_LIBRARIES_TEMP} CACHE STRING "Where the SDL2 Library can be found")
   # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
-  SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
-ENDIF(SDL2_LIBRARY_TEMP)
+  SET(SDL2_LIBRARIES_TEMP "${SDL2_LIBRARIES_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARIES_TEMP)
 
 INCLUDE(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARIES SDL2_INCLUDE_DIRS)

--- a/src/platform/sdl/CMakeLists.txt
+++ b/src/platform/sdl/CMakeLists.txt
@@ -13,6 +13,12 @@ if (SDL_VERSION EQUAL "2")
 		link_directories(${SDL2_LIBDIR})
 		set(SDL_VERSION_DEBIAN "2-2.0-0")
 		set(SDL_FOUND ON PARENT_SCOPE)
+
+		if (NOT SDL2MAIN_LIBRARY)
+			set(SDL2MAIN_LIBRARY "")
+		endif()
+
+		set(SDLMAIN_LIBRARY ${SDL2MAIN_LIBRARY})
 	endif()
 endif()
 


### PR DESCRIPTION
Sorry, I forgot to send this patches that does fix SDL2 package search (Apperently pkg find look for different names than the one that were originally in FindSDL2.cmake)
