### PR TITLE
Scripting: Change behaviour related to absolute and relative paths.

### DIFF
--- a/src/script/engines/lua.c
+++ b/src/script/engines/lua.c
@@ -476,24 +476,24 @@ bool _luaLoad(struct mScriptEngineContext* ctx, const char* filename, struct VFi
 		free(luaContext->lastError);
 		luaContext->lastError = NULL;
 	}
-	char name[80];
 	if (filename) {
+		char name[strlen(filename) + 2];
 		if (*filename == '*') {
 			snprintf(name, sizeof(name), "=%s", filename + 1);
 		} else {
-			const char* lastSlash = strrchr(filename, '/');
-			const char* lastBackslash = strrchr(filename, '\\');
-			if (lastSlash && lastBackslash) {
-				if (lastSlash > lastBackslash) {
-					filename = lastSlash + 1;
-				} else {
-					filename = lastBackslash + 1;
-				}
-			} else if (lastSlash) {
-				filename = lastSlash + 1;
-			} else if (lastBackslash) {
-				filename = lastBackslash + 1;
+			char  dir[strlen(filename)];
+			char *slash, *backslash;
+			strcpy(dir, filename);
+			slash = strrchr(dir, '/');
+			backslash = strrchr(dir, '\\');
+			if (!slash || (backslash && backslash < slash)) {
+				slash = backslash;
 			}
+			if (slash) {
+				slash[1] = '\0'; // keep slash itself for some reasons
+				chdir(dir);
+			}
+
 			snprintf(name, sizeof(name), "@%s", filename);
 		}
 		filename = name;


### PR DESCRIPTION
I added the following changes related to file management on Lua Scripts:

1. Deleted the code which removes the absolute path from the filename. This is because LUA saves which file is running each function, and with that you can do the following in order to get the folder containing the file which is currently running:
path_of_running_file = debug.getinfo(1, "S").source:sub(2):match("(.*[/\\])")

And if the emulator only gives the LUA Engine the filename, this code returns nil.
I looked into other ways to get the path of running script, but all I've found is related to DLL modules, and this change simplifies this task.


2. Added some lines extracted from VBA-Rerecording and modified them in order to make them compatible with all OS (not Windows only). change the working folder to the folder containing the running LUA Script. This allows the LUA engine to look into the running script's folder for other scripts or modules if the current script requires them. Without this change, all .lua files must be stored in mGBA's lua folder, and the DLLs in mGBA's own folder.
