### PR TITLE
Util: Removed broken dllexport symbol

### DIFF
--- a/include/mgba-util/common.h
+++ b/include/mgba-util/common.h
@@ -222,7 +222,6 @@ typedef intptr_t ssize_t;
 #define _CONSTRUCTOR(FN, PRE) \
     static void FN(void); \
     __declspec(allocate(".CRT$XCU")) void (*_CONSTRUCTOR_ ## FN)(void) = FN; \
-    __pragma(comment(linker,"/include:" PRE "_CONSTRUCTOR_" #FN)) \
     static void FN(void)
 #ifdef _WIN64
 #define CONSTRUCTOR(FN) _CONSTRUCTOR(FN, "")


### PR DESCRIPTION
Under Microsoft Visual C++ 2019, exporting the costructor causes build issue with mgba-qt port.
Removing the line does fix some compilation issue (and actually some linking issue with Qt).