### PR TITLE
GDB Stub: Allow to override GDB's handling of write watchpoints

### DIFF
--- a/include/mgba/internal/debugger/gdb-stub.h
+++ b/include/mgba/internal/debugger/gdb-stub.h
@@ -24,6 +24,12 @@ enum GDBStubAckState {
 	GDB_ACK_OFF
 };
 
+enum GDBWatchpointsBehvaior {
+	GDB_WATCHPOINT_STANDARD_LOGIC = 0,
+	GDB_WATCHPOINT_OVERRIDE_LOGIC,
+	GDB_WATCHPOINT_OVERRIDE_LOGIC_ANY_WRITE,
+};
+
 struct GDBStub {
 	struct mDebugger d;
 
@@ -40,10 +46,12 @@ struct GDBStub {
 
 	bool supportsSwbreak;
 	bool supportsHwbreak;
+
+	enum GDBWatchpointsBehvaior watchpointsBehavior;
 };
 
 void GDBStubCreate(struct GDBStub*);
-bool GDBStubListen(struct GDBStub*, int port, const struct Address* bindAddress);
+bool GDBStubListen(struct GDBStub*, int port, const struct Address* bindAddress, enum GDBWatchpointsBehvaior watchpointsBehavior);
 
 void GDBStubHangup(struct GDBStub*);
 void GDBStubShutdown(struct GDBStub*);

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -53,7 +53,7 @@ struct mDebugger* mDebuggerCreate(enum mDebuggerType type, struct mCore* core) {
 	case DEBUGGER_GDB:
 #ifdef USE_GDB_STUB
 		GDBStubCreate(&debugger->gdb);
-		GDBStubListen(&debugger->gdb, 2345, 0);
+		GDBStubListen(&debugger->gdb, 2345, 0, GDB_WATCHPOINT_STANDARD_LOGIC);
 		break;
 #endif
 	case DEBUGGER_NONE:

--- a/src/platform/qt/GDBController.cpp
+++ b/src/platform/qt/GDBController.cpp
@@ -32,8 +32,12 @@ void GDBController::setBindAddress(const Address& address) {
 	m_bindAddress = address;
 }
 
+void GDBController::setWatchpointsBehavior(int watchpointsBehaviorId) {
+	m_watchpointsBehavior = static_cast<GDBWatchpointsBehvaior>(watchpointsBehaviorId);
+}
+
 void GDBController::listen() {
-	if (GDBStubListen(&m_gdbStub, m_port, &m_bindAddress)) {
+	if (GDBStubListen(&m_gdbStub, m_port, &m_bindAddress, m_watchpointsBehavior)) {
 		if (!isAttached()) {
 			attach();
 		}

--- a/src/platform/qt/GDBController.h
+++ b/src/platform/qt/GDBController.h
@@ -28,6 +28,7 @@ public:
 public slots:
 	void setPort(ushort port);
 	void setBindAddress(const Address&);
+	void setWatchpointsBehavior(int watchpointsBehaviorId);
 	void listen();
 
 signals:
@@ -41,6 +42,7 @@ private:
 
 	ushort m_port = 2345;
 	Address m_bindAddress;
+	enum GDBWatchpointsBehvaior m_watchpointsBehavior = GDB_WATCHPOINT_STANDARD_LOGIC;
 };
 
 }

--- a/src/platform/qt/GDBWindow.cpp
+++ b/src/platform/qt/GDBWindow.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "GDBWindow.h"
 
+#include <QButtonGroup>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -12,6 +13,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QHBoxLayout>
+#include <QRadioButton>
 #include <QVBoxLayout>
 
 #include "GDBController.h"
@@ -46,6 +48,28 @@ GDBWindow::GDBWindow(GDBController* controller, QWidget* parent)
 	m_bindAddressEdit->setMaxLength(15);
 	connect(m_bindAddressEdit, &QLineEdit::textChanged, this, &GDBWindow::bindAddressChanged);
 	settingsGrid->addWidget(m_bindAddressEdit, 1, 1, Qt::AlignLeft);
+
+	QGroupBox* watchpointsSettings = new QGroupBox(tr("Write watchpoints behavior"));
+	mainSegment->addWidget(watchpointsSettings);
+
+	QVBoxLayout* watchpointsSettingsLayout = new QVBoxLayout;
+	watchpointsSettings->setLayout(watchpointsSettingsLayout);
+
+	QButtonGroup* watchpointsButtonGroup = new QButtonGroup(watchpointsSettings);
+	connect(watchpointsButtonGroup, &QButtonGroup::idClicked, controller, &GDBController::setWatchpointsBehavior);
+
+	m_watchpointsStandardRadio = new QRadioButton(tr("Standard GDB"), watchpointsSettings);
+	m_watchpointsStandardRadio->setChecked(true);
+	watchpointsButtonGroup->addButton(m_watchpointsStandardRadio, GDB_WATCHPOINT_STANDARD_LOGIC);
+	watchpointsSettingsLayout->addWidget(m_watchpointsStandardRadio);
+
+	m_watchpointsOverrideLogicRadio = new QRadioButton(tr("Internal change detection"), watchpointsSettings);
+	watchpointsButtonGroup->addButton(m_watchpointsOverrideLogicRadio, GDB_WATCHPOINT_OVERRIDE_LOGIC);
+	watchpointsSettingsLayout->addWidget(m_watchpointsOverrideLogicRadio);
+
+	m_watchpointsOverrideLogicAnyWriteRadio = new QRadioButton(tr("Break on all writes"), watchpointsSettings);
+	watchpointsButtonGroup->addButton(m_watchpointsOverrideLogicAnyWriteRadio, GDB_WATCHPOINT_OVERRIDE_LOGIC_ANY_WRITE);
+	watchpointsSettingsLayout->addWidget(m_watchpointsOverrideLogicAnyWriteRadio);
 
 	QHBoxLayout* buttons = new QHBoxLayout;
 
@@ -92,6 +116,9 @@ void GDBWindow::bindAddressChanged(const QString& bindAddressString) {
 void GDBWindow::started() {
 	m_portEdit->setEnabled(false);
 	m_bindAddressEdit->setEnabled(false);
+	m_watchpointsStandardRadio->setEnabled(false);
+	m_watchpointsOverrideLogicRadio->setEnabled(false);
+	m_watchpointsOverrideLogicAnyWriteRadio->setEnabled(false);
 	m_startStopButton->setText(tr("Stop"));
 	m_breakButton->setEnabled(true);
 	disconnect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &GDBController::listen);
@@ -102,6 +129,9 @@ void GDBWindow::started() {
 void GDBWindow::stopped() {
 	m_portEdit->setEnabled(true);
 	m_bindAddressEdit->setEnabled(true);
+	m_watchpointsStandardRadio->setEnabled(true);
+	m_watchpointsOverrideLogicRadio->setEnabled(true);
+	m_watchpointsOverrideLogicAnyWriteRadio->setEnabled(true);
 	m_startStopButton->setText(tr("Start"));
 	m_breakButton->setEnabled(false);
 	disconnect(m_startStopButton, &QAbstractButton::clicked, m_gdbController, &DebuggerController::detach);

--- a/src/platform/qt/GDBWindow.h
+++ b/src/platform/qt/GDBWindow.h
@@ -9,6 +9,7 @@
 
 class QLineEdit;
 class QPushButton;
+class QRadioButton;
 
 namespace QGBA {
 
@@ -34,6 +35,9 @@ private:
 
 	QLineEdit* m_portEdit;
 	QLineEdit* m_bindAddressEdit;
+	QRadioButton* m_watchpointsStandardRadio;
+	QRadioButton* m_watchpointsOverrideLogicRadio;
+	QRadioButton* m_watchpointsOverrideLogicAnyWriteRadio;
 	QPushButton* m_startStopButton;
 	QPushButton* m_breakButton;
 };


### PR DESCRIPTION
This PR allows to override the GDB's handling of write watchpoints in 2 ways:

- Take control of the GDB's logic that detects if a write watchpoint changed or not as well as prevent a potentially unwanted step into
- The above, but with the addition to also break on nonmodifying watchpoints

The GDB logic part is done by hiding the truth to GDB: we send an S05 instead of a T05watch which forces GDB to stop and not do anything more than that. This can be desired because without this, it's not possible for GDB to know about mgba's savestates which means that say you do a savestate, break on a write watchpoint and then load that state causing the same write, GDB will not be able to detect this and ignore the request to stop (it will just request the inferior to continue). This logic is already properly handled in mgba so we just defer to it instead. Additionally, GDB assumes incorrectly that the break happens ON THE write instructions because normally, it would break there, step into and check if the value changed. mGBA actually breaks on the instruction AFTER so the end result is you end up 2 instructions after. This logic override simply allows us to have GDB not do that so we always end up on the instruction after the write.

For the nonmodifying writes, we simply change the internal type of watchpoint accordingly. This allows to bypass EITHER change logic which is not a feature that GDB supports, but is needed in a lot of reverse engineering cases.

The new options are introduced in the GDB server window, here's a preview of the new window:

![Screenshot from 2022-02-09 20-28-02](https://user-images.githubusercontent.com/8932978/153319613-f7dd57df-74e7-455c-91ef-0aeec5b0bbf3.png)
