### PR TITLE
Qt: Always apply SmoothPixMapTransform to the background logo

### DIFF
--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1978,7 +1978,7 @@ void WindowBackground::paintEvent(QPaintEvent* event) {
 	QWidget::paintEvent(event);
 	const QPixmap& logo = pixmap();
 	QPainter painter(this);
-	painter.setRenderHint(QPainter::SmoothPixmapTransform, m_filter);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
 	painter.fillRect(QRect(QPoint(), size()), Qt::black);
 	QSize s = size();
 	QSize ds = s;


### PR DESCRIPTION
Currently, the background logo of the Qt application looks not very nice if the bilinear filter is disabled in the mGBA settings and tends to be pretty blurry.
![mgba-no-antialias](https://user-images.githubusercontent.com/11882577/93005647-30eab400-f553-11ea-8f75-a0d72fb61982.png)

This simple patch always enables the `SmoothPixmapTransform` rendering hint for drawing the background logo, so the hinting filter will always be applied, resulting in a much cleaner image of the background logo regardless of the bilinear filter for the emulation being enabled or disabled.
![mgba-with-antialias](https://user-images.githubusercontent.com/11882577/93005648-3516d180-f553-11ea-8af4-0ad6de6e28f6.PNG)

Any chance to get this merged or am I breaking something here? :-)