### PR TITLE
GBA: Add override for DigiCommunication Nyo

### DIFF
--- a/src/gba/overrides.c
+++ b/src/gba/overrides.c
@@ -35,6 +35,9 @@ static const struct GBACartridgeOverride _overrides[] = {
 	{ "AC8E", SAVEDATA_EEPROM, HW_NONE, IDLE_LOOP_NONE, false },
 	{ "AC8P", SAVEDATA_EEPROM, HW_NONE, IDLE_LOOP_NONE, false },
 
+	// DigiCommunication Nyo - Datou! Black Gemagema Dan
+	{ "BDKJ", SAVEDATA_EEPROM, HW_NONE, IDLE_LOOP_NONE, false },
+
 	// Dragon Ball Z - The Legacy of Goku
 	{ "ALGP", SAVEDATA_EEPROM, HW_NONE, IDLE_LOOP_NONE, false },
 


### PR DESCRIPTION
I got a physical copy of the game, dumped the save data, and tried to get it to work with mGBA, But this game was not detected correctly in autodetect.
It uses EEPROM, seems like the same PCB as the Dragon Ball Z - The Legacy of Goku.