### PR TITLE
Use consistent conditionals for big endian detection in PSR union

### DIFF
--- a/include/mgba/internal/arm/arm.h
+++ b/include/mgba/internal/arm/arm.h
@@ -70,7 +70,7 @@ struct ARMCore;
 
 union PSR {
 	struct {
-#if defined(__POWERPC__) || defined(__PPC__)
+#if defined(__BIG_ENDIAN__)
 		unsigned n : 1;
 		unsigned z : 1;
 		unsigned c : 1;


### PR DESCRIPTION
This was breaking mGBA rather badly on my PPC little-endian host, starting from bf8c1d1b4b52d45cd84590dc7bd7d40b0dffc7bd with the introduction of the `#if defined(__BIG_ENDIAN__)` below the one I changed here.

Optimistically, this fix might also help more than just folks with modern POWER systems -- after all, not all PowerPC hosts are big-endian, and PowerPC isn't the only big-endian architecture.

Cheers
-lif