### PR TITLE
GBA: Fix msvc compilation

### DIFF
--- a/src/gba/ereader.c
+++ b/src/gba/ereader.c
@@ -288,7 +288,7 @@ static void _eReaderAddress(uint8_t* origin, int a) {
 }
 
 static void _eReaderReedSolomon(const uint8_t* input, uint8_t* output) {
-	uint8_t rsBuffer[64] = {};
+	uint8_t rsBuffer[64] = { 0 };
 	int i;
 	for (i = 0; i < 48; ++i) {
 		rsBuffer[63 - i] = input[i];


### PR DESCRIPTION
With this change, it builded (at least for me) fine under Visual Studio 2019 (vcpkg + manual libepoxy)