### PR TITLE
Add configurable custom LCD shader

### DIFF
--- a/res/shaders/customLCD.shader/ags001-light.fs
+++ b/res/shaders/customLCD.shader/ags001-light.fs
@@ -1,0 +1,36 @@
+varying vec2 texCoord;
+uniform sampler2D tex;
+uniform float reflectionBrightness;
+uniform vec2 reflectionDistance;
+uniform float lightBrightness;
+uniform int enable;
+
+const float speed = 2.0;
+const float decay = 2.0;
+const float coeff = 2.5;
+
+void main() {
+	if(enable==1)
+	{
+	float sp = pow(speed, lightBrightness);
+	float dc = pow(decay, -lightBrightness);
+	float s = (sp - dc) / (sp + dc);
+	vec2 radius = (texCoord.st - vec2(0.5, 0.5)) * vec2(coeff * s);
+	radius = pow(abs(radius), vec2(4.0));
+	vec3 bleed = vec3(0.12, 0.14, 0.19);
+	bleed += (dot(radius, radius) + vec3(0.02, 0.03, 0.05)) * vec3(0.14, 0.18, 0.2);
+
+	vec4 color = texture2D(tex, texCoord);
+	color.rgb += pow(bleed, pow(vec3(lightBrightness), vec3(-0.5)));
+
+	vec4 reflection = texture2D(tex, texCoord - reflectionDistance);
+	color.rgb += reflection.rgb * reflectionBrightness;
+	color.a = 1.0;
+	gl_FragColor = color;
+	}
+	else
+	{	
+	vec4 color = texture2D(tex, texCoord);
+	gl_FragColor = color;
+	}
+}

--- a/res/shaders/customLCD.shader/customLCD-brightness.fs
+++ b/res/shaders/customLCD.shader/customLCD-brightness.fs
@@ -1,0 +1,9 @@
+varying vec2 texCoord;
+uniform sampler2D tex;
+uniform float brightness;
+
+void main() {
+	vec4 color = texture2D(tex, texCoord);
+	color.rgb *= brightness;
+	gl_FragColor = color;
+}

--- a/res/shaders/customLCD.shader/customLCD-pixelBounds.fs
+++ b/res/shaders/customLCD.shader/customLCD-pixelBounds.fs
@@ -1,0 +1,14 @@
+varying vec2 texCoord;
+uniform sampler2D tex;
+uniform vec2 texSize;
+uniform float boundBrightness;
+
+void main() {
+	vec4 color = texture2D(tex, texCoord);
+	if (int(mod(texCoord.s * texSize.x * 6.0, 6.0)) == 5 ||
+		int(mod(texCoord.t * texSize.y * 6.0, 6.0)) == 5)
+	{
+		color.rgb *= vec3(1.0, 1.0, 1.0) * boundBrightness;
+	}
+	gl_FragColor = color;
+}

--- a/res/shaders/customLCD.shader/customLCD-subPixels.fs
+++ b/res/shaders/customLCD.shader/customLCD-subPixels.fs
@@ -1,0 +1,15 @@
+varying vec2 texCoord;
+uniform sampler2D tex;
+uniform vec2 texSize;
+uniform float subPixelDimming;
+
+void main() {
+	vec4 color = texture2D(tex, texCoord);
+	vec3 subPixels[3];
+	float subPixelDimming = 1.0 - subPixelDimming;
+	subPixels[0] = vec3(1.0, subPixelDimming, subPixelDimming);
+	subPixels[1] = vec3(subPixelDimming, 1.0, subPixelDimming);
+	subPixels[2] = vec3(subPixelDimming, subPixelDimming, 1.0);
+	color.rgb *= subPixels[int(mod(texCoord.s * texSize.x * 3.0, 3.0))];
+	gl_FragColor = color;
+}	

--- a/res/shaders/customLCD.shader/manifest.ini
+++ b/res/shaders/customLCD.shader/manifest.ini
@@ -1,0 +1,65 @@
+[shader]
+name=Custom LCD
+author=endrift, Dominus Iniquitatis, EddyHg80
+description=Configurable LCD emulation.
+passes=4
+
+[pass.0]
+fragmentShader=customLCD-brightness.fs
+blend=1
+width=-1
+height=-1
+
+[pass.0.uniform.brightness]
+type=float
+default=1.1
+readableName=Brightness
+
+[pass.1]
+fragmentShader=customLCD-subPixels.fs
+blend=1
+width=-3
+height=-3
+
+[pass.1.uniform.subPixelDimming]
+type=float
+default=0.2
+readableName=Sub pixel dimming
+
+[pass.2]
+fragmentShader=customLCD-pixelBounds.fs
+blend=1
+width=-6
+height=-6
+
+[pass.2.uniform.boundBrightness]
+type=float
+default=0.9
+readableName=Pixel bound brightness
+
+[pass.3]
+fragmentShader=ags001-light.fs
+blend=1
+width=-6
+height=-6
+
+[pass.3.uniform.enable]
+type=int
+default=0
+readableName=Enable AGS-001's pristine light and reflections
+
+[pass.3.uniform.lightBrightness]
+type=float
+default=0.9
+readableName=Light brightness
+
+[pass.3.uniform.reflectionBrightness]
+type=float
+default=0.07
+readableName=Reflection brightness
+
+[pass.3.uniform.reflectionDistance]
+type=float2
+default[0]=0
+default[1]=0.025
+readableName=Reflection offset (x|y)


### PR DESCRIPTION
Hi everybody, I didn't know where to post this so here I am.

Yesterday I got carried over and learned a bit of glsl shaders in order to create my own personal shader, and since I made it totally customizable through the UI I might as well share it.

**End result (default):**
<details>
  <summary>Click to expand</summary>

  ![screen1](https://user-images.githubusercontent.com/9092453/146744245-f81e8780-a8dd-4fbf-b9fd-e879875b38c9.png)
</details>

It is designed to work best at x6 integer resolution or higher (1080p or higher). Now I'll go into details.
Feedback is welcome!

- Pass0: Brightness
Since we are going to remove some colors in order to simulate subpixels I added a brightness boost before anything else
```
varying vec2 texCoord;
uniform sampler2D tex;
uniform float brightness;

void main() {
	vec4 color = texture2D(tex, texCoord);
	color.rgb *= brightness;
	gl_FragColor = color;
}
```
Brightness is a parameter passed through the UI, the default is 1.1.
![image](https://user-images.githubusercontent.com/9092453/146743952-408b27db-87ab-487f-bdf6-2a8d48570247.png)


- Pass1: Subpixels
I basically ~~stole~~ copied endrift's code from the ags001 shader and reworked it to make it configurable through the UI.
```
varying vec2 texCoord;
uniform sampler2D tex;
uniform vec2 texSize;
uniform float subPixelDimming;

void main() {
	vec4 color = texture2D(tex, texCoord);
	vec3 subPixels[3];
	float subPixelDimming = 1.0 - subPixelDimming;
	subPixels[0] = vec3(1.0, subPixelDimming, subPixelDimming);
	subPixels[1] = vec3(subPixelDimming, 1.0, subPixelDimming);
	subPixels[2] = vec3(subPixelDimming, subPixelDimming, 1.0);
	color.rgb *= subPixels[int(mod(texCoord.s * texSize.x * 3.0, 3.0))];
	gl_FragColor = color;
}	
```
![image](https://user-images.githubusercontent.com/9092453/146745295-a41d9093-108d-4c68-b468-6b69474c5ef1.png)

- Pass2: Pixel boundaries
Here I implemented Dominus Iniquitatis' LCD shader code, but insted of working with a 3x3 grid for each pixel it's a 6x6, so the borders are thinner. Also the darkened pixels are the top and right instead of bottom and left.
And again, the borders brightness is configurable in the UI.
```
varying vec2 texCoord;
uniform sampler2D tex;
uniform vec2 texSize;
uniform float boundBrightness;

void main() {
	vec4 color = texture2D(tex, texCoord);
	if (int(mod(texCoord.s * texSize.x * 6.0, 6.0)) == 5 ||
		int(mod(texCoord.t * texSize.y * 6.0, 6.0)) == 5)
	{
		color.rgb *= vec3(1.0, 1.0, 1.0) * boundBrightness;
	}
	gl_FragColor = color;
}
```
![image](https://user-images.githubusercontent.com/9092453/146745790-0789b5ff-6e96-4438-8add-294f9ca20b19.png)


- Pass3: endrift's recreation of light and reflection of the AGS-001 screen (this was actually a joke, but I fell for it so the least I can do is to include it anyway lol)
Yep copy-pasted (since I don't have time to dive in), but I added a flag to enable or disable it in the UI, so it's disabled by default.
```
varying vec2 texCoord;
uniform sampler2D tex;
uniform float reflectionBrightness;
uniform vec2 reflectionDistance;
uniform float lightBrightness;
uniform int enable;

const float speed = 2.0;
const float decay = 2.0;
const float coeff = 2.5;

void main() {
	if(enable==1)
	{
	float sp = pow(speed, lightBrightness);
	float dc = pow(decay, -lightBrightness);
	float s = (sp - dc) / (sp + dc);
	vec2 radius = (texCoord.st - vec2(0.5, 0.5)) * vec2(coeff * s);
	radius = pow(abs(radius), vec2(4.0));
	vec3 bleed = vec3(0.12, 0.14, 0.19);
	bleed += (dot(radius, radius) + vec3(0.02, 0.03, 0.05)) * vec3(0.14, 0.18, 0.2);

	vec4 color = texture2D(tex, texCoord);
	color.rgb += pow(bleed, pow(vec3(lightBrightness), vec3(-0.5)));

	vec4 reflection = texture2D(tex, texCoord - reflectionDistance);
	color.rgb += reflection.rgb * reflectionBrightness;
	color.a = 1.0;
	gl_FragColor = color;
	}
	else
	{	
	vec4 color = texture2D(tex, texCoord);
	gl_FragColor = color;
	}
}
```

![image](https://user-images.githubusercontent.com/9092453/146748720-999e8296-7fea-4c70-9139-e5a7e722ea68.png)
