### PR TITLE
gdb-stub: Add support for the T command by faking it

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -629,6 +629,7 @@ size_t _parseGDBMessage(struct GDBStub* stub, const char* message) {
 		_readGPRs(stub, message);
 		break;
 	case 'H':
+	case 'T':
 		// This is faked because we only have one thread
 		strncpy(stub->outgoing, "OK", GDB_STUB_MAX_LINE - 4);
 		_sendMessage(stub);


### PR DESCRIPTION
This needs some context because the T command became needed due to this ghidra issue I encountered while trying to setup a debugging environment with ghidra's debugger connected to mgba's gdb stub. The issue thread can be found here: https://github.com/NationalSecurityAgency/ghidra/issues/3452

Essentially, ghidra will send a T command to gdb for a lot of its functions to make sure the thread you are currently debugging is still alive, but mgba did not support that command. It supports H, but that one is implemented by faking it since mgba only operates on one thread. 

Since the ONLY thread mgba operates on should still be alive when the gdb stub is active, it would make sense for the same reasons to simply fake it the same way for the T command and since I got very good success to setup a debugger with ghidra, it seems reasonable to add support to it as ghidra will encounter the issue.

To note, ik the code repeats itself with the H case, but I noticed the layout of this switch was organized to have the command codes sorted, lmk if this is fine or it's preferred to have both cases do the same thing.