### PR TITLE
Don't crash when resetting scripting UI

### DIFF
--- a/src/platform/qt/ScriptingView.cpp
+++ b/src/platform/qt/ScriptingView.cpp
@@ -66,14 +66,22 @@ void ScriptingView::addTextBuffer(ScriptingTextBuffer* buffer) {
 	});
 	connect(buffer, &QObject::destroyed, this, [this, buffer, item]() {
 		m_textBuffers.removeAll(buffer);
-		m_ui.buffers->removeItemWidget(item);
+		delete item;
 	});
 	m_ui.buffers->addItem(item);
 	m_ui.buffers->setCurrentItem(item);
 }
 
 void ScriptingView::selectBuffer(int index) {
-	m_ui.buffer->setDocument(m_textBuffers[index]->document());
+	if (index < 0 || index >= m_textBuffers.size()) {
+		// If the selected buffer is out of bounds, use a dummy buffer.
+		// This will be automatically deleted when a different document is set.
+		QTextDocument* dummy = new QTextDocument(m_ui.buffer);
+		dummy->setDocumentLayout(new QPlainTextDocumentLayout(dummy));
+		m_ui.buffer->setDocument(dummy);
+	} else {
+		m_ui.buffer->setDocument(m_textBuffers[index]->document());
+	}
 }
 
 QString ScriptingView::getFilters() const {

--- a/src/platform/qt/ScriptingView.cpp
+++ b/src/platform/qt/ScriptingView.cpp
@@ -74,11 +74,8 @@ void ScriptingView::addTextBuffer(ScriptingTextBuffer* buffer) {
 
 void ScriptingView::selectBuffer(int index) {
 	if (index < 0 || index >= m_textBuffers.size()) {
-		// If the selected buffer is out of bounds, use a dummy buffer.
-		// This will be automatically deleted when a different document is set.
-		QTextDocument* dummy = new QTextDocument(m_ui.buffer);
-		dummy->setDocumentLayout(new QPlainTextDocumentLayout(dummy));
-		m_ui.buffer->setDocument(dummy);
+		// If the selected buffer is out of bounds, clear the document.
+		m_ui.buffer->setDocument(nullptr);
 	} else {
 		m_ui.buffer->setDocument(m_textBuffers[index]->document());
 	}


### PR DESCRIPTION
By creating a buffer in the scripting console, then resetting the scripting state, then creating another buffer, the list in the UI gets out of sync with the list of buffers. This fixes that.