### PR TITLE
GDB Stub: use only hardware breakpoints regardless of GDB's request

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -487,7 +487,6 @@ static void _setBreakpoint(struct GDBStub* stub, const char* message) {
 	unsigned i = 0;
 	uint32_t address = _readHex(readAddress, &i);
 	readAddress += i + 1;
-	uint32_t kind = _readHex(readAddress, &i);
 
 	struct mBreakpoint breakpoint = {
 		.address = address,
@@ -499,8 +498,6 @@ static void _setBreakpoint(struct GDBStub* stub, const char* message) {
 
 	switch (message[0]) {
 	case '0':
-		ARMDebuggerSetSoftwareBreakpoint(stub->d.platform, address, kind == 2 ? MODE_THUMB : MODE_ARM);
-		break;
 	case '1':
 		stub->d.platform->setBreakpoint(stub->d.platform, &breakpoint);
 		break;


### PR DESCRIPTION
This will always put a hardware breakpoint regardless if GDB sends a software or hardware breakpoint.

The reason for this is simple: software breakpoints can be very unreliable for determining if we are in Thumb or ARM mode. I can even get setups to be able to consistently reproduce this problem (I even get this issue in arm-none-ebai-gdb which is supposed to be more targetted for what we want here). A wrong guess by GDB can be fatal as mgba could add an ARM breakpoint in Thumb code and it just so happen that in Thumb, the first half of the bkpt instruction corresponds to a branch a bit further in the code, atrocities ensures, but usually ends up in SIGILL and mgba SPAMMING errors.

I also don't think we should be letting GDB decide the kind of breakpoints between ARM and Thumb: mgba already has a functional CLI debugger and it doesn't need to care about it as well as GDB getting its guess wrong sometimes. It's also a bit unintuitive to me to have one kind of breakpoint where it MAY burn in fire and the other that will ALWAYS work.

For reference, Dolphin actually does this too, but in their case, they do not even support software breakpoint. I am curious as to why mgba supports it actually, but it seems to me that at least for GDB, it would make more sense to use the type of breakpoint that works no matter what and since mgba is an emulator, it doesn't have any limits on hard breakpoints.

EDIT: just to add, it's actually possible to have GDB request software without the user wanting it for stuff like nexti. The other way to prevent it is to advertise to GDB we ONLY support hardware, but that's practically doing the same thing.