### PR TITLE
Fix bug in deleting breakpoints

### DIFF
--- a/include/mgba/debugger/debugger.h
+++ b/include/mgba/debugger/debugger.h
@@ -101,7 +101,7 @@ struct mDebuggerPlatform {
 
 	bool (*hasBreakpoints)(struct mDebuggerPlatform*);
 	void (*checkBreakpoints)(struct mDebuggerPlatform*);
-	bool (*clearBreakpoint)(struct mDebuggerPlatform*, ssize_t id);
+	bool (*clearBreakpoint)(struct mDebuggerPlatform*, uint32_t addr);
 
 	ssize_t (*setBreakpoint)(struct mDebuggerPlatform*, const struct mBreakpoint*);
 	void (*listBreakpoints)(struct mDebuggerPlatform*, struct mBreakpointList*);

--- a/src/arm/debugger/debugger.c
+++ b/src/arm/debugger/debugger.c
@@ -71,7 +71,7 @@ static void ARMDebuggerDeinit(struct mDebuggerPlatform* platform);
 static void ARMDebuggerEnter(struct mDebuggerPlatform* d, enum mDebuggerEntryReason reason, struct mDebuggerEntryInfo* info);
 
 static ssize_t ARMDebuggerSetBreakpoint(struct mDebuggerPlatform*, const struct mBreakpoint*);
-static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform*, ssize_t id);
+static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform*, uint32_t addr);
 static void ARMDebuggerListBreakpoints(struct mDebuggerPlatform*, struct mBreakpointList*);
 static ssize_t ARMDebuggerSetWatchpoint(struct mDebuggerPlatform*, const struct mWatchpoint*);
 static void ARMDebuggerListWatchpoints(struct mDebuggerPlatform*, struct mWatchpointList*);
@@ -193,13 +193,13 @@ static ssize_t ARMDebuggerSetBreakpoint(struct mDebuggerPlatform* d, const struc
 	return id;
 }
 
-static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform* d, ssize_t id) {
+static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform* d, uint32_t addr) {
 	struct ARMDebugger* debugger = (struct ARMDebugger*) d;
 	size_t i;
 
 	struct ARMDebugBreakpointList* breakpoints = &debugger->breakpoints;
 	for (i = 0; i < ARMDebugBreakpointListSize(breakpoints); ++i) {
-		if (ARMDebugBreakpointListGetPointer(breakpoints, i)->d.id == id) {
+		if (ARMDebugBreakpointListGetPointer(breakpoints, i)->d.address == addr) {
 			_destroyBreakpoint(ARMDebugBreakpointListGetPointer(breakpoints, i));
 			ARMDebugBreakpointListShift(breakpoints, i, 1);
 			return true;
@@ -209,7 +209,7 @@ static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform* d, ssize_t id) 
 	struct ARMDebugBreakpointList* swBreakpoints = &debugger->swBreakpoints;
 	if (debugger->clearSoftwareBreakpoint) {
 		for (i = 0; i < ARMDebugBreakpointListSize(swBreakpoints); ++i) {
-			if (ARMDebugBreakpointListGetPointer(swBreakpoints, i)->d.id == id) {
+			if (ARMDebugBreakpointListGetPointer(swBreakpoints, i)->d.address == addr) {
 				debugger->clearSoftwareBreakpoint(debugger, ARMDebugBreakpointListGetPointer(swBreakpoints, i));
 				ARMDebugBreakpointListShift(swBreakpoints, i, 1);
 				return true;
@@ -219,7 +219,7 @@ static bool ARMDebuggerClearBreakpoint(struct mDebuggerPlatform* d, ssize_t id) 
 
 	struct mWatchpointList* watchpoints = &debugger->watchpoints;
 	for (i = 0; i < mWatchpointListSize(watchpoints); ++i) {
-		if (mWatchpointListGetPointer(watchpoints, i)->id == id) {
+		if (mWatchpointListGetPointer(watchpoints, i)->address == addr) {
 			_destroyWatchpoint(mWatchpointListGetPointer(watchpoints, i));
 			mWatchpointListShift(watchpoints, i, 1);
 			if (!mWatchpointListSize(&debugger->watchpoints)) {

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -611,8 +611,8 @@ static void _clearBreakpoint(struct CLIDebugger* debugger, struct CLIDebugVector
 		debugger->backend->printf(debugger->backend, "%s\n", ERROR_MISSING_ARGS);
 		return;
 	}
-	uint64_t id = dv->intValue;
-	debugger->d.platform->clearBreakpoint(debugger->d.platform, id);
+	uint32_t addr = dv->intValue;
+	debugger->d.platform->clearBreakpoint(debugger->d.platform, addr);
 }
 
 static void _listBreakpoints(struct CLIDebugger* debugger, struct CLIDebugVector* dv) {

--- a/src/lr35902/debugger/debugger.c
+++ b/src/lr35902/debugger/debugger.c
@@ -65,7 +65,7 @@ static void LR35902DebuggerEnter(struct mDebuggerPlatform* d, enum mDebuggerEntr
 
 static ssize_t LR35902DebuggerSetBreakpoint(struct mDebuggerPlatform*, const struct mBreakpoint*);
 static void LR35902DebuggerListBreakpoints(struct mDebuggerPlatform*, struct mBreakpointList*);
-static bool LR35902DebuggerClearBreakpoint(struct mDebuggerPlatform*, ssize_t id);
+static bool LR35902DebuggerClearBreakpoint(struct mDebuggerPlatform*, uint32_t addr);
 static ssize_t LR35902DebuggerSetWatchpoint(struct mDebuggerPlatform*, const struct mWatchpoint*);
 static void LR35902DebuggerListWatchpoints(struct mDebuggerPlatform*, struct mWatchpointList*);
 static void LR35902DebuggerCheckBreakpoints(struct mDebuggerPlatform*);
@@ -138,14 +138,14 @@ static ssize_t LR35902DebuggerSetBreakpoint(struct mDebuggerPlatform* d, const s
 
 }
 
-static bool LR35902DebuggerClearBreakpoint(struct mDebuggerPlatform* d, ssize_t id) {
+static bool LR35902DebuggerClearBreakpoint(struct mDebuggerPlatform* d, uint32_t addr) {
 	struct LR35902Debugger* debugger = (struct LR35902Debugger*) d;
 	size_t i;
 
 	struct mBreakpointList* breakpoints = &debugger->breakpoints;
 	for (i = 0; i < mBreakpointListSize(breakpoints); ++i) {
 		struct mBreakpoint* breakpoint = mBreakpointListGetPointer(breakpoints, i);
-		if (breakpoint->id == id) {
+		if (breakpoint->address == addr) {
 			_destroyBreakpoint(breakpoint);
 			mBreakpointListShift(breakpoints, i, 1);
 			return true;
@@ -155,7 +155,7 @@ static bool LR35902DebuggerClearBreakpoint(struct mDebuggerPlatform* d, ssize_t 
 	struct mWatchpointList* watchpoints = &debugger->watchpoints;
 	for (i = 0; i < mWatchpointListSize(watchpoints); ++i) {
 		struct mWatchpoint* watchpoint = mWatchpointListGetPointer(watchpoints, i);
-		if (watchpoint->id == id) {
+		if (watchpoint->address == addr) {
 			_destroyWatchpoint(watchpoint);
 			mWatchpointListShift(watchpoints, i, 1);
 			if (!mWatchpointListSize(&debugger->watchpoints)) {


### PR DESCRIPTION
Fix a very silly bug which prevented breakpoints from being deleted. I'm surprised that it went unnoticed.