### PR TITLE
FFmpeg: Support FFmpeg 5.0

### DIFF
--- a/src/feature/ffmpeg/ffmpeg-decoder.c
+++ b/src/feature/ffmpeg/ffmpeg-decoder.c
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "ffmpeg-decoder.h"
 
+#include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
 
 void FFmpegDecoderInit(struct FFmpegDecoder* decoder) {
@@ -38,7 +39,7 @@ bool FFmpegDecoderOpen(struct FFmpegDecoder* decoder, const char* infile) {
 #else
 		enum AVMediaType type = decoder->context->streams[i]->codec->codec_type;
 #endif
-		struct AVCodec* codec;
+		const struct AVCodec* codec;
 		struct AVCodecContext* context = NULL;
 		if (type == AVMEDIA_TYPE_VIDEO && decoder->videoStream < 0) {
 			decoder->video = avcodec_alloc_context3(NULL);

--- a/src/feature/ffmpeg/ffmpeg-encoder.c
+++ b/src/feature/ffmpeg/ffmpeg-encoder.c
@@ -12,6 +12,9 @@
 
 #include <libavcodec/version.h>
 #include <libavcodec/avcodec.h>
+#if LIBAVCODEC_VERSION_MAJOR >= 58
+#include <libavcodec/bsf.h>
+#endif
 
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
@@ -121,7 +124,7 @@ bool FFmpegEncoderSetAudio(struct FFmpegEncoder* encoder, const char* acodec, un
 		return true;
 	}
 
-	AVCodec* codec = avcodec_find_encoder_by_name(acodec);
+	const AVCodec* codec = avcodec_find_encoder_by_name(acodec);
 	if (!codec) {
 		return false;
 	}
@@ -193,7 +196,7 @@ bool FFmpegEncoderSetVideo(struct FFmpegEncoder* encoder, const char* vcodec, in
 		return true;
 	}
 
-	AVCodec* codec = avcodec_find_encoder_by_name(vcodec);
+	const AVCodec* codec = avcodec_find_encoder_by_name(vcodec);
 	if (!codec) {
 		return false;
 	}
@@ -213,7 +216,7 @@ bool FFmpegEncoderSetVideo(struct FFmpegEncoder* encoder, const char* vcodec, in
 	if (encoder->pixFormat == AV_PIX_FMT_NONE) {
 		return false;
 	}
-	if (vbr < 0 && !av_opt_find(&codec->priv_class, "crf", NULL, 0, 0)) {
+	if (vbr < 0 && !av_opt_find((void*) &codec->priv_class, "crf", NULL, 0, 0)) {
 		return false;
 	}
 	encoder->videoCodec = vcodec;
@@ -223,7 +226,7 @@ bool FFmpegEncoderSetVideo(struct FFmpegEncoder* encoder, const char* vcodec, in
 }
 
 bool FFmpegEncoderSetContainer(struct FFmpegEncoder* encoder, const char* container) {
-	AVOutputFormat* oformat = av_guess_format(container, 0, 0);
+	const AVOutputFormat* oformat = av_guess_format(container, 0, 0);
 	if (!oformat) {
 		return false;
 	}
@@ -241,9 +244,9 @@ void FFmpegEncoderSetLooping(struct FFmpegEncoder* encoder, bool loop) {
 }
 
 bool FFmpegEncoderVerifyContainer(struct FFmpegEncoder* encoder) {
-	AVOutputFormat* oformat = av_guess_format(encoder->containerFormat, 0, 0);
-	AVCodec* acodec = avcodec_find_encoder_by_name(encoder->audioCodec);
-	AVCodec* vcodec = avcodec_find_encoder_by_name(encoder->videoCodec);
+	const AVOutputFormat* oformat = av_guess_format(encoder->containerFormat, 0, 0);
+	const AVCodec* acodec = avcodec_find_encoder_by_name(encoder->audioCodec);
+	const AVCodec* vcodec = avcodec_find_encoder_by_name(encoder->videoCodec);
 	if ((encoder->audioCodec && !acodec) || (encoder->videoCodec && !vcodec) || !oformat || (!acodec && !vcodec)) {
 		return false;
 	}
@@ -257,8 +260,8 @@ bool FFmpegEncoderVerifyContainer(struct FFmpegEncoder* encoder) {
 }
 
 bool FFmpegEncoderOpen(struct FFmpegEncoder* encoder, const char* outfile) {
-	AVCodec* acodec = avcodec_find_encoder_by_name(encoder->audioCodec);
-	AVCodec* vcodec = avcodec_find_encoder_by_name(encoder->videoCodec);
+	const AVCodec* acodec = avcodec_find_encoder_by_name(encoder->audioCodec);
+	const AVCodec* vcodec = avcodec_find_encoder_by_name(encoder->videoCodec);
 	if ((encoder->audioCodec && !acodec) || (encoder->videoCodec && !vcodec) || !FFmpegEncoderVerifyContainer(encoder)) {
 		return false;
 	}
@@ -272,9 +275,9 @@ bool FFmpegEncoderOpen(struct FFmpegEncoder* encoder, const char* outfile) {
 	encoder->currentVideoFrame = 0;
 	encoder->skipResidue = 0;
 
-	AVOutputFormat* oformat = av_guess_format(encoder->containerFormat, 0, 0);
+	const AVOutputFormat* oformat = av_guess_format(encoder->containerFormat, 0, 0);
 #ifndef USE_LIBAV
-	avformat_alloc_output_context2(&encoder->context, oformat, 0, outfile);
+	avformat_alloc_output_context2(&encoder->context, (AVOutputFormat*) oformat, 0, outfile);
 #else
 	encoder->context = avformat_alloc_context();
 	strncpy(encoder->context->filename, outfile, sizeof(encoder->context->filename) - 1);


### PR DESCRIPTION
Hello,

Debian's FFmpeg maintainers reported that mgba fails to compile using the newly released FFmpeg 5.0.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1004768

I have compiled, run `mgba-cinema`, and briefly tested video and GIF encoding with these changes on Debian unstable, with both FFmpeg 4.4 and 5.0.

I'm not sure about all the `const` additions. The FFmpeg 5.0 APIs return `const` pointers, but there are places with both versions where the pointers are passed to functions taking `void *`, which of course causes a new warning. I don't really know what's less bad here; at least `const` makes sure mGBA itself is sane?