### PR TITLE
Setting to show filename in title bar instead of ROM name.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,6 @@
 Features:
  - e-Reader card scanning
  - Add APNG recording
- - Setting to display the file name of the currently loaded ROM instead of the game name in the title bar (closes mgba.io/i/1784)
 Emulation fixes:
  - ARM: Fix ALU reading PC after shifting
  - ARM: Fix STR storing PC after address calculation
@@ -37,6 +36,7 @@ Misc:
  - Qt: Add hex index to palette view
  - Qt: Add transformation matrix info to sprite view
  - Qt: Add per-page scrolling to memory view (fixes mgba.io/i/1795)
+ - Qt: Setting to display the file name of the currently loaded ROM instead of the game name in the title bar (closes mgba.io/i/1784)
 
 0.8.2: (2020-06-14)
 Emulation fixes:

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 Features:
  - e-Reader card scanning
  - Add APNG recording
+ - Setting to display the file name of the currently loaded ROM instead of the game name in the title bar (closes mgba.io/i/1784)
 Emulation fixes:
  - ARM: Fix ALU reading PC after shifting
  - ARM: Fix STR storing PC after address calculation

--- a/CHANGES
+++ b/CHANGES
@@ -36,7 +36,7 @@ Misc:
  - Qt: Add hex index to palette view
  - Qt: Add transformation matrix info to sprite view
  - Qt: Add per-page scrolling to memory view (fixes mgba.io/i/1795)
- - Qt: Setting to display the file name of the currently loaded ROM instead of the game name in the title bar (closes mgba.io/i/1784)
+ - Qt: Add setting to display ROM filename in title (closes mgba.io/i/1784)
 
 0.8.2: (2020-06-14)
 Emulation fixes:

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -328,7 +328,8 @@ void mCoreLoadForeignConfig(struct mCore* core, const struct mCoreConfig* config
 
 	mCoreConfigCopyValue(&core->config, config, "cheatAutosave");
 	mCoreConfigCopyValue(&core->config, config, "cheatAutoload");
-
+	mCoreConfigCopyValue(&core->config, config, "showFilename");
+	
 	core->loadConfig(core, config);
 }
 

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -328,8 +328,7 @@ void mCoreLoadForeignConfig(struct mCore* core, const struct mCoreConfig* config
 
 	mCoreConfigCopyValue(&core->config, config, "cheatAutosave");
 	mCoreConfigCopyValue(&core->config, config, "cheatAutoload");
-	mCoreConfigCopyValue(&core->config, config, "showFilename");
-	
+
 	core->loadConfig(core, config);
 }
 

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -400,6 +400,7 @@ void SettingsView::updateConfig() {
 	saveSetting("showFps", m_ui.showFps);
 	saveSetting("cheatAutoload", m_ui.cheatAutoload);
 	saveSetting("cheatAutosave", m_ui.cheatAutosave);
+	saveSetting("showFilename", m_ui.showFilename);
 	saveSetting("autoload", m_ui.autoload);
 	saveSetting("autosave", m_ui.autosave);
 	saveSetting("logToFile", m_ui.logToFile);
@@ -574,6 +575,7 @@ void SettingsView::reloadConfig() {
 	loadSetting("showFps", m_ui.showFps, true);
 	loadSetting("cheatAutoload", m_ui.cheatAutoload, true);
 	loadSetting("cheatAutosave", m_ui.cheatAutosave, true);
+	loadSetting("showFilename", m_ui.showFilename, false);
 	loadSetting("autoload", m_ui.autoload, true);
 	loadSetting("autosave", m_ui.autosave, false);
 	loadSetting("logToFile", m_ui.logToFile);

--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -657,6 +657,23 @@
          </property>
         </widget>
        </item>
+       <item row="20" column="0" colspan="2">
+        <widget class="Line" name="line_16">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1">
+        <widget class="QCheckBox" name="showFilename">
+         <property name="text">
+          <string>Show filename instead of ROM name in title bar</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="emulation">

--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -586,21 +586,21 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QCheckBox" name="useDiscordPresence">
          <property name="text">
           <string>Enable Discord Rich Presence</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="0" colspan="2">
+       <item row="15" column="0" colspan="2">
         <widget class="Line" name="line_13">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QCheckBox" name="autosave">
          <property name="text">
           <string>Automatically save state</string>
@@ -610,7 +610,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QCheckBox" name="autoload">
          <property name="text">
           <string>Automatically load state</string>
@@ -620,14 +620,14 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0" colspan="2">
+       <item row="18" column="0" colspan="2">
         <widget class="Line" name="line_16">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="19" column="1">
         <widget class="QCheckBox" name="cheatAutosave">
          <property name="text">
           <string>Automatically save cheats</string>
@@ -637,7 +637,7 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="1">
+       <item row="20" column="1">
         <widget class="QCheckBox" name="cheatAutoload">
          <property name="text">
           <string>Automatically load cheats</string>
@@ -647,7 +647,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="showOSD">
          <property name="text">
           <string>Show OSD messages</string>
@@ -657,14 +657,7 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="0" colspan="2">
-        <widget class="Line" name="line_16">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="showFilename">
          <property name="text">
           <string>Show filename instead of ROM name in title bar</string>

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1031,27 +1031,23 @@ void Window::updateTitle(float fps) {
 		NoIntroGame game{};
 		uint32_t crc32 = 0;
 		m_controller->thread()->core->checksum(m_controller->thread()->core, &crc32, CHECKSUM_CRC32);
-
-		char* gameTitle;
+		
 		mCore* core = m_controller->thread()->core;
-		int showFilename = 0;
-
-		if (mCoreConfigGetIntValue(&core->config, "showFilename", &showFilename) && showFilename) {
-			gameTitle = new char[PATH_MAX];
-			strcpy(gameTitle, core->dirs.baseName);
+		
+		if (m_config->getOption("showFilename").toInt()) {
+			title = core->dirs.baseName;
 		} else {
-			gameTitle = new char[17] { '\0' };
+			char gameTitle[17] = { '\0' };
 			core->getGameTitle(core, gameTitle);
-		}
-
-		title = gameTitle;
-		delete[] gameTitle;
+			title = gameTitle;
 
 #ifdef USE_SQLITE3
-		if (db && crc32 && NoIntroDBLookupGameByCRC(db, crc32, &game) && !showFilename) {
-			title = QLatin1String(game.name);
-		}
+			if (db && crc32 && NoIntroDBLookupGameByCRC(db, crc32, &game)) {
+				title = QLatin1String(game.name);
+			}
 #endif
+		}
+		
 		MultiplayerController* multiplayer = m_controller->multiplayerController();
 		if (multiplayer && multiplayer->attached() > 1) {
 			title += tr(" -  Player %1 of %2").arg(multiplayer->playerId(m_controller.get()) + 1).arg(multiplayer->attached());

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1032,13 +1032,23 @@ void Window::updateTitle(float fps) {
 		uint32_t crc32 = 0;
 		m_controller->thread()->core->checksum(m_controller->thread()->core, &crc32, CHECKSUM_CRC32);
 
-		char gameTitle[17] = { '\0' };
+		char* gameTitle;
 		mCore* core = m_controller->thread()->core;
-		core->getGameTitle(core, gameTitle);
+		int showFilename = 0;
+
+		if (mCoreConfigGetIntValue(&core->config, "showFilename", &showFilename) && showFilename) {
+			gameTitle = new char[PATH_MAX];
+			strcpy(gameTitle, core->dirs.baseName);
+		} else {
+			gameTitle = new char[17] { '\0' };
+			core->getGameTitle(core, gameTitle);
+		}
+
 		title = gameTitle;
+		delete[] gameTitle;
 
 #ifdef USE_SQLITE3
-		if (db && crc32 && NoIntroDBLookupGameByCRC(db, crc32, &game)) {
+		if (db && crc32 && NoIntroDBLookupGameByCRC(db, crc32, &game) && !showFilename) {
 			title = QLatin1String(game.name);
 		}
 #endif

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1030,12 +1030,13 @@ void Window::updateTitle(float fps) {
 		const NoIntroDB* db = GBAApp::app()->gameDB();
 		NoIntroGame game{};
 		uint32_t crc32 = 0;
-		m_controller->thread()->core->checksum(m_controller->thread()->core, &crc32, CHECKSUM_CRC32);
-		
 		mCore* core = m_controller->thread()->core;
-		
-		if (m_config->getOption("showFilename").toInt()) {
-			title = core->dirs.baseName;
+		core->checksum(m_controller->thread()->core, &crc32, CHECKSUM_CRC32);
+		QString filePath = windowFilePath();
+
+		if (m_config->getOption("showFilename").toInt() && !filePath.isNull()) {
+			QFileInfo fileInfo(filePath);
+			title = fileInfo.fileName();
 		} else {
 			char gameTitle[17] = { '\0' };
 			core->getGameTitle(core, gameTitle);


### PR DESCRIPTION
This implements the feature requested in #1784 

One caveat: the best source of data I could find for the currently loaded ROM's file name was the `baseName` field of the `mDirectorySet` struct (the instance held by `mCore`). However, this doesn't seem to carry the file extension.

So, if you loaded the file `pokemon-fire-red.gba`, you would only see `pokemon-fire-red`.