### PR TITLE
Win32: Fix x64 installation paths

### DIFF
--- a/src/platform/windows/setup/setup.iss.in
+++ b/src/platform/windows/setup/setup.iss.in
@@ -48,15 +48,11 @@ LicenseFile={#BinDir}\LICENSE.txt
   #define IsRelease = 'no'
   AppVerName={#AppName} {#VersionString} (Development build)
 #endif
-#if '{#WinBits}' == '64'
-  ArchitecturesInstallIn64BitMode=x64
-  ArchitecturesAllows=x64
-#endif
 OutputBaseFilename={#AppName}-setup-{#CleanVersionString}-win{#WinBits}
 UsePreviousLanguage=False
 DisableWelcomePage=False
 VersionInfoDescription={#AppName} is an open-source Game Boy Advance emulator
-VersionInfoCopyright=© 2013–2018 Jeffrey Pfau
+VersionInfoCopyright=© 2013–2019 Jeffrey Pfau
 VersionInfoProductName={#AppName}
 VersionInfoVersion={#AppVer}
 Compression=lzma2/ultra64
@@ -64,6 +60,8 @@ SolidCompression=True
 VersionInfoTextVersion={#AppVer}
 VersionInfoProductVersion={#AppVer}
 VersionInfoProductTextVersion={#AppVer}
+ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x86 x64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
The current way to check if we are running a 64 bit version of Windows
in order to detect the proper path ("Program Files" or "Program Files
(x86)") doesn't work, thus even the 64 bit version is installed in the
32 bit Program Files folder.

The check itself is not necessary, since Inno Setup is smart enough to
check the platform it's running on and chooses the proper path and
registry settings by itself.