### PR TITLE
Qt: Game Boy Printer output via external command

### DIFF
--- a/include/mgba/internal/gb/sio/printer.h
+++ b/include/mgba/internal/gb/sio/printer.h
@@ -29,6 +29,13 @@ enum GBPrinterPacketByte {
 	GB_PRINTER_BYTE_UNCOMPRESSED_DATA
 };
 
+enum GBPrinterParameterByte {
+	GB_PRINTER_PARAMETER_BYTE_SHEETS,
+	GB_PRINTER_PARAMETER_BYTE_MARGINS,
+	GB_PRINTER_PARAMETER_BYTE_PALETTE,
+	GB_PRINTER_PARAMETER_BYTE_EXPOSURE
+};
+
 enum GBPrinterStatus {
 	GB_PRINTER_STATUS_CHECKSUM_ERROR = 0x01,
 	GB_PRINTER_STATUS_PRINTING = 0x02,
@@ -64,6 +71,13 @@ struct GBPrinter {
 	enum GBPrinterPacketByte next;
 	uint8_t status;
 	int printWait;
+
+	enum GBPrinterParameterByte nextParam;
+	uint8_t sheets;
+	uint8_t topMargin;
+	uint8_t bottomMargin;
+	uint8_t palette;
+	uint8_t exposure;
 };
 
 void GBPrinterCreate(struct GBPrinter* printer);

--- a/src/gb/sio/printer.c
+++ b/src/gb/sio/printer.c
@@ -59,7 +59,24 @@ static void _processByte(struct GBPrinter* printer) {
 		}
 		break;
 	case GB_PRINTER_COMMAND_PRINT:
-		// TODO
+		switch (printer->nextParam) { 
+		case GB_PRINTER_PARAMETER_BYTE_SHEETS:
+			printer->sheets = printer->byte;
+			printer->nextParam = GB_PRINTER_PARAMETER_BYTE_MARGINS;
+			break;
+		case GB_PRINTER_PARAMETER_BYTE_MARGINS:
+			printer->topMargin = printer->byte >> 4;
+			printer->bottomMargin = printer->byte & 0xF;
+			printer->nextParam = GB_PRINTER_PARAMETER_BYTE_PALETTE;
+			break;
+		case GB_PRINTER_PARAMETER_BYTE_PALETTE:
+			printer->palette = printer->byte;
+			printer->nextParam = GB_PRINTER_PARAMETER_BYTE_EXPOSURE;
+			break;
+		case GB_PRINTER_PARAMETER_BYTE_EXPOSURE:
+			printer->exposure = printer->byte;
+			printer->nextParam = GB_PRINTER_PARAMETER_BYTE_SHEETS;
+		}
 		break;
 	default:
 		break;
@@ -112,6 +129,9 @@ static uint8_t GBPrinterWriteSC(struct GBSIODriver* driver, uint8_t value) {
 			case GB_PRINTER_COMMAND_INIT:
 				printer->currentIndex = 0;
 				printer->status &= ~(GB_PRINTER_STATUS_PRINT_REQ | GB_PRINTER_STATUS_READY);
+				break;
+			case GB_PRINTER_COMMAND_PRINT:
+				printer->nextParam = GB_PRINTER_PARAMETER_BYTE_SHEETS;
 				break;
 			default:
 				break;

--- a/src/platform/qt/CoreController.h
+++ b/src/platform/qt/CoreController.h
@@ -182,7 +182,7 @@ public slots:
 
 #ifdef M_CORE_GB
 	void setupExtPrinter();
-	void extPrint(const QImage&);
+	void extPrint(const QImage&, int topMargin, int bottomMargin, int exposure);
 	void attachPrinter();
 	void detachPrinter();
 	void endPrint();
@@ -228,7 +228,7 @@ signals:
 	void statusPosted(const QString& message);
 	void logPosted(int level, int category, const QString& log);
 
-	void imagePrinted(const QImage&);
+	void imagePrinted(const QImage&, int topMargin, int bottomMargin, int exposure);
 
 private:
 	void updateKeys();

--- a/src/platform/qt/CoreController.h
+++ b/src/platform/qt/CoreController.h
@@ -11,6 +11,8 @@
 #include <QMutex>
 #include <QObject>
 #include <QSize>
+#include <QProcess>
+#include <QTemporaryFile>
 
 #include "VFileDevice.h"
 
@@ -42,6 +44,12 @@ class InputController;
 class LogController;
 class MultiplayerController;
 class Override;
+
+class TempProcess : public QProcess {
+Q_OBJECT
+public:
+	QTemporaryFile m_temp;
+};
 
 class CoreController : public QObject {
 Q_OBJECT
@@ -173,6 +181,8 @@ public slots:
 	void exportSharkport(const QString& path);
 
 #ifdef M_CORE_GB
+	void setupExtPrinter();
+	void extPrint(const QImage&);
 	void attachPrinter();
 	void detachPrinter();
 	void endPrint();
@@ -295,6 +305,7 @@ private:
 		GBPrinter d;
 		CoreController* parent;
 	} m_printer;
+	QString m_extPrintCmd;
 #endif
 
 #ifdef M_CORE_GBA

--- a/src/platform/qt/PrinterView.cpp
+++ b/src/platform/qt/PrinterView.cpp
@@ -75,11 +75,13 @@ void PrinterView::clear() {
 	m_ui.copyButton->setEnabled(false);
 }
 
-void PrinterView::printImage(const QImage& image) {
-	QPixmap pixmap(image.width(), image.height() + m_image.height());
+void PrinterView::printImage(const QImage& image, int topMargin, int bottomMargin, int exposure) {
+	QPixmap pixmap(image.width(), image.height() + m_image.height() + ((topMargin + bottomMargin) * 16));
+	pixmap.fill();
 	QPainter painter(&pixmap);
 	painter.drawPixmap(0, 0, m_image);
-	painter.drawImage(0, m_image.height(), image);
+	painter.setOpacity(0.5 + (exposure / 256.0));
+	painter.drawImage(0, m_image.height() + (topMargin * 16), image);
 	m_image = pixmap;
 	m_ui.image->setPixmap(m_image.scaled(m_image.size() * m_ui.magnification->value()));
 	m_timer.start();

--- a/src/platform/qt/PrinterView.h
+++ b/src/platform/qt/PrinterView.h
@@ -33,7 +33,7 @@ public slots:
 	void clear();
 
 private slots:
-	void printImage(const QImage&);
+	void printImage(const QImage&, int topMargin, int bottomMargin, int exposure);
 	void printLine();
 	void printAll();
 


### PR DESCRIPTION
This gives the Qt interface an option to send Game Boy Printer image data to an external program. It saves the image in PNG format to a temp file. When the program exits, it signals to the Game Boy that printing has finished, and deletes the temp file (though I haven't actually verified that that last bit is happening, yet).

There's no UI yet. To use this, you have to open `config.ini` and add an `extPrintCmd` line to the `[ports.qt]` section. It takes a full command line, as parsed by `QProcess::splitCommand()`. Put a `%1` anywhere you want the temp filename to go.

I didn't go into this with any familiarity whatsoever with C++, Qt, or mGBA internals, so there may well be huge, glaring mistakes here.