### PR TITLE
Stack traces: add detection for other calling conventions and stack manipulation

### DIFF
--- a/include/mgba/internal/arm/decoder-inlines.h
+++ b/include/mgba/internal/arm/decoder-inlines.h
@@ -22,4 +22,16 @@
 	info->nInstructionCycles = 1; \
 	info->nDataCycles = 1;
 
+static inline bool ARMInstructionIsBranch(enum ARMMnemonic mnemonic) {
+	switch (mnemonic) {
+		case ARM_MN_B:
+		case ARM_MN_BL:
+		case ARM_MN_BX:
+			// TODO: case: ARM_MN_BLX:
+			return true;
+		default:
+			return false;
+	}
+}
+
 #endif

--- a/include/mgba/internal/arm/isa-inlines.h
+++ b/include/mgba/internal/arm/isa-inlines.h
@@ -107,4 +107,39 @@ static inline uint32_t _ARMPCAddress(struct ARMCore* cpu) {
 	return cpu->gprs[ARM_PC] - _ARMInstructionLength(cpu) * 2;
 }
 
+static inline bool ARMTestCondition(struct ARMCore* cpu, unsigned condition) {
+	switch (condition) {
+		case 0x0:
+			return ARM_COND_EQ;
+		case 0x1:
+			return ARM_COND_NE;
+		case 0x2:
+			return ARM_COND_CS;
+		case 0x3:
+			return ARM_COND_CC;
+		case 0x4:
+			return ARM_COND_MI;
+		case 0x5:
+			return ARM_COND_PL;
+		case 0x6:
+			return ARM_COND_VS;
+		case 0x7:
+			return ARM_COND_VC;
+		case 0x8:
+			return ARM_COND_HI;
+		case 0x9:
+			return ARM_COND_LS;
+		case 0xA:
+			return ARM_COND_GE;
+		case 0xB:
+			return ARM_COND_LT;
+		case 0xC:
+			return ARM_COND_GT;
+		case 0xD:
+			return ARM_COND_LE;
+		default:
+			return true;
+	}
+}
+
 #endif

--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -82,6 +82,7 @@ static void _gdbStubEntered(struct mDebugger* debugger, enum mDebuggerEntryReaso
 		snprintf(stub->outgoing, GDB_STUB_MAX_LINE - 4, "S%02x", SIGILL);
 		break;
 	case DEBUGGER_ENTER_ATTACHED:
+	case DEBUGGER_ENTER_STACK:
 		return;
 	}
 	_sendMessage(stub);

--- a/src/debugger/stack-trace.c
+++ b/src/debugger/stack-trace.c
@@ -65,7 +65,7 @@ void mStackTraceFormatFrame(struct mStackTrace* stack, uint32_t frame, char* out
 	size_t written = snprintf(out, *length, "#%d  ", frame);
 	CHECK_LENGTH();
 	if (prevFrame) {
-		written += snprintf(out + written, *length - written, "%08X ", prevFrame->entryAddress);
+		written += snprintf(out + written, *length - written, "0x%08X ", prevFrame->entryAddress);
 		CHECK_LENGTH();
 	}
 	if (!stackFrame) {
@@ -83,9 +83,13 @@ void mStackTraceFormatFrame(struct mStackTrace* stack, uint32_t frame, char* out
 	}
 	if (prevFrame) {
 		int32_t offset = stackFrame->callAddress - prevFrame->entryAddress;
-		written += snprintf(out + written, *length - written, "at %08X [%08X+%d]\n", stackFrame->callAddress, prevFrame->entryAddress, offset);
+		if (offset >= 0) {
+			written += snprintf(out + written, *length - written, "at 0x%08X [0x%08X+%d]\n", stackFrame->callAddress, prevFrame->entryAddress, offset);
+		} else {
+			written += snprintf(out + written, *length - written, "at 0x%08X\n", stackFrame->callAddress);
+		}
 	} else {
-		written += snprintf(out + written, *length - written, "at %08X\n", stackFrame->callAddress);
+		written += snprintf(out + written, *length - written, "at 0x%08X\n", stackFrame->callAddress);
 	}
 	*length = written;
 }


### PR DESCRIPTION
The stack trace implementation from the last PR didn't account for calling conventions common on the GBA and had some noteworthy oversights. This PR adds support for:
* calling a function by writing to `lr` followed by `b` or `bx` (since ARMv4 doesn't have `blx`)
* returning from a function using `mov pc, lr` (oops!)
* heuristically determining if `mov pc, rN` is meant to be a function return based on `sp` and `pc`
* skipped/unwound stack frames
* branches not taken (oops!)
* two-instruction `bl` in Thumb mode

It also cleans up backtrace rendering and some cosmetic miscalculations.