### PR TITLE
Return correct byte in out of bounds ROM load

### DIFF
--- a/src/gba/memory.c
+++ b/src/gba/memory.c
@@ -679,7 +679,7 @@ uint32_t GBALoad8(struct ARMCore* cpu, uint32_t address, int* cycleCounter) {
 			value = GBAVFameGetPatternValue(address, 8);
 		} else {
 			mLOG(GBA_MEM, GAME_ERROR, "Out of bounds ROM Load8: 0x%08X", address);
-			value = (address >> 1) & 0xFF;
+			value = ((address >> 1) >> ((address & 1) * 8)) & 0xFF;
 		}
 		break;
 	case REGION_CART_SRAM:


### PR DESCRIPTION
According to GBATEK unused memory is filled the following way:

> Because Gamepak uses the same signal-lines for both 16bit data and for lower 16bit halfword address, the entire gamepak ROM area is effectively filled by incrementing 16bit values (Address/2 AND FFFFh).

mGBA already adheres to that in word / halfword loads but the byte variant seems to be wrong. Currently it returns the same value for both bytes of the actual 16bit value. Please correct me if I am wrong here.