### PR TITLE
Fix italian real time clock translation

### DIFF
--- a/src/platform/qt/ts/mgba-it.ts
+++ b/src/platform/qt/ts/mgba-it.ts
@@ -4495,7 +4495,7 @@ Game Boy Advance è un marchio registrato di Nintendo Co., Ltd.</translation>
     <message>
         <location filename="../SensorView.ui" line="97"/>
         <source>MM/dd/yy hh:mm:ss AP</source>
-        <translation>gg/MM/aa OO:mm:ss</translation>
+        <translation>dd/MM/yy hh:mm:ss</translation>
     </message>
     <message>
         <location filename="../SensorView.ui" line="107"/>

--- a/src/platform/qt/ts/mgba-it.ts
+++ b/src/platform/qt/ts/mgba-it.ts
@@ -4495,7 +4495,7 @@ Game Boy Advance è un marchio registrato di Nintendo Co., Ltd.</translation>
     <message>
         <location filename="../SensorView.ui" line="97"/>
         <source>MM/dd/yy hh:mm:ss AP</source>
-        <translation>dd/MM/yy hh:mm:ss</translation>
+        <translation>dd/MM/yy HH:mm:ss</translation>
     </message>
     <message>
         <location filename="../SensorView.ui" line="107"/>


### PR DESCRIPTION
Title.

Looking at the other languages this should fix it.

Closes #1798 

In the spanish localization the hours were HH and not hh, is there a particular reason?