### PR TITLE
Fix a race condition on `InputController::m_pendingEvents`

### DIFF
--- a/src/platform/qt/InputController.cpp
+++ b/src/platform/qt/InputController.cpp
@@ -384,6 +384,7 @@ int InputController::pollEvents() {
 		SDL_JoystickUpdate();
 		int numButtons = SDL_JoystickNumButtons(joystick);
 		int i;
+		QReadLocker l(&m_eventsLock);
 		for (i = 0; i < numButtons; ++i) {
 			GBAKey key = static_cast<GBAKey>(mInputMapKey(&m_inputMap, SDL_BINDING_BUTTON, i));
 			if (key == GBA_KEY_NONE) {
@@ -396,6 +397,7 @@ int InputController::pollEvents() {
 				activeButtons |= 1 << key;
 			}
 		}
+		l.unlock();
 		int numHats = SDL_JoystickNumHats(joystick);
 		for (i = 0; i < numHats; ++i) {
 			int hat = SDL_JoystickGetHat(joystick, i);
@@ -561,6 +563,7 @@ void InputController::bindHat(uint32_t type, int hat, GamepadHatEvent::Direction
 }
 
 void InputController::testGamepad(int type) {
+	QWriteLocker l(&m_eventsLock);
 	auto activeAxes = activeGamepadAxes(type);
 	auto oldAxes = m_activeAxes;
 	m_activeAxes = activeAxes;

--- a/src/platform/qt/InputController.h
+++ b/src/platform/qt/InputController.h
@@ -10,6 +10,7 @@
 
 #include <QImage>
 #include <QMutex>
+#include <QReadWriteLock>
 #include <QObject>
 #include <QSet>
 #include <QTimer>
@@ -181,6 +182,7 @@ private:
 	QTimer m_gamepadTimer{nullptr};
 
 	QSet<GBAKey> m_pendingEvents;
+	QReadWriteLock m_eventsLock;
 };
 
 }


### PR DESCRIPTION
This member could be accessed at the same from different threads leading
to random (rare) crashes.

Fixes #1875