### PR TITLE
clear buffer list in UI before deleting buffers

### DIFF
--- a/src/platform/qt/ScriptingController.cpp
+++ b/src/platform/qt/ScriptingController.cpp
@@ -86,6 +86,7 @@ void ScriptingController::clearController() {
 }
 
 void ScriptingController::reset() {
+	emit aboutToReset();
 	CoreController::Interrupter interrupter(m_controller);
 	for (ScriptingTextBuffer* buffer : m_buffers) {
 		delete buffer;

--- a/src/platform/qt/ScriptingController.h
+++ b/src/platform/qt/ScriptingController.h
@@ -36,6 +36,7 @@ public:
 	QList<ScriptingTextBuffer*> textBuffers() { return m_buffers; }
 
 signals:
+	void aboutToReset();
 	void log(const QString&);
 	void warn(const QString&);
 	void error(const QString&);

--- a/src/platform/qt/ScriptingView.h
+++ b/src/platform/qt/ScriptingView.h
@@ -25,6 +25,7 @@ private slots:
 
 	void addTextBuffer(ScriptingTextBuffer*);
 	void selectBuffer(int);
+	void controllerReset();
 
 private:
 	QString getFilters() const;
@@ -38,6 +39,7 @@ private:
 	ScriptingController* m_controller;
 	QList<ScriptingTextBuffer*> m_textBuffers;
 	QStringList m_mruFiles;
+	QTextDocument* m_blankDocument;
 };
 
 }


### PR DESCRIPTION
Resetting the scripting state crashes mGBA. This PR does the minimum necessary to make it not do that by clearing out the list of buffers in the UI before deleting any data structures.

This PR is mutually exclusive with https://github.com/mgba-emu/mgba/pull/2566 as both solve the same issue in different ways.