### PR TITLE
medusa: stack trace fixes

### DIFF
--- a/include/mgba/internal/arm/decoder-inlines.h
+++ b/include/mgba/internal/arm/decoder-inlines.h
@@ -27,7 +27,7 @@ static inline bool ARMInstructionIsBranch(enum ARMMnemonic mnemonic) {
 		case ARM_MN_B:
 		case ARM_MN_BL:
 		case ARM_MN_BX:
-			// TODO: case: ARM_MN_BLX:
+		case ARM_MN_BLX:
 			return true;
 		default:
 			return false;

--- a/src/arm/debugger/debugger.c
+++ b/src/arm/debugger/debugger.c
@@ -61,7 +61,7 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 
 	bool interrupt = false;
 	bool isWideInstruction = ARMDecodeCombined(cpu, &info);
-	if (!isWideInstruction && info.mnemonic == ARM_MN_BL) {
+	if (!isWideInstruction && (info.mnemonic == ARM_MN_BL || info.mnemonic == ARM_MN_BLX)) {
 		return false;
 	}
 	if (!ARMTestCondition(cpu, info.condition)) {


### PR DESCRIPTION
This is the same as #1832 but for the medusa branch. The primary difference is in how the condition abstraction is handled in order to support ARMv5.