### PR TITLE
Qt: Fix compiling with M_CORE_GB disabled

### DIFF
--- a/src/platform/qt/CoreController.cpp
+++ b/src/platform/qt/CoreController.cpp
@@ -632,12 +632,16 @@ void CoreController::yankPak() {
 	Interrupter interrupter(this);
 
 	switch (platform()) {
+#ifdef M_CORE_GBA
 	case PLATFORM_GBA:
 		GBAYankROM(static_cast<GBA*>(m_threadContext.core->board));
 		break;
+#endif
+#ifdef M_CORE_GB
 	case PLATFORM_GB:
 		GBYankROM(static_cast<GB*>(m_threadContext.core->board));
 		break;
+#endif
 	}
 }
 

--- a/src/platform/qt/MapView.cpp
+++ b/src/platform/qt/MapView.cpp
@@ -167,6 +167,7 @@ void MapView::updateTilesGBA(bool force) {
 		int frame = 0;
 		QString offset(tr("N/A"));
 		QString transform(tr("N/A"));
+#ifdef M_CORE_GBA
 		if (m_controller->platform() == PLATFORM_GBA) {
 			uint16_t* io = static_cast<GBA*>(m_controller->thread()->core->board)->memory.io;
 			int mode = GBARegisterDISPCNTGetMode(io[REG_DISPCNT >> 1]);
@@ -199,12 +200,15 @@ void MapView::updateTilesGBA(bool force) {
 
 			}
 		}
+#endif
+#ifdef M_CORE_GB
 		if (m_controller->platform() == PLATFORM_GB) {
 			uint8_t* io = static_cast<GB*>(m_controller->thread()->core->board)->memory.io;
 			int x = io[m_map == 0 ? 0x42 : 0x4A];
 			int y = io[m_map == 0 ? 0x43 : 0x4B];
 			offset = QString("%1, %2").arg(x).arg(y);
 		}
+#endif
 		if (bitmap >= 0) {
 			mBitmapCache* bitmapCache = mBitmapCacheSetGetPointer(&m_cacheSet->bitmaps, bitmap);
 			int width = mBitmapCacheSystemInfoGetWidth(bitmapCache->sysConfig);

--- a/src/platform/qt/OverrideView.cpp
+++ b/src/platform/qt/OverrideView.cpp
@@ -69,6 +69,7 @@ OverrideView::OverrideView(ConfigController* config, QWidget* parent)
 		m_ui.hwRumble->setEnabled(!enabled);
 	});
 
+#ifdef M_CORE_GB
 	m_colorPickers[0] = ColorPicker(m_ui.color0, QColor(0xF8, 0xF8, 0xF8));
 	m_colorPickers[1] = ColorPicker(m_ui.color1, QColor(0xA8, 0xA8, 0xA8));
 	m_colorPickers[2] = ColorPicker(m_ui.color2, QColor(0x50, 0x50, 0x50));
@@ -86,6 +87,7 @@ OverrideView::OverrideView(ConfigController* config, QWidget* parent)
 			m_gbColors[colorId] = color.rgb() | 0xFF000000;
 		});
 	}
+#endif
 
 #ifndef M_CORE_GBA
 	m_ui.tabWidget->removeTab(m_ui.tabWidget->indexOf(m_ui.tabGBA));


### PR DESCRIPTION
GB specific code was added without guards, causing configurations with
it disabled to fail compiling:

    cmake -B build -DM_CORE_GB:BOOL=OFF

Resolves: #1578
Fixes: a44a8f668f6a5 ("GB: Add yanking")
Fixes: fbe375fab992c ("Core: Add support for caching bitmapped modes")
Fixes: 06657d9fde5a2 ("Qt: Add additional info to map view")
Fixes: f15aacd0b6aaf ("Qt: Set default Game Boy colors")