### PR TITLE
doc: Updated the Docker Run command on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The recommended way to build for most platforms is to use Docker. Several Docker
 
 To use a Docker image to build mGBA, simply run the following command while in the root of an mGBA checkout:
 
-	docker run --rm -t -v $PWD:/home/mgba/src mgba/windows:w32
+	docker run --rm -t -v ${PWD}:/home/mgba/src mgba/windows:w32
 
 This will produce a `build-win32` directory with the build products. Replace `mgba/windows:w32` with another Docker image for other platforms, which will produce a corresponding other directory. The following Docker images available on Docker Hub:
 


### PR DESCRIPTION
Powershell dictates the requirement where automatic variables need to be wrapped around with curly brackets ({}). This is referenced from the documentation here, as quoted below:  https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_variables?view=powershell-7.2

"To create or display a variable name that includes spaces or special characters, enclose the variable name with the curly braces ({}) characters. The curly braces direct PowerShell to interpret the variable name's characters as literals. For example, the following command creates the variable named 'save-items'. The curly braces ({}) are needed because variable name includes a hyphen (-) special character."