### PR TITLE
GBVisualizer support

### DIFF
--- a/src/gb/io.c
+++ b/src/gb/io.c
@@ -672,6 +672,13 @@ uint8_t GBIORead(struct GB* gb, unsigned address) {
 			case REG_SVBK:
 				// Handled transparently by the registers
 				goto success;
+
+			case REG_PCM12:				
+				return (gb->audio.playingCh2 ? (gb->audio.ch2.sample << 4) : 0) | (gb->audio.playingCh1 ? (gb->audio.ch1.sample) : 0);
+
+			case REG_PCM34:				
+				return (gb->audio.playingCh4 ? (gb->audio.ch4.sample << 4) : 0) | (gb->audio.playingCh3 ? (gb->audio.ch3.sample) : 0);
+
 			default:
 				break;
 			}

--- a/src/gb/io.c
+++ b/src/gb/io.c
@@ -673,10 +673,20 @@ uint8_t GBIORead(struct GB* gb, unsigned address) {
 				// Handled transparently by the registers
 				goto success;
 
-			case REG_PCM12:				
+				/*
+				 * Undocumented PCM12, PCM34 register functionality.
+				 *
+				 * Some information provided at...
+				 * Author: https://github.com/LIJI32
+				 * Github repo: https://github.com/LIJI32/GBVisualizer
+				 *
+				 */
+
+				// Return the current PCM amplitude of the 4 different APU channels.
+			case REG_PCM12:
 				return (gb->audio.playingCh2 ? (gb->audio.ch2.sample << 4) : 0) | (gb->audio.playingCh1 ? (gb->audio.ch1.sample) : 0);
 
-			case REG_PCM34:				
+			case REG_PCM34:
 				return (gb->audio.playingCh4 ? (gb->audio.ch4.sample << 4) : 0) | (gb->audio.playingCh3 ? (gb->audio.ch3.sample) : 0);
 
 			default:


### PR DESCRIPTION
Added support for use of the undocumented registers PCM12, and PCM34. Tested with running the given ROM from GBVisualizer, and got desired output.

Closes  #1468.