### PR TITLE
Qt: Toggle to show filename or gamename in library mode

### DIFF
--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -488,6 +488,7 @@ void SettingsView::updateConfig() {
 	saveSetting("gba.forceGbp", m_ui.forceGbp);
 	saveSetting("vbaBugCompat", m_ui.vbaBugCompat);
 	saveSetting("updateAutoCheck", m_ui.updateAutoCheck);
+	saveSetting("showFilenameInLibrary", m_ui.showFilenameInLibrary);
 
 	if (m_ui.audioBufferSize->currentText().toInt() > 8192) {
 		m_ui.audioBufferSize->setCurrentText("8192");
@@ -710,6 +711,7 @@ void SettingsView::reloadConfig() {
 	loadSetting("gba.forceGbp", m_ui.forceGbp);
 	loadSetting("vbaBugCompat", m_ui.vbaBugCompat, true);
 	loadSetting("updateAutoCheck", m_ui.updateAutoCheck);
+	loadSetting("showFilenameInLibrary", m_ui.showFilenameInLibrary);
 
 	m_ui.libraryStyle->setCurrentIndex(loadSetting("libraryStyle").toInt());
 

--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -564,27 +564,34 @@
         </widget>
        </item>
        <item row="4" column="1">
+        <widget class="QCheckBox" name="showFilenameInLibrary">
+         <property name="text">
+          <string>Show filename instead of ROM name in library view</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
         <widget class="QPushButton" name="clearCache">
          <property name="text">
           <string>Clear cache</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="2">
+       <item row="6" column="0" colspan="2">
         <widget class="Line" name="line_8">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QCheckBox" name="allowOpposingDirections">
          <property name="text">
           <string>Allow opposing input directions</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QCheckBox" name="suspendScreensaver">
          <property name="text">
           <string>Suspend screensaver</string>
@@ -594,14 +601,14 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_41">
          <property name="text">
           <string>When inactive:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_21">
          <item>
           <widget class="QCheckBox" name="pauseOnFocusLost">
@@ -619,14 +626,14 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_42">
          <property name="text">
           <string>When minimized:</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_24">
          <item>
           <widget class="QCheckBox" name="pauseOnMinimize">
@@ -644,14 +651,14 @@
          </item>
         </layout>
        </item>
-       <item row="10" column="0" colspan="2">
+       <item row="11" column="0" colspan="2">
         <widget class="Line" name="line_17">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="dynamicTitle">
          <property name="text">
           <string>Dynamically update window title</string>
@@ -661,7 +668,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="showFps">
          <property name="text">
           <string>Show FPS in title bar</string>
@@ -671,7 +678,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QCheckBox" name="showFilename">
          <property name="text">
           <string>Show filename instead of ROM name in title bar</string>
@@ -681,14 +688,14 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0" colspan="2">
+       <item row="15" column="0" colspan="2">
         <widget class="Line" name="line_18">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QCheckBox" name="showOSD">
          <property name="text">
           <string>Show OSD messages</string>
@@ -698,7 +705,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <layout class="QVBoxLayout" name="osdDisplay">
          <property name="leftMargin">
           <number>20</number>
@@ -719,21 +726,21 @@
          </item>
         </layout>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <widget class="QCheckBox" name="useDiscordPresence">
          <property name="text">
           <string>Enable Discord Rich Presence</string>
          </property>
         </widget>
        </item>
-       <item row="18" column="0" colspan="2">
+       <item row="19" column="0" colspan="2">
         <widget class="Line" name="line_13">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="19" column="1">
+       <item row="20" column="1">
         <widget class="QCheckBox" name="autosave">
          <property name="text">
           <string>Automatically save state</string>
@@ -743,7 +750,7 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="1">
+       <item row="21" column="1">
         <widget class="QCheckBox" name="autoload">
          <property name="text">
           <string>Automatically load state</string>
@@ -753,14 +760,14 @@
          </property>
         </widget>
        </item>
-       <item row="21" column="0" colspan="2">
+       <item row="22" column="0" colspan="2">
         <widget class="Line" name="line_16">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="22" column="1">
+       <item row="23" column="1">
         <widget class="QCheckBox" name="cheatAutosave">
          <property name="text">
           <string>Automatically save cheats</string>
@@ -770,7 +777,7 @@
          </property>
         </widget>
        </item>
-       <item row="23" column="1">
+       <item row="24" column="1">
         <widget class="QCheckBox" name="cheatAutoload">
          <property name="text">
           <string>Automatically load cheats</string>
@@ -2369,7 +2376,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="gbColors"/>
   <buttongroup name="multiplayerAudio"/>
+  <buttongroup name="gbColors"/>
  </buttongroups>
 </ui>

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -123,6 +123,12 @@ Window::Window(CoreManager* manager, ConfigController* config, int playerId, QWi
 		}
 	}, this);
 	m_config->updateOption("showLibrary");
+
+	ConfigOption* showFilenameInLibrary = m_config->addOption("showFilenameInLibrary");
+	showFilenameInLibrary->connect([this](const QVariant& value) {
+			m_libraryView->setShowFilename(value.toBool());
+	}, this); 
+    m_config->updateOption("showFilenameInLibrary");
 	ConfigOption* libraryStyle = m_config->addOption("libraryStyle");
 	libraryStyle->connect([this](const QVariant& value) {
 		m_libraryView->setViewStyle(static_cast<LibraryStyle>(value.toInt()));

--- a/src/platform/qt/library/LibraryController.cpp
+++ b/src/platform/qt/library/LibraryController.cpp
@@ -37,6 +37,9 @@ void AbstractGameList::updateEntry(const LibraryEntry& item) {
 void AbstractGameList::removeEntry(const QString& item) {
 	removeEntries({item});
 }
+void AbstractGameList::setShowFilename(bool showFilename) {
+	m_showFilename = showFilename;
+}
 
 LibraryController::LibraryController(QWidget* parent, const QString& path, ConfigController* config)
 	: QStackedWidget(parent)
@@ -209,4 +212,17 @@ void LibraryController::loadDirectory(const QString& dir, bool recursive) {
 	qint64 libraryJob = m_libraryJob;
 	mLibraryLoadDirectory(library.get(), dir.toUtf8().constData(), recursive);
 	m_libraryJob.testAndSetOrdered(libraryJob, -1);
+}
+void LibraryController::setShowFilename(bool showFilename) {
+	if (showFilename == m_showFilename) {
+		return;
+	}
+	m_showFilename = showFilename;
+	if (m_libraryGrid) {
+		m_libraryGrid->setShowFilename(m_showFilename);
+	}
+	if (m_libraryTree) {
+		m_libraryTree->setShowFilename(m_showFilename);
+	}
+	refresh();
 }

--- a/src/platform/qt/library/LibraryController.h
+++ b/src/platform/qt/library/LibraryController.h
@@ -65,8 +65,12 @@ public:
 	virtual void addEntry(const LibraryEntry&);
 	virtual void updateEntry(const LibraryEntry&);
 	virtual void removeEntry(const QString&);
+	virtual void setShowFilename(bool showFilename);
 
 	virtual QWidget* widget() = 0;
+
+protected:
+	bool m_showFilename = false;
 };
 
 class LibraryController final : public QStackedWidget {
@@ -79,6 +83,7 @@ public:
 
 	LibraryStyle viewStyle() const { return m_currentStyle; }
 	void setViewStyle(LibraryStyle newStyle);
+	void setShowFilename(bool showFilename);
 
 	void selectEntry(const QString& fullpath);
 	LibraryEntry selectedEntry();
@@ -112,6 +117,7 @@ private:
 
 	std::unique_ptr<LibraryGrid> m_libraryGrid;
 	std::unique_ptr<LibraryTree> m_libraryTree;
+	bool m_showFilename = false;
 };
 
 }

--- a/src/platform/qt/library/LibraryGrid.cpp
+++ b/src/platform/qt/library/LibraryGrid.cpp
@@ -69,8 +69,7 @@ void LibraryGrid::addEntry(const LibraryEntry& item) {
 	}
 
 	QListWidgetItem* i = new QListWidgetItem;
-	i->setText(item.displayTitle());
-
+	i->setText(m_showFilename ? item.filename : item.displayTitle());
 	m_widget->addItem(i);
 	m_items.insert(item.fullpath, i);
 }
@@ -83,7 +82,7 @@ void LibraryGrid::updateEntries(const QList<LibraryEntry>& items) {
 
 void LibraryGrid::updateEntry(const LibraryEntry& item) {
 	QListWidgetItem* i = m_items.value(item.fullpath);
-	i->setText(item.displayTitle());
+	i->setText(m_showFilename ? item.filename : item.displayTitle());
 }
 
 void LibraryGrid::removeEntries(const QList<QString>& items) {

--- a/src/platform/qt/library/LibraryTree.cpp
+++ b/src/platform/qt/library/LibraryTree.cpp
@@ -140,7 +140,7 @@ void LibraryTree::updateEntry(const LibraryEntry& item) {
 	m_entries[item.fullpath] = item;
 
 	LibraryTreeItem* i = static_cast<LibraryTreeItem*>(m_items.value(item.fullpath));
-	i->setText(COL_NAME, item.displayTitle());
+	i->setText(COL_NAME, m_showFilename ? item.filename : item.displayTitle());
 	i->setText(COL_PLATFORM, nicePlatformFormat(item.platform));
 	i->setFilesize(item.filesize);
 	i->setText(COL_CRC32, QString("%0").arg(item.crc32, 8, 16, QChar('0')));


### PR DESCRIPTION
The following PR implements the requested feature in #2415 .
It adds a new checkbox `Show Filename instead of ROM name in library view` in the Settings page, under Interface:

![Screenshot_20220326_222632](https://user-images.githubusercontent.com/1557903/160262764-c94e8d15-65e3-41a3-9c43-9acba420e736.png)

Smoke tested in manjaro linux with QT 5.15.3
- Verified the option defaults to false.
- Verified the option saves and loads correctly
- Verified that the names change as expected depending on the state of the checkbox.