### PR TITLE
Clean up rendering of logging grid checkboxes

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCE_FILES
 	AudioProcessor.cpp
 	CheatsModel.cpp
 	CheatsView.cpp
+	CheckBoxDelegate.cpp
 	ConfigController.cpp
 	ColorPicker.cpp
 	CoreManager.cpp

--- a/src/platform/qt/CheckBoxDelegate.cpp
+++ b/src/platform/qt/CheckBoxDelegate.cpp
@@ -16,8 +16,7 @@ CheckBoxDelegate::CheckBoxDelegate(QObject* parent)
 	// initializers only
 }
 
-void CheckBoxDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
-{
+void CheckBoxDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const {
 	QAbstractItemView* view = qobject_cast<QAbstractItemView*>(option.styleObject);
 	if (view && (index.flags() & Qt::ItemIsUserCheckable)) {
 		// Set up style options

--- a/src/platform/qt/CheckBoxDelegate.cpp
+++ b/src/platform/qt/CheckBoxDelegate.cpp
@@ -1,0 +1,50 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "CheckBoxDelegate.h"
+#include <QStyle>
+#include <QAbstractItemView>
+#include <QtDebug>
+
+using namespace QGBA;
+
+CheckBoxDelegate::CheckBoxDelegate(QObject* parent)
+	: QStyledItemDelegate(parent)
+{
+	// initializers only
+}
+
+void CheckBoxDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	QAbstractItemView* view = qobject_cast<QAbstractItemView*>(option.styleObject);
+	if (view && (index.flags() & Qt::ItemIsUserCheckable)) {
+		// Set up style options
+		QStyleOptionViewItem newOption(option);
+		initStyleOption(&newOption, index);
+		if (view->currentIndex() == index && (newOption.state & QStyle::State_HasFocus)) {
+			newOption.state |= QStyle::State_KeyboardFocusChange;
+		}
+		if (newOption.checkState == Qt::PartiallyChecked) {
+			newOption.state |= QStyle::State_NoChange;
+		} else if (newOption.checkState == Qt::Checked) {
+			newOption.state |= QStyle::State_On;
+		} else {
+			newOption.state |= QStyle::State_Off;
+		}
+
+		// Draw background
+		view->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &newOption, painter, view);
+
+		// Draw checkbox
+		int checkWidth = view->style()->pixelMetric(QStyle::PM_IndicatorWidth);
+		int checkHeight = view->style()->pixelMetric(QStyle::PM_IndicatorHeight);
+		int xMargin = (newOption.rect.width() - checkWidth) / 2;
+		int yMargin = (newOption.rect.height() - checkHeight) / 2;
+		newOption.rect.setRect(newOption.rect.left() + xMargin, newOption.rect.top() + yMargin, checkWidth, checkHeight);
+		view->style()->drawPrimitive(QStyle::PE_IndicatorItemViewItemCheck, &newOption, painter, view);
+	} else {
+		QStyledItemDelegate::paint(painter, option, index);
+	}
+}

--- a/src/platform/qt/CheckBoxDelegate.h
+++ b/src/platform/qt/CheckBoxDelegate.h
@@ -9,8 +9,7 @@
 
 namespace QGBA {
 
-class CheckBoxDelegate : public QStyledItemDelegate
-{
+class CheckBoxDelegate : public QStyledItemDelegate {
 public:
 	CheckBoxDelegate(QObject* parent = nullptr);
 

--- a/src/platform/qt/CheckBoxDelegate.h
+++ b/src/platform/qt/CheckBoxDelegate.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include <QStyledItemDelegate>
+
+namespace QGBA {
+
+class CheckBoxDelegate : public QStyledItemDelegate
+{
+public:
+	CheckBoxDelegate(QObject* parent = nullptr);
+
+	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+};
+
+}

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -6,6 +6,7 @@
 #include "SettingsView.h"
 
 #include "AudioProcessor.h"
+#include "CheckBoxDelegate.h"
 #include "ConfigController.h"
 #include "Display.h"
 #include "GBAApp.h"
@@ -355,9 +356,11 @@ SettingsView::SettingsView(ConfigController* controller, InputController* inputC
 	}
 
 	m_ui.loggingView->setModel(&m_logModel);
+	m_ui.loggingView->setItemDelegate(new CheckBoxDelegate(m_ui.loggingView));
 	m_ui.loggingView->setHorizontalHeader(new RotatedHeaderView(Qt::Horizontal));
 	m_ui.loggingView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 	m_ui.loggingView->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+	connect(m_ui.loggingView, SIGNAL(clicked(QModelIndex)), m_ui.loggingView, SLOT(setCurrentIndex(QModelIndex)));
 
 	connect(m_ui.logFileBrowse, &QAbstractButton::pressed, [this] () {
 		QString path = GBAApp::app()->getSaveFileName(this, "Select log file");


### PR DESCRIPTION
> <@endrift> @CodaHighland I just noticed that if you click on the checkbox...box in the logging settings grid, you get this selection frame for the text that isn't present...any idea how to get rid of it? 
> <@endrift> ![image](https://user-images.githubusercontent.com/4741538/154745819-44e5f3c4-af83-4de2-b21c-103accb70257.png)
> <@endrift> you can see it's also taking up space that I don't need to on the right

Qt's item views aren't designed for this specific use case, but they provide accommodations for nonstandard appearances through QAbstractItemDelegate. This PR makes sure that the checkbox is centered within the cell and renders the keyboard focus in a more appropriate manner.

It also makes sure that the keyboard subfocus is updated appropriately, since clicking checkboxes in itemviews doesn't set the current item like clicking the text does.