### PR TITLE
refactor the script buffer list into a model

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -252,6 +252,7 @@ if(ENABLE_SCRIPTING)
 	list(APPEND SOURCE_FILES
 		ScriptingController.cpp
 		ScriptingTextBuffer.cpp
+		ScriptingTextBufferModel.cpp
 		ScriptingView.cpp)
 
 	list(APPEND UI_FILES

--- a/src/platform/qt/ScriptingController.cpp
+++ b/src/platform/qt/ScriptingController.cpp
@@ -7,7 +7,6 @@
 
 #include "CoreController.h"
 #include "ScriptingTextBuffer.h"
-class QTextDocument;
 
 using namespace QGBA;
 

--- a/src/platform/qt/ScriptingController.cpp
+++ b/src/platform/qt/ScriptingController.cpp
@@ -113,7 +113,7 @@ void ScriptingController::init() {
 	mScriptContextRegisterEngines(&m_scriptContext);
 
 	mScriptContextAttachLogger(&m_scriptContext, &m_logger);
-	mScriptContextSetTextBufferFactory(&m_scriptContext, &ScriptingTextBufferModel::createTextBuffer, m_bufferModel);
+	m_bufferModel->attachToContext(&m_scriptContext);
 
 	HashTableEnumerate(&m_scriptContext.engines, [](const char* key, void* engine, void* context) {
 	ScriptingController* self = static_cast<ScriptingController*>(context);

--- a/src/platform/qt/ScriptingController.h
+++ b/src/platform/qt/ScriptingController.h
@@ -21,15 +21,12 @@ namespace QGBA {
 
 class CoreController;
 class ScriptingTextBuffer;
+class ScriptingTextBufferModel;
 
-class ScriptingController : public QAbstractListModel {
+class ScriptingController : public QObject {
 Q_OBJECT
 
 public:
-	enum ItemDataRole {
-		DocumentRole = Qt::UserRole + 1,
-	};
-
 	ScriptingController(QObject* parent = nullptr);
 	~ScriptingController();
 
@@ -39,10 +36,7 @@ public:
 	bool load(VFileDevice& vf, const QString& name);
 
 	mScriptContext* context() { return &m_scriptContext; }
-	QList<ScriptingTextBuffer*> textBuffers() { return m_buffers; }
-
-	int rowCount(const QModelIndex& parent = QModelIndex()) const;
-	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+	ScriptingTextBufferModel* textBufferModel() const { return m_bufferModel; }
 
 signals:
 	void log(const QString&);
@@ -54,9 +48,6 @@ public slots:
 	void clearController();
 	void reset();
 	void runCode(const QString& code);
-
-private slots:
-	void bufferNameChanged(const QString&);
 
 private:
 	void init();
@@ -71,7 +62,7 @@ private:
 
 	mScriptEngineContext* m_activeEngine = nullptr;
 	QHash<QString, mScriptEngineContext*> m_engines;
-	QList<ScriptingTextBuffer*> m_buffers;
+	ScriptingTextBufferModel* m_bufferModel;
 
 	std::shared_ptr<CoreController> m_controller;
 };

--- a/src/platform/qt/ScriptingController.h
+++ b/src/platform/qt/ScriptingController.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <QHash>
-#include <QAbstractListModel>
+#include <QObject>
 
 #include <mgba/script/context.h>
 #include <mgba/core/scripting.h>

--- a/src/platform/qt/ScriptingController.h
+++ b/src/platform/qt/ScriptingController.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <QHash>
-#include <QObject>
+#include <QAbstractListModel>
 
 #include <mgba/script/context.h>
 #include <mgba/core/scripting.h>
@@ -20,10 +20,14 @@ namespace QGBA {
 class CoreController;
 class ScriptingTextBuffer;
 
-class ScriptingController : public QObject {
+class ScriptingController : public QAbstractListModel {
 Q_OBJECT
 
 public:
+	enum ItemDataRole {
+		DocumentRole = Qt::UserRole + 1,
+	};
+
 	ScriptingController(QObject* parent = nullptr);
 	~ScriptingController();
 
@@ -35,6 +39,9 @@ public:
 	mScriptContext* context() { return &m_scriptContext; }
 	QList<ScriptingTextBuffer*> textBuffers() { return m_buffers; }
 
+	int rowCount(const QModelIndex& parent = QModelIndex()) const;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+
 signals:
 	void log(const QString&);
 	void warn(const QString&);
@@ -45,6 +52,9 @@ public slots:
 	void clearController();
 	void reset();
 	void runCode(const QString& code);
+
+private slots:
+	void bufferNameChanged(const QString&);
 
 private:
 	void init();

--- a/src/platform/qt/ScriptingController.h
+++ b/src/platform/qt/ScriptingController.h
@@ -15,6 +15,8 @@
 
 #include <memory>
 
+class QTextDocument;
+
 namespace QGBA {
 
 class CoreController;

--- a/src/platform/qt/ScriptingTextBuffer.h
+++ b/src/platform/qt/ScriptingTextBuffer.h
@@ -47,12 +47,12 @@ private:
 	static void deinit(struct mScriptTextBuffer*);
 
 	static void setName(struct mScriptTextBuffer*, const char* name);
- 
+
 	static uint32_t getX(const struct mScriptTextBuffer*);
 	static uint32_t getY(const struct mScriptTextBuffer*);
 	static uint32_t cols(const struct mScriptTextBuffer*);
 	static uint32_t rows(const struct mScriptTextBuffer*);
- 
+
 	static void print(struct mScriptTextBuffer*, const char* text);
 	static void clear(struct mScriptTextBuffer*);
 	static void setSize(struct mScriptTextBuffer*, uint32_t cols, uint32_t rows);

--- a/src/platform/qt/ScriptingTextBufferModel.cpp
+++ b/src/platform/qt/ScriptingTextBufferModel.cpp
@@ -1,0 +1,68 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "ScriptingTextBufferModel.h"
+
+#include "ScriptingTextBuffer.h"
+
+#include <QTextDocument>
+
+using namespace QGBA;
+
+ScriptingTextBufferModel::ScriptingTextBufferModel(QObject* parent)
+	: QAbstractListModel(parent)
+{
+	// initializers only
+}
+
+void ScriptingTextBufferModel::reset() {
+	beginResetModel();
+	QList<ScriptingTextBuffer*> toDelete = m_buffers;
+	m_buffers.clear();
+	endResetModel();
+	for (ScriptingTextBuffer* buffer : toDelete) {
+		delete buffer;
+	}
+}
+
+mScriptTextBuffer* ScriptingTextBufferModel::createTextBuffer(void* context) {
+	ScriptingTextBufferModel* self = static_cast<ScriptingTextBufferModel*>(context);
+	self->beginInsertRows(QModelIndex(), self->m_buffers.size(), self->m_buffers.size() + 1);
+	ScriptingTextBuffer* buffer = new ScriptingTextBuffer(self);
+	QObject::connect(buffer, &ScriptingTextBuffer::bufferNameChanged, self, &ScriptingTextBufferModel::bufferNameChanged);
+	self->m_buffers.append(buffer);
+	emit self->textBufferCreated(buffer);
+	self->endInsertRows();
+	return buffer->textBuffer();
+}
+
+void ScriptingTextBufferModel::bufferNameChanged(const QString&) {
+	ScriptingTextBuffer* buffer = qobject_cast<ScriptingTextBuffer*>(sender());
+	int row = m_buffers.indexOf(buffer);
+	if (row < 0) {
+		return;
+	}
+	QModelIndex idx = index(row, 0);
+	emit dataChanged(idx, idx, { Qt::DisplayRole });
+}
+
+int ScriptingTextBufferModel::rowCount(const QModelIndex& parent) const {
+	if (parent.isValid()) {
+		return 0;
+	}
+	return m_buffers.size();
+}
+
+QVariant ScriptingTextBufferModel::data(const QModelIndex& index, int role) const {
+	if (index.parent().isValid() || index.row() < 0 || index.row() >= m_buffers.size() || index.column() != 0) {
+		return QVariant();
+	}
+	if (role == Qt::DisplayRole) {
+		return m_buffers[index.row()]->document()->metaInformation(QTextDocument::DocumentTitle);
+	} else if (role == ScriptingTextBufferModel::DocumentRole) {
+		return QVariant::fromValue<QTextDocument*>(m_buffers[index.row()]->document());
+	}
+	return QVariant();
+}

--- a/src/platform/qt/ScriptingTextBufferModel.cpp
+++ b/src/platform/qt/ScriptingTextBufferModel.cpp
@@ -17,6 +17,11 @@ ScriptingTextBufferModel::ScriptingTextBufferModel(QObject* parent)
 	// initializers only
 }
 
+void ScriptingTextBufferModel::attachToContext(mScriptContext* context)
+{
+	mScriptContextSetTextBufferFactory(context, &ScriptingTextBufferModel::createTextBuffer, this);
+}
+
 void ScriptingTextBufferModel::reset() {
 	beginResetModel();
 	QList<ScriptingTextBuffer*> toDelete = m_buffers;

--- a/src/platform/qt/ScriptingTextBufferModel.h
+++ b/src/platform/qt/ScriptingTextBufferModel.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include <QAbstractListModel>
+
+class mScriptTextBuffer;
+
+namespace QGBA {
+
+class ScriptingTextBuffer;
+
+class ScriptingTextBufferModel : public QAbstractListModel {
+Q_OBJECT
+friend class ScriptingController;
+
+public:
+	enum ItemDataRole {
+		DocumentRole = Qt::UserRole + 1,
+	};
+
+	ScriptingTextBufferModel(QObject* parent = nullptr);
+
+	int rowCount(const QModelIndex& parent = QModelIndex()) const;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+
+signals:
+	void textBufferCreated(ScriptingTextBuffer*);
+
+public slots:
+	void reset();
+
+private slots:
+	void bufferNameChanged(const QString&);
+
+private:
+	static mScriptTextBuffer* createTextBuffer(void* context);
+
+	QList<ScriptingTextBuffer*> m_buffers;
+};
+
+}

--- a/src/platform/qt/ScriptingTextBufferModel.h
+++ b/src/platform/qt/ScriptingTextBufferModel.h
@@ -7,6 +7,8 @@
 
 #include <QAbstractListModel>
 
+#include <mgba/script/context.h>
+
 class mScriptTextBuffer;
 
 namespace QGBA {
@@ -15,7 +17,6 @@ class ScriptingTextBuffer;
 
 class ScriptingTextBufferModel : public QAbstractListModel {
 Q_OBJECT
-friend class ScriptingController;
 
 public:
 	enum ItemDataRole {
@@ -23,6 +24,8 @@ public:
 	};
 
 	ScriptingTextBufferModel(QObject* parent = nullptr);
+
+	void attachToContext(mScriptContext* context);
 
 	int rowCount(const QModelIndex& parent = QModelIndex()) const;
 	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;

--- a/src/platform/qt/ScriptingView.cpp
+++ b/src/platform/qt/ScriptingView.cpp
@@ -9,7 +9,6 @@
 #include "ConfigController.h"
 #include "ScriptingController.h"
 #include "ScriptingTextBuffer.h"
-#include <QtDebug>
 
 using namespace QGBA;
 

--- a/src/platform/qt/ScriptingView.cpp
+++ b/src/platform/qt/ScriptingView.cpp
@@ -26,7 +26,9 @@ ScriptingView::ScriptingView(ScriptingController* controller, ConfigController* 
 	connect(m_ui.prompt, &QLineEdit::returnPressed, this, &ScriptingView::submitRepl);
 	connect(m_ui.runButton, &QAbstractButton::clicked, this, &ScriptingView::submitRepl);
 	connect(m_controller, &ScriptingController::modelAboutToBeReset, this, &ScriptingView::controllerReset);
-	connect(m_controller, &ScriptingController::rowsInserted, this, &ScriptingView::bufferAdded);
+	connect(m_controller, &ScriptingController::rowsInserted, this, [this](const QModelIndex&, int row, int) {
+		m_ui.buffers->setCurrentIndex(m_controller->index(row, 0));
+	});
 	connect(m_controller, &ScriptingController::log, m_ui.log, &LogWidget::log);
 	connect(m_controller, &ScriptingController::warn, m_ui.log, &LogWidget::warn);
 	connect(m_controller, &ScriptingController::error, m_ui.log, &LogWidget::error);
@@ -62,10 +64,6 @@ void ScriptingView::load() {
 
 void ScriptingView::controllerReset() {
 	selectBuffer(QModelIndex());
-}
-
-void ScriptingView::bufferAdded(const QModelIndex&, int row, int) {
-	m_ui.buffers->setCurrentIndex(m_controller->index(row, 0));
 }
 
 void ScriptingView::selectBuffer(const QModelIndex& current, const QModelIndex&) {

--- a/src/platform/qt/ScriptingView.h
+++ b/src/platform/qt/ScriptingView.h
@@ -23,8 +23,9 @@ private slots:
 	void submitRepl();
 	void load();
 
-	void addTextBuffer(ScriptingTextBuffer*);
-	void selectBuffer(int);
+	void controllerReset();
+	void selectBuffer(const QModelIndex& current, const QModelIndex& = QModelIndex());
+	void bufferAdded(const QModelIndex&, int row, int);
 
 private:
 	QString getFilters() const;
@@ -36,8 +37,8 @@ private:
 
 	ConfigController* m_config;
 	ScriptingController* m_controller;
-	QList<ScriptingTextBuffer*> m_textBuffers;
 	QStringList m_mruFiles;
+	QTextDocument* m_blankDocument;
 };
 
 }

--- a/src/platform/qt/ScriptingView.h
+++ b/src/platform/qt/ScriptingView.h
@@ -25,7 +25,6 @@ private slots:
 
 	void controllerReset();
 	void selectBuffer(const QModelIndex& current, const QModelIndex& = QModelIndex());
-	void bufferAdded(const QModelIndex&, int row, int);
 
 private:
 	QString getFilters() const;

--- a/src/platform/qt/ScriptingView.ui
+++ b/src/platform/qt/ScriptingView.ui
@@ -16,7 +16,7 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
     <item row="0" column="0" rowspan="3">
-     <widget class="QListWidget" name="buffers">
+     <widget class="QListView" name="buffers">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
         <horstretch>0</horstretch>


### PR DESCRIPTION
Resetting the scripting state crashes mGBA. This PR refactors the way the UI keeps track of the list of buffers by using a list model instead of a QListWidget, enabling the use of standard Qt MVC signals to avoid conflicts.

This PR is mutually exclusive with https://github.com/mgba-emu/mgba/pull/2565 as both solve the same issue in different ways.