### PR TITLE
Debugger: define symbols in CLI, show symbols in stack traces

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Features:
  - Add WebP and APNG recording
  - Support for unlicensed Pokemon Jade/Diamond Game Boy mapper
  - Stack tracing tools in ARM debugger (by ahigerd)
+ - Command scripts for CLI debugger (by ahigerd)
 Emulation fixes:
  - ARM: Fix ALU reading PC after shifting
  - ARM: Fix STR storing PC after address calculation

--- a/include/mgba-util/table.h
+++ b/include/mgba-util/table.h
@@ -35,12 +35,19 @@ void HashTableInit(struct Table* table, size_t initialSize, void (deinitializer(
 void HashTableDeinit(struct Table* table);
 
 void* HashTableLookup(const struct Table*, const char* key);
+void* HashTableLookupBinary(const struct Table*, const void* key, size_t keylen);
 void HashTableInsert(struct Table*, const char* key, void* value);
+void HashTableInsertBinary(struct Table*, const void* key, size_t keylen, void* value);
 
 void HashTableRemove(struct Table*, const char* key);
+void HashTableRemoveBinary(struct Table*, const void* key, size_t keylen);
 void HashTableClear(struct Table*);
 
 void HashTableEnumerate(const struct Table*, void (handler(const char* key, void* value, void* user)), void* user);
+const char* HashTableSearch(const struct Table* table, bool (predicate(const char* key, const void* value, const void* user)), const void* user);
+const char* HashTableSearchPointer(const struct Table* table, const void* value);
+const char* HashTableSearchData(const struct Table* table, const void* value, size_t bytes);
+const char* HashTableSearchString(const struct Table* table, const char* value);
 size_t HashTableSize(const struct Table*);
 
 CXX_GUARD_END

--- a/include/mgba/internal/debugger/cli-debugger.h
+++ b/include/mgba/internal/debugger/cli-debugger.h
@@ -95,6 +95,11 @@ void CLIDebuggerAttachBackend(struct CLIDebugger*, struct CLIDebuggerBackend*);
 
 bool CLIDebuggerTabComplete(struct CLIDebugger*, const char* token, bool initial, size_t len);
 
+bool CLIDebuggerRunCommand(struct CLIDebugger* debugger, const char* line, size_t count);
+#if ENABLE_SCRIPTING
+void CLIDebuggerScriptEngineInstall(struct mScriptBridge* sb);
+#endif
+
 CXX_GUARD_END
 
 #endif

--- a/include/mgba/internal/debugger/stack-trace.h
+++ b/include/mgba/internal/debugger/stack-trace.h
@@ -14,6 +14,8 @@ CXX_GUARD_START
 #include <mgba/core/log.h>
 #include <mgba-util/vector.h>
 
+struct mDebuggerSymbols;
+
 enum mStackTraceMode {
 	STACK_TRACE_DISABLED = 0,
 	STACK_TRACE_ENABLED = 1,
@@ -23,8 +25,11 @@ enum mStackTraceMode {
 };
 
 struct mStackFrame {
+	int callSegment;
 	uint32_t callAddress;
+	int entrySegment;
 	uint32_t entryAddress;
+	int frameBaseSegment;
 	uint32_t frameBaseAddress;
 	void* regs;
 	bool finished;
@@ -47,8 +52,9 @@ void mStackTraceDeinit(struct mStackTrace* stack);
 void mStackTraceClear(struct mStackTrace* stack);
 size_t mStackTraceGetDepth(struct mStackTrace* stack);
 struct mStackFrame* mStackTracePush(struct mStackTrace* stack, uint32_t pc, uint32_t destAddress, uint32_t sp, void* regs);
+struct mStackFrame* mStackTracePushSegmented(struct mStackTrace* stack, int pcSegment, uint32_t pc, int destSegment, uint32_t destAddress, int spSegment, uint32_t sp, void* regs);
 struct mStackFrame* mStackTraceGetFrame(struct mStackTrace* stack, uint32_t frame);
-void mStackTraceFormatFrame(struct mStackTrace* stack, uint32_t frame, char* out, size_t* length);
+void mStackTraceFormatFrame(struct mStackTrace* stack, struct mDebuggerSymbols* st, uint32_t frame, char* out, size_t* length);
 void mStackTracePop(struct mStackTrace* stack);
 
 CXX_GUARD_END

--- a/include/mgba/internal/debugger/symbols.h
+++ b/include/mgba/internal/debugger/symbols.h
@@ -16,6 +16,7 @@ struct mDebuggerSymbols* mDebuggerSymbolTableCreate(void);
 void mDebuggerSymbolTableDestroy(struct mDebuggerSymbols*);
 
 bool mDebuggerSymbolLookup(const struct mDebuggerSymbols*, const char* name, int32_t* value, int* segment);
+const char* mDebuggerSymbolReverseLookup(const struct mDebuggerSymbols*, int32_t value, int segment);
 
 void mDebuggerSymbolAdd(struct mDebuggerSymbols*, const char* name, int32_t value, int segment);
 void mDebuggerSymbolRemove(struct mDebuggerSymbols*, const char* name);

--- a/src/debugger/CMakeLists.txt
+++ b/src/debugger/CMakeLists.txt
@@ -6,6 +6,10 @@ set(SOURCE_FILES
 	symbols.c
 	stack-trace.c)
 
+if(ENABLE_SCRIPTING)
+	list(APPEND SOURCE_FILES cli-debugger-scripting.c)
+endif()
+
 set(TEST_FILES
 	test/lexer.c
 	test/parser.c)

--- a/src/debugger/cli-debugger-scripting.c
+++ b/src/debugger/cli-debugger-scripting.c
@@ -1,0 +1,137 @@
+/* Copyright (c) 2013-2020 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include <mgba/core/scripting.h>
+#include <mgba-util/string.h>
+#include <mgba-util/vfs.h>
+
+#include <mgba/debugger/debugger.h>
+#include <mgba/internal/debugger/cli-debugger.h>
+
+static const char* CLIScriptEngineName(struct mScriptEngine*);
+static bool CLIScriptEngineInit(struct mScriptEngine*, struct mScriptBridge*);
+static void CLIScriptEngineDeinit(struct mScriptEngine*);
+static bool CLIScriptEngineIsScript(struct mScriptEngine*, const char* name, struct VFile* vf);
+static bool CLIScriptEngineLoadScript(struct mScriptEngine*, const char* name, struct VFile* vf);
+static void CLIScriptEngineRun(struct mScriptEngine*);
+static bool CLIScriptEngineLookupSymbol(struct mScriptEngine*, const char* name, int32_t* out);
+static void CLIScriptDebuggerEntered(struct mScriptEngine*, enum mDebuggerEntryReason, struct mDebuggerEntryInfo*);
+
+struct CLIScriptStatement {
+	char* command;
+	size_t commandLen;
+};
+
+DECLARE_VECTOR(CLIScript, struct CLIScriptStatement);
+DEFINE_VECTOR(CLIScript, struct CLIScriptStatement);
+
+struct CLIScriptEngine {
+	struct mScriptEngine d;
+	struct mScriptBridge* sb;
+	struct CLIScript script;
+};
+
+static void CLIScriptEngineClear(struct CLIScriptEngine* engine) {
+	size_t i = CLIScriptSize(&engine->script);
+	while (i-- > 0) {
+		struct CLIScriptStatement* statement = CLIScriptGetPointer(&engine->script, i);
+		free(statement->command);
+	}
+	CLIScriptClear(&engine->script);
+}
+
+struct CLIScriptEngine* CLICreateScriptEngine(void) {
+	struct CLIScriptEngine* engine = malloc(sizeof(*engine));
+	engine->d.name = CLIScriptEngineName;
+	engine->d.init = CLIScriptEngineInit;
+	engine->d.deinit = CLIScriptEngineDeinit;
+	engine->d.isScript = CLIScriptEngineIsScript;
+	engine->d.loadScript = CLIScriptEngineLoadScript;
+	engine->d.run = CLIScriptEngineRun;
+	engine->d.lookupSymbol = CLIScriptEngineLookupSymbol;
+	engine->d.debuggerEntered = CLIScriptDebuggerEntered;
+	engine->sb = NULL;
+	return engine;
+}
+
+void CLIDebuggerScriptEngineInstall(struct mScriptBridge* sb) {
+	struct CLIScriptEngine* se = CLICreateScriptEngine();
+	mScriptBridgeInstallEngine(sb, &se->d);
+}
+
+const char* CLIScriptEngineName(struct mScriptEngine* se) {
+	UNUSED(se);
+	return "cli-debugger";
+}
+
+bool CLIScriptEngineInit(struct mScriptEngine* se, struct mScriptBridge* sb) {
+	struct CLIScriptEngine* engine = (struct CLIScriptEngine*) se;
+	engine->sb = sb;
+	CLIScriptInit(&engine->script, 0);
+	return true;
+}
+
+void CLIScriptEngineDeinit(struct mScriptEngine* se) {
+	struct CLIScriptEngine* engine = (struct CLIScriptEngine*) se;
+	CLIScriptEngineClear(engine);
+	CLIScriptDeinit(&engine->script);
+	free(se);
+}
+
+bool CLIScriptEngineIsScript(struct mScriptEngine* se, const char* name, struct VFile* vf) {
+	UNUSED(se);
+	UNUSED(vf);
+	return endswith(name, ".mrc");
+}
+
+bool CLIScriptEngineLoadScript(struct mScriptEngine* se, const char* name, struct VFile* vf) {
+	UNUSED(name);
+	struct CLIScriptEngine* engine = (struct CLIScriptEngine*) se;
+	char buffer[256];
+	ssize_t size;
+	CLIScriptEngineClear(engine);
+	struct CLIScriptStatement* statement;
+	while ((size = vf->readline(vf, buffer, sizeof(buffer))) > 0) {
+		if (buffer[size - 1] == '\n') {
+			--size;
+		}
+		statement = CLIScriptAppend(&engine->script);
+		statement->command = strndup(buffer, size);
+		statement->commandLen = size;
+	}
+	return true;
+}
+
+void CLIScriptEngineRun(struct mScriptEngine* se) {
+	struct CLIScriptEngine* engine = (struct CLIScriptEngine*) se;
+	struct CLIDebugger* debugger = (struct CLIDebugger*) mScriptBridgeGetDebugger(engine->sb);
+	struct CLIScriptStatement* statement;
+	size_t statementCount = CLIScriptSize(&engine->script);
+	size_t i;
+	for (i = 0; i < statementCount; i++) {
+		statement = CLIScriptGetPointer(&engine->script, i);
+		CLIDebuggerRunCommand(debugger, statement->command, statement->commandLen);
+	}
+}
+
+bool CLIScriptEngineLookupSymbol(struct mScriptEngine* se, const char* name, int32_t* out) {
+	UNUSED(se);
+	UNUSED(name);
+	UNUSED(out);
+	return false;
+}
+
+void CLIScriptDebuggerEntered(struct mScriptEngine* se, enum mDebuggerEntryReason reason, struct mDebuggerEntryInfo* info) {
+	UNUSED(reason);
+	UNUSED(info);
+	struct CLIScriptEngine* engine = (struct CLIScriptEngine*) se;
+
+	struct mDebugger* debugger = mScriptBridgeGetDebugger(engine->sb);
+	if (!debugger) {
+		return;
+	}
+
+	// TODO: CLIDebuggerEntered(reason, info);
+}

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -137,6 +137,7 @@ static struct CLIDebuggerCommandAlias _debuggerCommandAliases[] = {
 	{ "p/x", "print/x" },
 	{ "q", "quit" },
 	{ "w", "watch" },
+	{ ".", "source" },
 	{ 0, 0 }
 };
 
@@ -944,7 +945,7 @@ static int _tryCommands(struct CLIDebugger* debugger, struct CLIDebuggerCommandS
 	return -1;
 }
 
-static bool _parse(struct CLIDebugger* debugger, const char* line, size_t count) {
+bool CLIDebuggerRunCommand(struct CLIDebugger* debugger, const char* line, size_t count) {
 	const char* firstSpace = strchr(line, ' ');
 	size_t cmdLength;
 	if (firstSpace) {
@@ -984,10 +985,10 @@ static void _commandLine(struct mDebugger* debugger) {
 		if (line[0] == '\n') {
 			line = cliDebugger->backend->historyLast(cliDebugger->backend, &len);
 			if (line && len) {
-				_parse(cliDebugger, line, len);
+				CLIDebuggerRunCommand(cliDebugger, line, len);
 			}
 		} else {
-			_parse(cliDebugger, line, len);
+			CLIDebuggerRunCommand(cliDebugger, line, len);
 			cliDebugger->backend->historyAppend(cliDebugger->backend, line);
 		}
 	}

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -72,6 +72,8 @@ static void _source(struct CLIDebugger*, struct CLIDebugVector*);
 static void _backtrace(struct CLIDebugger*, struct CLIDebugVector*);
 static void _finish(struct CLIDebugger*, struct CLIDebugVector*);
 static void _setStackTraceMode(struct CLIDebugger*, struct CLIDebugVector*);
+static void _setSymbol(struct CLIDebugger*, struct CLIDebugVector*);
+static void _findSymbol(struct CLIDebugger*, struct CLIDebugVector*);
 
 static struct CLIDebuggerCommandSummary _debuggerCommands[] = {
 	{ "backtrace", _backtrace, "i", "Print backtrace of all or specified frames" },
@@ -92,8 +94,10 @@ static struct CLIDebuggerCommandSummary _debuggerCommands[] = {
 	{ "r/1", _readByte, "I", "Read a byte from a specified offset" },
 	{ "r/2", _readHalfword, "I", "Read a halfword from a specified offset" },
 	{ "r/4", _readWord, "I", "Read a word from a specified offset" },
-	{ "stack", _setStackTraceMode, "S", "Changes the stack tracing mode" },
+	{ "set", _setSymbol, "SI", "Assign a symbol to an address" },
+	{ "stack", _setStackTraceMode, "S", "Change the stack tracing mode" },
 	{ "status", _printStatus, "", "Print the current status" },
+	{ "symbol", _findSymbol, "I", "Find the symbol name for an address" },
 	{ "trace", _trace, "Is", "Trace a number of instructions" },
 	{ "w/1", _writeByte, "II", "Write a byte at a specified offset" },
 	{ "w/2", _writeHalfword, "II", "Write a halfword at a specified offset" },
@@ -1178,10 +1182,11 @@ static void _backtrace(struct CLIDebugger* debugger, struct CLIDebugVector* dv) 
 		frames = dv->intValue;
 	}
 	ssize_t i;
+	struct mDebuggerSymbols* symbolTable = debugger->d.core->symbolTable;
 	for (i = 0; i < frames; ++i) {
 		char trace[1024];
 		size_t traceSize = sizeof(trace) - 2;
-		mStackTraceFormatFrame(stack, i, trace, &traceSize);
+		mStackTraceFormatFrame(stack, symbolTable, i, trace, &traceSize);
 		debugger->backend->printf(debugger->backend, "%s", trace);
 	}
 }
@@ -1230,5 +1235,48 @@ static void _setStackTraceMode(struct CLIDebugger* debugger, struct CLIDebugVect
 		platform->setStackTraceMode(platform, STACK_TRACE_BREAK_ON_BOTH);
 	} else {
 		debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
+	}
+}
+
+static void _setSymbol(struct CLIDebugger* debugger, struct CLIDebugVector* dv) {
+	struct mDebuggerSymbols* symbolTable = debugger->d.core->symbolTable;
+	if (!symbolTable) {
+		debugger->backend->printf(debugger->backend, "No symbol table available.\n");
+		return;
+	}
+	if (!dv || !dv->next) {
+		debugger->backend->printf(debugger->backend, "%s\n", ERROR_MISSING_ARGS);
+		return;
+	}
+	if (dv->type != CLIDV_CHAR_TYPE || dv->next->type != CLIDV_INT_TYPE) {
+		debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
+		return;
+	}
+	mDebuggerSymbolAdd(symbolTable, dv->charValue, dv->next->intValue, dv->next->segmentValue);
+}
+
+static void _findSymbol(struct CLIDebugger* debugger, struct CLIDebugVector* dv) {
+	struct mDebuggerSymbols* symbolTable = debugger->d.core->symbolTable;
+	if (!symbolTable) {
+		debugger->backend->printf(debugger->backend, "No symbol table available.\n");
+		return;
+	}
+	if (!dv) {
+		debugger->backend->printf(debugger->backend, "%s\n", ERROR_MISSING_ARGS);
+		return;
+	}
+	if (dv->type != CLIDV_INT_TYPE) {
+		debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
+		return;
+	}
+	const char* name = mDebuggerSymbolReverseLookup(symbolTable, dv->intValue, dv->segmentValue);
+	if (name) {
+		if (dv->segmentValue >= 0) {
+			debugger->backend->printf(debugger->backend, " 0x%02X:%08X = %s\n", dv->segmentValue, dv->intValue, name);
+		} else {
+			debugger->backend->printf(debugger->backend, " 0x%08X = %s\n", dv->intValue, name);
+		}
+	} else {
+		debugger->backend->printf(debugger->backend, "Not found.\n");
 	}
 }

--- a/src/platform/sdl/main.c
+++ b/src/platform/sdl/main.c
@@ -210,6 +210,9 @@ int mSDLRun(struct mSDLRenderer* renderer, struct mArguments* args) {
 #ifdef ENABLE_PYTHON
 	mPythonSetup(bridge);
 #endif
+#ifdef USE_DEBUGGERS
+	CLIDebuggerScriptEngineInstall(bridge);
+#endif
 #endif
 
 #ifdef USE_DEBUGGERS
@@ -223,7 +226,7 @@ int mSDLRun(struct mSDLRenderer* renderer, struct mArguments* args) {
 #endif
 		mDebuggerAttach(debugger, renderer->core);
 		mDebuggerEnter(debugger, DEBUGGER_ENTER_MANUAL, NULL);
- #ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING
 		mScriptBridgeSetDebugger(bridge, debugger);
 #endif
 	}


### PR DESCRIPTION
mGBA can already load symbols out of ELF files (and I think there's work being done on loading them from separate sym files). This PR adds the ability to define new symbols in the CLI debugger and to resolve addresses to their matching symbol table entries in stack traces.

As a bonus feature, it also adds a new scripting engine to allow running a list of debugger commands from a file. It's pretty simplistic, but it does the job.