### PR TITLE
Simplified QT5 module search

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -22,10 +22,7 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt5Multimedia)
-find_package(Qt5Network)
-find_package(Qt5OpenGL)
-find_package(Qt5Widgets)
+find_package(Qt5 COMPONENTS Core Widgets OpenGL Network Multimedia)
 
 if(NOT BUILD_GL AND NOT BUILD_GLES2)
 	message(WARNING "OpenGL is recommended to build the Qt port")


### PR DESCRIPTION
With the old method, the user have to manually specify the Qt5 folders for each component (Under CMake for Windows), like Qt5_Widgets_Dir, Qt5_Network_Dir and so on.

Using this method simplify searching for the required modules, as the user only have to fit Qt5_Dir with the directory of Qt5Config.cmake and all the other modules will be still found without specifying where they are.