### PR TITLE
msvc : fix compilation for c11/c17 lang standards

### DIFF
--- a/include/mgba-util/threading.h
+++ b/include/mgba-util/threading.h
@@ -11,7 +11,7 @@
 CXX_GUARD_START
 
 #ifndef DISABLE_THREADING
-#if __STDC_VERSION__ >= 201112L
+#if (__STDC_VERSION__ >= 201112L) && (__STDC_NO_THREADS__ != 1)
 #define ThreadLocal _Thread_local void*
 #define ThreadLocalInitKey(X)
 #define ThreadLocalSetKey(K, V) K = V


### PR DESCRIPTION
msvc currently supports up to c17 but does not implement some optional features. see https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160 and https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-160