### PR TITLE
Stack traces: fix tracing of indirect jumps and interrupt handlers

### DIFF
--- a/include/mgba/internal/arm/decoder.h
+++ b/include/mgba/internal/arm/decoder.h
@@ -217,6 +217,7 @@ void ARMDecodeThumb(uint16_t opcode, struct ARMInstructionInfo* info);
 bool ARMDecodeThumbCombine(struct ARMInstructionInfo* info1, struct ARMInstructionInfo* info2,
                            struct ARMInstructionInfo* out);
 int ARMDisassemble(struct ARMInstructionInfo* info, uint32_t pc, char* buffer, int blen);
+uint32_t ARMResolveMemoryAccess(struct ARMInstructionInfo* info, struct ARMRegisterFile* regs, uint32_t pc);
 
 CXX_GUARD_END
 

--- a/include/mgba/internal/arm/isa-inlines.h
+++ b/include/mgba/internal/arm/isa-inlines.h
@@ -142,4 +142,26 @@ static inline bool ARMTestCondition(struct ARMCore* cpu, unsigned condition) {
 	}
 }
 
+static inline enum RegisterBank ARMSelectBank(enum PrivilegeMode mode) {
+	switch (mode) {
+	case MODE_USER:
+	case MODE_SYSTEM:
+		// No banked registers
+		return BANK_NONE;
+	case MODE_FIQ:
+		return BANK_FIQ;
+	case MODE_IRQ:
+		return BANK_IRQ;
+	case MODE_SUPERVISOR:
+		return BANK_SUPERVISOR;
+	case MODE_ABORT:
+		return BANK_ABORT;
+	case MODE_UNDEFINED:
+		return BANK_UNDEFINED;
+	default:
+		// This should be unreached
+		return BANK_NONE;
+	}
+}
+
 #endif

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -9,16 +9,14 @@
 #include <mgba/internal/arm/isa-inlines.h>
 #include <mgba/internal/arm/isa-thumb.h>
 
-static inline enum RegisterBank _ARMSelectBank(enum PrivilegeMode);
-
 void ARMSetPrivilegeMode(struct ARMCore* cpu, enum PrivilegeMode mode) {
 	if (mode == cpu->privilegeMode) {
 		// Not switching modes after all
 		return;
 	}
 
-	enum RegisterBank newBank = _ARMSelectBank(mode);
-	enum RegisterBank oldBank = _ARMSelectBank(cpu->privilegeMode);
+	enum RegisterBank newBank = ARMSelectBank(mode);
+	enum RegisterBank oldBank = ARMSelectBank(cpu->privilegeMode);
 	if (newBank != oldBank) {
 		// Switch banked registers
 		if (mode == MODE_FIQ || cpu->privilegeMode == MODE_FIQ) {
@@ -44,28 +42,6 @@ void ARMSetPrivilegeMode(struct ARMCore* cpu, enum PrivilegeMode mode) {
 		cpu->spsr.packed = cpu->bankedSPSRs[newBank];
 	}
 	cpu->privilegeMode = mode;
-}
-
-static inline enum RegisterBank _ARMSelectBank(enum PrivilegeMode mode) {
-	switch (mode) {
-	case MODE_USER:
-	case MODE_SYSTEM:
-		// No banked registers
-		return BANK_NONE;
-	case MODE_FIQ:
-		return BANK_FIQ;
-	case MODE_IRQ:
-		return BANK_IRQ;
-	case MODE_SUPERVISOR:
-		return BANK_SUPERVISOR;
-	case MODE_ABORT:
-		return BANK_ABORT;
-	case MODE_UNDEFINED:
-		return BANK_UNDEFINED;
-	default:
-		// This should be unreached
-		return BANK_NONE;
-	}
 }
 
 void ARMInit(struct ARMCore* cpu) {

--- a/src/arm/debugger/debugger.c
+++ b/src/arm/debugger/debugger.c
@@ -29,6 +29,16 @@ static bool ARMDecodeCombined(struct ARMCore* cpu, struct ARMInstructionInfo* in
 	}
 }
 
+static inline int ARMGetStack(struct ARMRegisterFile* regs) {
+	if (!regs) {
+		return MODE_USER;
+	}
+	if (regs->cpsr.priv == MODE_SYSTEM) {
+		return MODE_USER;
+	}
+	return regs->cpsr.priv;
+}
+
 static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uint32_t pc) {
 	struct ARMDebugger* debugger = (struct ARMDebugger*) d;
 	struct ARMCore* cpu = debugger->cpu;
@@ -36,7 +46,8 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 	struct mStackTrace* stack = &d->p->stackTrace;
 
 	struct mStackFrame* frame = mStackTraceGetFrame(stack, 0);
-	if (frame && frame->frameBaseAddress < (uint32_t) cpu->gprs[ARM_SP]) {
+	int currentStack = ARMGetStack(&cpu->regs);
+	if (frame && frame->frameBaseAddress < (uint32_t) cpu->gprs[ARM_SP] && currentStack == ARMGetStack(frame->regs)) {
 		// The stack frame has been popped off the stack. This means the function
 		// has been returned from, or that the stack pointer has been otherwise
 		// manipulated. Either way, the function is done executing.
@@ -45,7 +56,7 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 			shouldBreak = shouldBreak || frame->breakWhenFinished;
 			mStackTracePop(stack);
 			frame = mStackTraceGetFrame(stack, 0);
-		} while (frame && frame->frameBaseAddress < (uint32_t) cpu->gprs[ARM_SP]);
+		} while (frame && frame->frameBaseAddress < (uint32_t) cpu->gprs[ARM_SP] && currentStack == ARMGetStack(frame->regs));
 		if (shouldBreak) {
 			struct mDebuggerEntryInfo debuggerInfo = {
 				.address = pc,
@@ -84,10 +95,10 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 		return false;
 	}
 
-	bool isCall = interrupt || (info.branchType & ARM_BRANCH_LINKED);
+	bool isCall = (info.branchType & ARM_BRANCH_LINKED);
 	uint32_t destAddress;
 
-	if (interrupt && info.branchType == ARM_BRANCH_NONE) {
+	if (interrupt && !isCall) {
 		// The stack frame was already pushed up above, so there's no
 		// action necessary here, but we still want to check for a
 		// breakpoint down below.
@@ -115,6 +126,9 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 			bool isBranch = ARMInstructionIsBranch(info.mnemonic);
 			int reg = (isBranch ? info.op1.reg : info.op2.reg);
 			destAddress = cpu->gprs[reg];
+			if ((info.operandFormat & ARM_OPERAND_MEMORY_2) && (info.branchType & ARM_BRANCH_INDIRECT)) {
+				destAddress = cpu->memory.load32(cpu, destAddress, NULL);
+			}
 			if (isBranch || (info.op1.reg == ARM_PC && !isMovPcLr)) {
 				// ARMv4 doesn't have the BLX opcode, so it uses an assignment to LR before a BX for that purpose.
 				struct ARMInstructionInfo prevInfo;
@@ -145,25 +159,23 @@ static bool ARMDebuggerUpdateStackTraceInternal(struct mDebuggerPlatform* d, uin
 		return false;
 	}
 
-	if (info.branchType & ARM_BRANCH_INDIRECT) {
-		destAddress = cpu->memory.load32(cpu, destAddress, NULL);
-	}
-
 	if (isCall) {
 		int instructionLength = isWideInstruction ? WORD_SIZE_ARM : WORD_SIZE_THUMB;
 		frame = mStackTracePush(stack, pc, destAddress + instructionLength, cpu->gprs[ARM_SP], &cpu->regs);
 		if (!(debugger->stackTraceMode & STACK_TRACE_BREAK_ON_CALL)) {
 			return false;
 		}
-	} else {
-		mStackTracePop(stack);
+	} else if (!interrupt) {
+		if (frame && currentStack == ARMGetStack(frame->regs)) {
+			mStackTracePop(stack);
+		}
 		if (!(debugger->stackTraceMode & STACK_TRACE_BREAK_ON_RETURN)) {
 			return false;
 		}
 	}
 	struct mDebuggerEntryInfo debuggerInfo = {
 		.address = pc,
-		.type.st.traceType = isCall ? STACK_TRACE_BREAK_ON_CALL : STACK_TRACE_BREAK_ON_RETURN,
+		.type.st.traceType = (interrupt || isCall) ? STACK_TRACE_BREAK_ON_CALL : STACK_TRACE_BREAK_ON_RETURN,
 		.pointId = 0
 	};
 	mDebuggerEnter(d->p, DEBUGGER_ENTER_STACK, &debuggerInfo);

--- a/src/arm/decoder.c
+++ b/src/arm/decoder.c
@@ -488,3 +488,46 @@ int ARMDisassemble(struct ARMInstructionInfo* info, uint32_t pc, char* buffer, i
 	buffer[blen - 1] = '\0';
 	return total;
 }
+
+uint32_t ARMResolveMemoryAccess(struct ARMInstructionInfo* info, struct ARMRegisterFile* regs, uint32_t pc) {
+	uint32_t address = 0;
+	int32_t offset = 0;
+	if (info->memory.format & ARM_MEMORY_REGISTER_BASE) {
+		if (info->memory.baseReg == ARM_PC && info->memory.format & ARM_MEMORY_IMMEDIATE_OFFSET) {
+			address = pc;
+		} else {
+			address = regs->gprs[info->memory.baseReg];
+		}
+	}
+	if (info->memory.format & ARM_MEMORY_POST_INCREMENT) {
+		return address;
+	}
+	if (info->memory.format & ARM_MEMORY_IMMEDIATE_OFFSET) {
+		offset = info->memory.offset.immediate;
+	} else if (info->memory.format & ARM_MEMORY_REGISTER_OFFSET) {
+		offset = info->memory.offset.reg == ARM_PC ? pc : regs->gprs[info->memory.offset.reg];
+	}
+	if (info->memory.format & ARM_MEMORY_SHIFTED_OFFSET) {
+		uint8_t shiftSize = info->memory.offset.shifterImm;
+		switch (info->memory.offset.shifterOp) {
+			case ARM_SHIFT_LSL:
+				offset <<= shiftSize;
+				break;
+			case ARM_SHIFT_LSR:
+				offset = ((uint32_t) offset) >> shiftSize;
+				break;
+			case ARM_SHIFT_ASR:
+				offset >>= shiftSize;
+				break;
+			case ARM_SHIFT_ROR:
+				offset = ROR(offset, shiftSize);
+				break;
+			case ARM_SHIFT_RRX:
+				offset = (regs->cpsr.c << 31) | ((uint32_t) offset >> 1);
+				break;
+			default:
+				break;
+		};
+	}
+	return address + (info->memory.format & ARM_MEMORY_OFFSET_SUBTRACT ? -offset : offset);
+}

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -1035,7 +1035,13 @@ static void _reportEntry(struct mDebugger* debugger, enum mDebuggerEntryReason r
 	case DEBUGGER_ENTER_STACK:
 		if (info) {
 			if (info->type.st.traceType == STACK_TRACE_BREAK_ON_CALL) {
-				cliDebugger->backend->printf(cliDebugger->backend, "Hit function call at at 0x%08X\n", info->address);
+				struct mStackTrace* stack = &cliDebugger->d.stackTrace;
+				struct mStackFrame* frame = mStackTraceGetFrame(stack, 0);
+				if (frame->interrupt) {
+					cliDebugger->backend->printf(cliDebugger->backend, "Hit interrupt at at 0x%08X\n", info->address);
+				} else {
+					cliDebugger->backend->printf(cliDebugger->backend, "Hit function call at at 0x%08X\n", info->address);
+				}
 			} else {
 				cliDebugger->backend->printf(cliDebugger->backend, "Hit function return at at 0x%08X\n", info->address);
 			}


### PR DESCRIPTION
I noticed totally bogus pointers in stack traces and it turns out I had misunderstood what the decoder was referring to as "indirect" branches. Also having interrupt handlers switch around the stack pointer was causing frames to be spuriously popped.