### PR TITLE
Fix "English" language name

### DIFF
--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -337,7 +337,8 @@ SettingsView::SettingsView(ConfigController* controller, InputController* inputC
 		}
 	});
 
-	m_ui.languages->setItemData(0, QLocale("en"));
+	QLocale englishLocale("en");
+	m_ui.languages->addItem(englishLocale.nativeLanguageName(), englishLocale);
 	QDir ts(":/translations/");
 	for (auto name : ts.entryList()) {
 		if (!name.endsWith(".qm") || !name.startsWith(binaryName)) {
@@ -647,7 +648,7 @@ void SettingsView::updateConfig() {
 	emit biosLoaded(mPLATFORM_GBA, m_ui.gbaBios->text());
 }
 
-void SettingsView::reloadConfig() {	
+void SettingsView::reloadConfig() {
 	loadSetting("bios", m_ui.gbaBios);
 	loadSetting("gba.bios", m_ui.gbaBios);
 	loadSetting("gb.bios", m_ui.gbBios);
@@ -818,7 +819,7 @@ void SettingsView::reloadConfig() {
 	} else if (multiplayerAudio == QLatin1String("active")) {
 		m_ui.multiplayerAudioActive->setChecked(true);
 	} else {
-		m_ui.multiplayerAudioAll->setChecked(true);		
+		m_ui.multiplayerAudioAll->setChecked(true);
 	}
 }
 

--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -523,13 +523,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QComboBox" name="languages">
-         <item>
-          <property name="text">
-           <string>English</string>
-          </property>
-         </item>
-        </widget>
+        <widget class="QComboBox" name="languages"/>
        </item>
        <item row="1" column="0" colspan="2">
         <widget class="Line" name="line_10">

--- a/src/platform/qt/ts/mgba-de.ts
+++ b/src/platform/qt/ts/mgba-de.ts
@@ -5472,11 +5472,6 @@ Download-Größe: %3</translation>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>Englisch</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="552"/>
         <source>List view</source>
         <translation>Listenansicht</translation>

--- a/src/platform/qt/ts/mgba-en.ts
+++ b/src/platform/qt/ts/mgba-en.ts
@@ -5476,11 +5476,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-es.ts
+++ b/src/platform/qt/ts/mgba-es.ts
@@ -5545,11 +5545,6 @@ Download size: %3</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>English</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>Biblioteca:</translation>

--- a/src/platform/qt/ts/mgba-fi.ts
+++ b/src/platform/qt/ts/mgba-fi.ts
@@ -5477,11 +5477,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-fr.ts
+++ b/src/platform/qt/ts/mgba-fr.ts
@@ -5570,11 +5570,6 @@ Download size: %3</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>anglais</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>Bibliothèque :</translation>

--- a/src/platform/qt/ts/mgba-hu.ts
+++ b/src/platform/qt/ts/mgba-hu.ts
@@ -5419,11 +5419,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-it.ts
+++ b/src/platform/qt/ts/mgba-it.ts
@@ -5736,11 +5736,6 @@ Download size: %3</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>inglese</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="552"/>
         <source>List view</source>
         <translation>lista a elenco</translation>

--- a/src/platform/qt/ts/mgba-ja.ts
+++ b/src/platform/qt/ts/mgba-ja.ts
@@ -5573,11 +5573,6 @@ Download size: %3</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>English</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>ライブラリー:</translation>

--- a/src/platform/qt/ts/mgba-ko.ts
+++ b/src/platform/qt/ts/mgba-ko.ts
@@ -5734,11 +5734,6 @@ Download size: %3</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>영어</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="552"/>
         <source>List view</source>
         <translation>목록 보기</translation>

--- a/src/platform/qt/ts/mgba-ms.ts
+++ b/src/platform/qt/ts/mgba-ms.ts
@@ -5476,11 +5476,6 @@ Download size: %3</source>
         <translation>Bahasa</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>Inggeris</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>Perpustakaan:</translation>

--- a/src/platform/qt/ts/mgba-nb_NO.ts
+++ b/src/platform/qt/ts/mgba-nb_NO.ts
@@ -5477,11 +5477,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-nl.ts
+++ b/src/platform/qt/ts/mgba-nl.ts
@@ -5511,11 +5511,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-pl.ts
+++ b/src/platform/qt/ts/mgba-pl.ts
@@ -5478,11 +5478,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-pt_BR.ts
+++ b/src/platform/qt/ts/mgba-pt_BR.ts
@@ -5545,11 +5545,6 @@ Download size: %3</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>Inglês</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>Biblioteca:</translation>

--- a/src/platform/qt/ts/mgba-ru.ts
+++ b/src/platform/qt/ts/mgba-ru.ts
@@ -5519,11 +5519,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-template.ts
+++ b/src/platform/qt/ts/mgba-template.ts
@@ -5474,11 +5474,6 @@ Download size: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation type="unfinished"></translation>

--- a/src/platform/qt/ts/mgba-tr.ts
+++ b/src/platform/qt/ts/mgba-tr.ts
@@ -5512,11 +5512,6 @@ Download size: %3</source>
         <translation>Dil</translation>
     </message>
     <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>İngilizce</translation>
-    </message>
-    <message>
         <location filename="../SettingsView.ui" line="544"/>
         <source>Library:</source>
         <translation>Kütüphane:</translation>

--- a/src/platform/qt/ts/mgba-zh_CN.ts
+++ b/src/platform/qt/ts/mgba-zh_CN.ts
@@ -1199,7 +1199,7 @@ Game Boy Advance 是任天堂有限公司（Nintendo Co., Ltd.）的注册商标
         <location filename="../ApplicationUpdatePrompt.cpp" line="26"/>
         <source>An update to %1 is available.
 Do you want to download and install it now? You will need to restart the emulator when the download is complete.</source>
-        <translation>%1 有更新可用。 
+        <translation>%1 有更新可用。
 您想要现在下载并安装它吗？在下载完成后，您将需要重新启动模拟器。</translation>
     </message>
     <message>
@@ -1207,8 +1207,8 @@ Do you want to download and install it now? You will need to restart the emulato
         <source>Current version: %1
 New version: %2
 Download size: %3</source>
-        <translation>当前版本：%1 
-新版本：%2 
+        <translation>当前版本：%1
+新版本：%2
 更新大小：%3</translation>
     </message>
     <message>
@@ -5478,11 +5478,6 @@ Download size: %3</source>
         <location filename="../SettingsView.ui" line="521"/>
         <source>Language</source>
         <translation>语言</translation>
-    </message>
-    <message>
-        <location filename="../SettingsView.ui" line="529"/>
-        <source>English</source>
-        <translation>英语</translation>
     </message>
     <message>
         <location filename="../SettingsView.ui" line="544"/>


### PR DESCRIPTION
The language selection dropdown lists the supported languages written in themselves for every language except English. English gets translated into the language of the active locale.

Bizarrely, this results in "English" being translated as "português do Brasil" when the system locale is set to Portugal Portuguese. THIS appears to be a bug in Qt, not a bug in mGBA, but it motivates fixing the above issue.