### PR TITLE
[SIO] Fix a -Wswitch warning out of lockstep.c

### DIFF
--- a/src/gba/sio/lockstep.c
+++ b/src/gba/sio/lockstep.c
@@ -462,6 +462,8 @@ static void _GBASIOLockstepNodeProcessEvents(struct mTiming* timing, void* user,
 				node->eventDiff = 0;
 			}
 			break;
+		default:
+			break;
 		}
 	} else if (node->nextEvent <= 0) {
 		if (!node->id) {


### PR DESCRIPTION
The compiler was complaining of unhandled branches, but a new `default` case
solves that.