### PR TITLE
Always use HLE-BIOS when loading multiboot games.

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -593,7 +593,7 @@ static void _GBACoreReset(struct mCore* core) {
 	GBAOverrideApplyDefaults(gba, gbacore->overrides);
 
 #if !defined(MINIMAL_CORE) || MINIMAL_CORE < 2
-	if (!gba->biosVf && core->opts.useBios) {
+	if (!gba->biosVf && core->opts.useBios && !GBAIsMB(gba->romVf)) {
 		struct VFile* bios = NULL;
 		bool found = false;
 		if (core->opts.bios) {
@@ -636,7 +636,7 @@ static void _GBACoreReset(struct mCore* core) {
 #endif
 
 	ARMReset(core->cpu);
-	if (core->opts.skipBios && (gba->romVf || gba->memory.rom)) {
+	if (core->opts.skipBios && (gba->romVf || gba->memory.rom) && !GBAIsMB(gba->romVf)) {
 		GBASkipBIOS(core->board);
 	}
 }


### PR DESCRIPTION
mGBA can't run multiboot games when skipping the BIOS (somehow muddles up the working HLE code path) or while using an accurately cloned / official BIOS (broken, game doesn't get loaded into EWRAM or ROM; even then would still need to be properly set up).