### PR TITLE
[debugger] Silence a -Wswitch warning out of gdb-stub.c

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -72,6 +72,8 @@ static void _gdbStubEntered(struct mDebugger* debugger, enum mDebuggerEntryReaso
 			case WATCHPOINT_RW:
 				type = "awatch";
 				break;
+			case WATCHPOINT_CHANGE:
+				break;
 			}
 			snprintf(stub->outgoing, GDB_STUB_MAX_LINE - 4, "T%02x%s:%08x;", SIGTRAP, type, info->address);
 		} else {


### PR DESCRIPTION
No one likes unhandled branches, and the compiler was just kindly reminding us
to take care of them.  Well, remind us no more, compiler.