### PR TITLE
Support variant symfile format with function sizes

### DIFF
--- a/src/debugger/symbols.c
+++ b/src/debugger/symbols.c
@@ -97,6 +97,13 @@ void mDebuggerLoadARMIPSSymbols(struct mDebuggerSymbols* st, struct VFile* vf) {
 			continue;
 		}
 
+		char* buf2 = strchr(buf, ',');
+
+		if (buf2 != NULL) {
+			// Commas separate names from function sizes
+			*buf2 = '\0';
+		}
+
 		mDebuggerSymbolAdd(st, buf, address, -1);
 	}
 }


### PR DESCRIPTION
This basically implements what I asked for a while back in comment on #1260, adding support for a slight variation on the symfile format, which includes sizes. ARMIPS outputs this format when supplied with `-sym2` (as opposed to `-sym`); the ARMIPS readme says that it was originally from PCSX2 and PPSSPP, and gives the following example:

```
00000000 0
80000000 .dbl:0010
80000010 Main
8000002C Subroutine,0000001C
80240000 NewBlock,00000014
```

As is, mGBA will parse that and create symbols called `Subroutine,0000001C` and `NewBlock,00000014`. This PR basically just checks for a comma in the name of a symbol in a symfile and throws away it and everything after it (so they'd be correctly identified as `Subroutine` and `NewBlock`).

It's a fairly trivial change, but I'm not overly confidant in C, so hopefully I didn't make any obvious errors. Let me know if there's anything that needs changing.