### PR TITLE
All: Added exports for qt

### DIFF
--- a/include/mgba/core/log.h
+++ b/include/mgba/core/log.h
@@ -7,6 +7,7 @@
 #define M_LOG_H
 
 #include <mgba-util/common.h>
+#include <mgba-util/dllexports.h>
 
 CXX_GUARD_START
 
@@ -65,7 +66,7 @@ void mLog(int category, enum mLogLevel level, const char* format, ...);
 		_mLOG_CAT_ ## CATEGORY = mLogGenerateCategory(NAME, ID); \
 	}
 
-mLOG_DECLARE_CATEGORY(STATUS)
+MGBA_EXPORT mLOG_DECLARE_CATEGORY(STATUS)
 
 CXX_GUARD_END
 

--- a/include/mgba/gba/interface.h
+++ b/include/mgba/gba/interface.h
@@ -7,6 +7,7 @@
 #define GBA_INTERFACE_H
 
 #include <mgba-util/common.h>
+#include <mgba-util/dllexports.h>
 
 CXX_GUARD_START
 
@@ -39,7 +40,7 @@ struct GBAAudio;
 struct GBASIO;
 struct GBAVideoRenderer;
 
-extern const int GBA_LUX_LEVELS[10];
+extern MGBA_EXPORT const int GBA_LUX_LEVELS[10];
 
 enum {
 	mPERIPH_GBA_LUMINANCE = 0x1000,

--- a/include/mgba/internal/gb/io.h
+++ b/include/mgba/internal/gb/io.h
@@ -7,6 +7,7 @@
 #define GB_IO_H
 
 #include <mgba-util/common.h>
+#include <mgba-util/dllexports.h>
 
 CXX_GUARD_START
 
@@ -108,7 +109,7 @@ enum GBIORegisters {
 	REG_MAX = 0x100
 };
 
-extern const char* const GBIORegisterNames[];
+extern MGBA_EXPORT const char* const GBIORegisterNames[];
 
 struct GB;
 void GBIOInit(struct GB* gb);

--- a/include/mgba/internal/gba/io.h
+++ b/include/mgba/internal/gba/io.h
@@ -161,7 +161,7 @@ enum GBAIORegisters {
 
 mLOG_DECLARE_CATEGORY(GBA_IO);
 
-extern const char* const GBAIORegisterNames[];
+extern MGBA_EXPORT const char* const GBAIORegisterNames[];
 
 struct GBA;
 void GBAIOInit(struct GBA* gba);

--- a/include/mgba/internal/gba/video.h
+++ b/include/mgba/internal/gba/video.h
@@ -7,6 +7,7 @@
 #define GBA_VIDEO_H
 
 #include <mgba-util/common.h>
+#include <mgba-util/dllexports.h>
 
 CXX_GUARD_START
 
@@ -228,7 +229,7 @@ struct GBASerializedState;
 void GBAVideoSerialize(const struct GBAVideo* video, struct GBASerializedState* state);
 void GBAVideoDeserialize(struct GBAVideo* video, const struct GBASerializedState* state);
 
-extern const int GBAVideoObjSizes[16][2];
+extern MGBA_EXPORT const int GBAVideoObjSizes[16][2];
 
 CXX_GUARD_END
 

--- a/src/gb/io.c
+++ b/src/gb/io.c
@@ -11,7 +11,7 @@
 
 mLOG_DEFINE_CATEGORY(GB_IO, "GB I/O", "gb.io");
 
-const char* const GBIORegisterNames[] = {
+MGBA_EXPORT const char* const GBIORegisterNames[] = {
 	[REG_JOYP] = "JOYP",
 	[REG_SB] = "SB",
 	[REG_SC] = "SC",

--- a/src/gba/hardware.c
+++ b/src/gba/hardware.c
@@ -13,7 +13,7 @@
 
 mLOG_DEFINE_CATEGORY(GBA_HW, "GBA Pak Hardware", "gba.hardware");
 
-const int GBA_LUX_LEVELS[10] = { 5, 11, 18, 27, 42, 62, 84, 109, 139, 183 };
+MGBA_EXPORT const int GBA_LUX_LEVELS[10] = { 5, 11, 18, 27, 42, 62, 84, 109, 139, 183 };
 
 static void _readPins(struct GBACartridgeHardware* hw);
 static void _outputPins(struct GBACartridgeHardware* hw, unsigned pins);

--- a/src/gba/video.c
+++ b/src/gba/video.c
@@ -33,7 +33,7 @@ static void GBAVideoDummyRendererPutPixels(struct GBAVideoRenderer* renderer, si
 static void _startHblank(struct mTiming*, void* context, uint32_t cyclesLate);
 static void _startHdraw(struct mTiming*, void* context, uint32_t cyclesLate);
 
-const int GBAVideoObjSizes[16][2] = {
+MGBA_EXPORT const int GBAVideoObjSizes[16][2] = {
 	{ 8, 8 },
 	{ 16, 16 },
 	{ 32, 32 },


### PR DESCRIPTION
This commit adds the ability to export the required function for building mgba-qt with Microsoft Visual C++.

Note: When launching a GBA game with Display mode different than Software (Qt), the emulator crashes. (reg-fifo.c at line 38).
