### PR TITLE
Core: make map cache aware of how many tiles to update in a write

### DIFF
--- a/include/mgba/core/map-cache.h
+++ b/include/mgba/core/map-cache.h
@@ -23,6 +23,7 @@ DECL_BITS(mMapCacheSystemInfo, TilesWide, 8, 4);
 DECL_BITS(mMapCacheSystemInfo, TilesHigh, 12, 4);
 DECL_BITS(mMapCacheSystemInfo, MacroTileSize, 16, 7);
 DECL_BITS(mMapCacheSystemInfo, MapAlign, 23, 2);
+DECL_BIT(mMapCacheSystemInfo, TilesPerWrite, 25);
 
 DECL_BITFIELD(mMapCacheEntryFlags, uint16_t);
 DECL_BITS(mMapCacheEntryFlags, PaletteId, 0, 4);

--- a/src/core/map-cache.c
+++ b/src/core/map-cache.c
@@ -75,6 +75,12 @@ void mMapCacheWriteVRAM(struct mMapCache* cache, uint32_t address) {
 		++status->vramVersion;
 		status->flags = mMapCacheEntryFlagsClearVramClean(status->flags);
 		status->tileStatus[mMapCacheEntryFlagsGetPaletteId(status->flags)].vramClean = 0;
+		if (mMapCacheSystemInfoGetTilesPerWrite(cache->sysConfig) == 1) {
+			status = &cache->status[(address >> mMapCacheSystemInfoGetMapAlign(cache->sysConfig)) + 1];
+			++status->vramVersion;
+			status->flags = mMapCacheEntryFlagsClearVramClean(status->flags);
+			status->tileStatus[mMapCacheEntryFlagsGetPaletteId(status->flags)].vramClean = 0;
+		}
 	}
 }
 

--- a/src/gb/renderers/cache-set.c
+++ b/src/gb/renderers/cache-set.c
@@ -35,6 +35,7 @@ void GBVideoCacheAssociate(struct mCacheSet* cache, struct GBVideo* video) {
 	if (video->p->model >= GB_MODEL_CGB) {
 		sysconfig = mMapCacheSystemInfoSetPaletteCount(0, 2);
 	}
+	sysconfig = mMapCacheSystemInfoSetTilesPerWrite(sysconfig, 0);
 	mMapCacheConfigureSystem(mMapCacheSetGetPointer(&cache->maps, 0), sysconfig);
 	mMapCacheConfigureSystem(mMapCacheSetGetPointer(&cache->maps, 1), sysconfig);
 

--- a/src/gba/renderers/cache-set.c
+++ b/src/gba/renderers/cache-set.c
@@ -167,6 +167,7 @@ static void GBAVideoCacheWriteBGCNT(struct mCacheSet* cache, size_t bg, uint16_t
 		sysconfig = mMapCacheSystemInfoSetPaletteCount(sysconfig, 4 * !p);
 		sysconfig = mMapCacheSystemInfoSetMacroTileSize(sysconfig, 5);
 		sysconfig = mMapCacheSystemInfoSetMapAlign(sysconfig, 1);
+		sysconfig = mMapCacheSystemInfoSetTilesPerWrite(sysconfig, 0);
 		tilesWide = 5;
 		tilesHigh = 5;
 		if (size & 1) {
@@ -182,6 +183,7 @@ static void GBAVideoCacheWriteBGCNT(struct mCacheSet* cache, size_t bg, uint16_t
 		sysconfig = mMapCacheSystemInfoSetPaletteCount(sysconfig, 0);
 		sysconfig = mMapCacheSystemInfoSetMacroTileSize(sysconfig, 4 + size);
 		sysconfig = mMapCacheSystemInfoSetMapAlign(sysconfig, 0);
+		sysconfig = mMapCacheSystemInfoSetTilesPerWrite(sysconfig, 1);
 
 		tilesHigh = 4 + size;
 		tilesWide = 4 + size;


### PR DESCRIPTION
Fixes a bug where ~~the memory editor didn't update renderer state when writing to VRAM, and another where~~ (chunked out to #2544) the map viewer only updates half the tiles when doing (16-bit) VRAM writes to an affine background (where tiles are 8 bit = 2 tiles updated at once).