### PR TITLE
Script bindings for sockets

### DIFF
--- a/include/mgba/core/scripting.h
+++ b/include/mgba/core/scripting.h
@@ -10,14 +10,11 @@
 
 CXX_GUARD_START
 
-#include <mgba/core/log.h>
 #ifdef USE_DEBUGGERS
 #include <mgba/debugger/debugger.h>
 #endif
 #include <mgba/script/macros.h>
 #include <mgba/script/types.h>
-
-mLOG_DECLARE_CATEGORY(SCRIPT);
 
 struct mCore;
 struct mScriptTextBuffer;

--- a/include/mgba/internal/script/socket.h
+++ b/include/mgba/internal/script/socket.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef M_SCRIPT_SOCKET_H
+#define M_SCRIPT_SOCKET_H
+
+enum mSocketErrorCode {
+	mSCRIPT_SOCKERR_UNKNOWN_ERROR = -1,
+	mSCRIPT_SOCKERR_OK = 0,
+	mSCRIPT_SOCKERR_AGAIN,
+	mSCRIPT_SOCKERR_ADDRESS_IN_USE,
+	mSCRIPT_SOCKERR_CONNECTION_REFUSED,
+	mSCRIPT_SOCKERR_DENIED,
+	mSCRIPT_SOCKERR_FAILED,
+	mSCRIPT_SOCKERR_NETWORK_UNREACHABLE,
+	mSCRIPT_SOCKERR_NOT_FOUND,
+	mSCRIPT_SOCKERR_NO_DATA,
+	mSCRIPT_SOCKERR_OUT_OF_MEMORY,
+	mSCRIPT_SOCKERR_TIMEOUT,
+	mSCRIPT_SOCKERR_UNSUPPORTED,
+};
+
+#endif

--- a/include/mgba/script/context.h
+++ b/include/mgba/script/context.h
@@ -10,6 +10,7 @@
 
 CXX_GUARD_START
 
+#include <mgba/core/log.h>
 #include <mgba/script/types.h>
 #include <mgba-util/table.h>
 #include <mgba-util/vfs.h>
@@ -17,6 +18,8 @@ CXX_GUARD_START
 #define mSCRIPT_KV_PAIR(KEY, VALUE) { #KEY, VALUE }
 #define mSCRIPT_CONSTANT_PAIR(NS, CONST) { #CONST, mScriptValueCreateFromSInt(NS ## _ ## CONST) }
 #define mSCRIPT_KV_SENTINEL { NULL, NULL }
+
+mLOG_DECLARE_CATEGORY(SCRIPT);
 
 struct mScriptFrame;
 struct mScriptFunction;
@@ -83,6 +86,7 @@ struct mScriptValue* mScriptContextAccessWeakref(struct mScriptContext*, struct 
 void mScriptContextClearWeakref(struct mScriptContext*, uint32_t weakref);
 
 void mScriptContextAttachStdlib(struct mScriptContext* context);
+void mScriptContextAttachSocket(struct mScriptContext* context);
 void mScriptContextExportConstants(struct mScriptContext* context, const char* nspace, struct mScriptKVPair* constants);
 void mScriptContextExportNamespace(struct mScriptContext* context, const char* nspace, struct mScriptKVPair* value);
 

--- a/res/scripts/socketserver.lua
+++ b/res/scripts/socketserver.lua
@@ -1,0 +1,103 @@
+lastkeys = nil
+server = nil
+ST_sockets = {}
+nextID = 1
+
+local KEY_NAMES = { "A", "B", "s", "S", "<", ">", "^", "v", "R", "L" }
+
+function ST_stop(id)
+	local sock = ST_sockets[id]
+	ST_sockets[id] = nil
+	sock:close()
+end
+
+function ST_format(id, msg, isError)
+	local prefix = "Socket " .. id
+	if isError then
+		prefix = prefix .. " Error: "
+	else
+		prefix = prefix .. " Received: "
+	end
+	return prefix .. msg
+end
+
+function ST_error(id, err)
+	console:error(ST_format(id, err, true))
+	ST_stop(id)
+end
+
+function ST_received(id)
+	local sock = ST_sockets[id]
+	if not sock then return end
+	while true do
+		local p, err = sock:receive(1024)
+		if p then
+			console:log(ST_format(id, p:match("^(.-)%s*$")))
+		else
+			if err ~= socket.ERRORS.AGAIN then
+				console:error(ST_format(id, err, true))
+				ST_stop(id)
+			end
+			return
+		end
+	end
+end
+
+function ST_scankeys()
+	local keys = emu:getKeys()
+	if keys ~= lastkeys then
+		lastkeys = keys
+		local msg = "["
+		for i, k in ipairs(KEY_NAMES) do
+			if (keys & (1 << (i - 1))) == 0 then
+				msg = msg .. " "
+			else
+				msg = msg .. k;
+			end
+		end
+		msg = msg .. "]\n"
+		for id, sock in pairs(ST_sockets) do
+			if sock then sock:send(msg) end
+		end
+	end
+end
+
+function ST_accept()
+	local sock, err = server:accept()
+	if err then
+		console:error(ST_format("Accept", err, true))
+		return
+	end
+	local id = nextID
+	nextID = id + 1
+	ST_sockets[id] = sock
+	sock:add("received", function() ST_received(id) end)
+	sock:add("error", function() ST_error(id) end)
+	console:log(ST_format(id, "Connected"))
+end
+
+callbacks:add("keysRead", ST_scankeys)
+
+local port = 8888
+server = nil
+while not server do
+	server, err = socket.bind(nil, port)
+	if err then
+		if err == "address in use" then
+			port = port + 1
+		else
+			console:error(ST_format("Bind", err, true))
+			break
+		end
+	else
+		local ok
+		ok, err = server:listen()
+		if err then
+			server:close()
+			console:error(ST_format("Listen", err, true))
+		else
+			console:log("Socket Server Test: Listening on port " .. port)
+			server:add("received", ST_accept)
+		end
+	end
+end

--- a/res/scripts/sockettest.lua
+++ b/res/scripts/sockettest.lua
@@ -1,0 +1,69 @@
+sockettest = nil
+lastkeys = nil
+
+local KEY_NAMES = { "A", "B", "s", "S", "<", ">", "^", "v", "R", "L" }
+
+function ST_stop()
+	if not sockettest then return end
+	console:log("Socket Test: Shutting down")
+	sockettest:close()
+	sockettest = nil
+end
+
+function ST_start()
+	ST_stop()
+	console:log("Socket Test: Connecting to 127.0.0.1:8888...")
+	sockettest = socket.tcp()
+	sockettest:add("received", ST_received)
+	sockettest:add("error", ST_error)
+	if sockettest:connect("127.0.0.1", 8888) then
+		console:log("Socket Test: Connected")
+		lastkeys = nil
+	else
+		console:log("Socket Test: Failed to connect")
+		ST_stop()
+	end
+end
+
+function ST_error(err)
+	console:error("Socket Test Error: " .. err)
+	ST_stop()
+end
+
+function ST_received()
+	while true do
+		local p, err = sockettest:receive(1024)
+		if p then
+			console:log("Socket Test Received: " .. p:match("^(.-)%s*$"))
+		else
+			if err ~= socket.ERRORS.AGAIN then
+				console:error("Socket Test Error: " .. err)
+				ST_stop()
+			end
+			return
+		end
+	end
+end
+
+function ST_scankeys()
+	if not sockettest then return end
+	local keys = emu:getKeys()
+	if keys ~= lastkeys then
+		lastkeys = keys
+		local msg = "["
+		for i, k in ipairs(KEY_NAMES) do
+			if (keys & (1 << (i - 1))) == 0 then
+				msg = msg .. " "
+			else
+				msg = msg .. k;
+			end
+		end
+		sockettest:send(msg .. "]\n")
+	end
+end
+
+callbacks:add("start", ST_start)
+callbacks:add("stop", ST_stop)
+callbacks:add("crashed", ST_stop)
+callbacks:add("reset", ST_start)
+callbacks:add("keysRead", ST_scankeys)

--- a/src/platform/qt/scripting/ScriptingController.cpp
+++ b/src/platform/qt/scripting/ScriptingController.cpp
@@ -113,6 +113,7 @@ void ScriptingController::runCode(const QString& code) {
 void ScriptingController::init() {
 	mScriptContextInit(&m_scriptContext);
 	mScriptContextAttachStdlib(&m_scriptContext);
+	mScriptContextAttachSocket(&m_scriptContext);
 	mScriptContextRegisterEngines(&m_scriptContext);
 
 	mScriptContextAttachLogger(&m_scriptContext, &m_logger);

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(ExportDirectory)
 set(SOURCE_FILES
 	context.c
+	socket.c
 	stdlib.c
 	types.c)
 

--- a/src/script/socket.c
+++ b/src/script/socket.c
@@ -1,0 +1,276 @@
+/* Copyright (c) 2013-2022 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include <mgba/script/context.h>
+
+#include <mgba/internal/script/socket.h>
+#include <mgba/script/macros.h>
+#include <mgba-util/socket.h>
+
+struct mScriptSocket {
+	Socket socket;
+	struct Address address;
+	int32_t error;
+	uint16_t port;
+};
+mSCRIPT_DECLARE_STRUCT(mScriptSocket);
+
+static const struct _mScriptSocketErrorMapping {
+	int32_t nativeError;
+	enum mSocketErrorCode mappedError;
+} _mScriptSocketErrorMappings[] = {
+	{ EAGAIN,                mSCRIPT_SOCKERR_AGAIN },
+	{ EADDRINUSE,            mSCRIPT_SOCKERR_ADDRESS_IN_USE },
+	{ ECONNREFUSED,          mSCRIPT_SOCKERR_CONNECTION_REFUSED },
+	{ EACCES,                mSCRIPT_SOCKERR_DENIED },
+	{ EPERM,                 mSCRIPT_SOCKERR_DENIED },
+	{ ENOTRECOVERABLE,       mSCRIPT_SOCKERR_FAILED },
+	{ ENETUNREACH,           mSCRIPT_SOCKERR_NETWORK_UNREACHABLE },
+	{ ETIMEDOUT,             mSCRIPT_SOCKERR_TIMEOUT },
+	{ EINVAL,                mSCRIPT_SOCKERR_UNSUPPORTED },
+	{ EPROTONOSUPPORT,       mSCRIPT_SOCKERR_UNSUPPORTED },
+#ifndef USE_GETHOSTBYNAME
+#ifdef _WIN32
+	{ WSATRY_AGAIN,          mSCRIPT_SOCKERR_AGAIN },
+	{ WSANO_RECOVERY,        mSCRIPT_SOCKERR_FAILED },
+	{ WSANO_DATA,            mSCRIPT_SOCKERR_NO_DATA },
+	{ WSAHOST_NOT_FOUND,     mSCRIPT_SOCKERR_NOT_FOUND },
+	{ WSATYPE_NOT_FOUND,     mSCRIPT_SOCKERR_NOT_FOUND },
+	{ WSA_NOT_ENOUGH_MEMORY, mSCRIPT_SOCKERR_OUT_OF_MEMORY },
+	{ WSAEAFNOSUPPORT,       mSCRIPT_SOCKERR_UNSUPPORTED },
+	{ WSAEINVAL,             mSCRIPT_SOCKERR_UNSUPPORTED },
+	{ WSAESOCKTNOSUPPORT,    mSCRIPT_SOCKERR_UNSUPPORTED },
+#else
+	{ EAI_AGAIN,             mSCRIPT_SOCKERR_AGAIN },
+	{ EAI_FAIL,              mSCRIPT_SOCKERR_FAILED },
+	{ EAI_NODATA,            mSCRIPT_SOCKERR_NO_DATA },
+	{ EAI_NONAME,            mSCRIPT_SOCKERR_NOT_FOUND },
+	{ EAI_MEMORY,            mSCRIPT_SOCKERR_OUT_OF_MEMORY },
+#endif
+#else
+	{ -TRY_AGAIN,            mSCRIPT_SOCKERR_AGAIN },
+	{ -NO_RECOVERY,          mSCRIPT_SOCKERR_FAILED },
+	{ -NO_DATA,              mSCRIPT_SOCKERR_NO_DATA },
+	{ -HOST_NOT_FOUND,       mSCRIPT_SOCKERR_NOT_FOUND },
+#endif
+};
+static const int _mScriptSocketNumErrorMappings = sizeof(_mScriptSocketErrorMappings) / sizeof(struct _mScriptSocketErrorMapping);
+
+static void _mScriptSocketSetError(struct mScriptSocket* ssock, int32_t err) {
+	if (!err) {
+		ssock->error = mSCRIPT_SOCKERR_OK;
+		return;
+	}
+	int i;
+	for (i = 0; i < _mScriptSocketNumErrorMappings; i++) {
+		if (_mScriptSocketErrorMappings[i].nativeError == err) {
+			ssock->error = _mScriptSocketErrorMappings[i].mappedError;
+			return;
+		}
+	}
+	ssock->error = mSCRIPT_SOCKERR_UNKNOWN_ERROR;
+}
+
+static void _mScriptSocketSetSocket(struct mScriptSocket* ssock, Socket socket) {
+	if (SOCKET_FAILED(socket)) {
+		ssock->socket = INVALID_SOCKET;
+		_mScriptSocketSetError(ssock, SocketError());
+	} else {
+		ssock->socket = socket;
+		ssock->error = mSCRIPT_SOCKERR_OK;
+	}
+}
+
+struct mScriptValue* _mScriptSocketCreate() {
+	struct mScriptSocket client = {
+		.socket = INVALID_SOCKET,
+		.error = mSCRIPT_SOCKERR_OK,
+		.port = 0
+	};
+
+	struct mScriptValue* result = mScriptValueAlloc(mSCRIPT_TYPE_MS_S(mScriptSocket));
+	result->value.opaque = calloc(1, sizeof(struct mScriptSocket));
+	*(struct mScriptSocket*) result->value.opaque = client;
+	result->flags = mSCRIPT_VALUE_FLAG_FREE_BUFFER;
+	return result;
+}
+
+void _mScriptSocketClose(struct mScriptSocket* ssock) {
+	if (!SOCKET_FAILED(ssock->socket)) {
+		SocketClose(ssock->socket);
+	}
+}
+
+struct mScriptValue* _mScriptSocketAccept(struct mScriptSocket* ssock) {
+	struct mScriptValue* value = _mScriptSocketCreate();
+	struct mScriptSocket* client = (struct mScriptSocket*) value->value.opaque;
+	_mScriptSocketSetSocket(client, SocketAccept(ssock->socket, &client->address));
+	if (!client->error) {
+		SocketSetBlocking(client->socket, false);
+	}
+	return value;
+}
+
+int32_t _mScriptSocketOpen(struct mScriptSocket* ssock, const char* addressStr, uint16_t port) {
+	struct Address* addr = NULL;
+	if (addressStr && addressStr[0]) {
+		int32_t err = SocketResolveHost(addressStr, &ssock->address);
+		if (err) {
+			_mScriptSocketSetError(ssock, err);
+			return err;
+		}
+		addr = &ssock->address;
+	}
+	ssock->port = port;
+	_mScriptSocketSetSocket(ssock, SocketOpenTCP(port, addr));
+	if (!ssock->error) {
+		SocketSetBlocking(ssock->socket, false);
+	}
+	return ssock->error;
+}
+
+int32_t _mScriptSocketConnect(struct mScriptSocket* ssock, const char* addressStr, uint16_t port) {
+	int32_t err = SocketResolveHost(addressStr, &ssock->address);
+	if (err) {
+		_mScriptSocketSetError(ssock, err);
+		return err;
+	}
+	ssock->port = port;
+	_mScriptSocketSetSocket(ssock, SocketConnectTCP(port, &ssock->address));
+	if (!ssock->error) {
+		SocketSetBlocking(ssock->socket, false);
+	}
+	return ssock->error;
+}
+
+int32_t _mScriptSocketListen(struct mScriptSocket* ssock, uint32_t queueLength) {
+	_mScriptSocketSetError(ssock, SocketListen(ssock->socket, queueLength));
+	return ssock->error;
+}
+
+int32_t _mScriptSocketSend(struct mScriptSocket* ssock, struct mScriptString* data) {
+	ssize_t written = SocketSend(ssock->socket, data->buffer, data->size);
+	if (written < 0) {
+		_mScriptSocketSetError(ssock, SocketError());
+		return -ssock->error;
+	}
+	ssock->error = mSCRIPT_SOCKERR_OK;
+	return written;
+}
+
+struct mScriptValue* _mScriptSocketRecv(struct mScriptSocket* ssock, uint32_t maxBytes) {
+	struct mScriptValue* value = mScriptStringCreateEmpty(maxBytes);
+	struct mScriptString* data = value->value.string;
+	ssize_t bytes = SocketRecv(ssock->socket, data->buffer, maxBytes);
+	if (bytes <= 0) {
+		data->size = 0;
+		_mScriptSocketSetError(ssock, SocketError());
+	} else {
+		data->size = bytes;
+		ssock->error = mSCRIPT_SOCKERR_OK;
+	}
+	return value;
+}
+
+// This works sufficiently well for a single socket, but it could be better.
+// Ideally, all sockets would be tracked and selected on together for efficiency.
+uint32_t _mScriptSocketSelectOne(struct mScriptSocket* ssock, int64_t timeoutMillis) {
+	Socket reads[] = { ssock->socket };
+	Socket errors[] = { ssock->socket };
+	int result = SocketPoll(1, reads, NULL, errors, timeoutMillis);
+	if (!result) {
+		return 0;
+	} else if (errors[0] != INVALID_SOCKET) {
+		_mScriptSocketSetError(ssock, SocketError());
+		return -1;
+	}
+	return 1;
+}
+
+mSCRIPT_BIND_FUNCTION(mScriptSocketCreate_Binding, W(mScriptSocket), _mScriptSocketCreate, 0);
+mSCRIPT_DECLARE_STRUCT_VOID_METHOD(mScriptSocket, close, _mScriptSocketClose, 0);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, W(mScriptSocket), accept, _mScriptSocketAccept, 0);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, S32, open, _mScriptSocketOpen, 2, CHARP, address, U16, port);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, S32, connect, _mScriptSocketConnect, 2, CHARP, address, U16, port);
+mSCRIPT_DECLARE_STRUCT_METHOD_WITH_DEFAULTS(mScriptSocket, S32, listen, _mScriptSocketListen, 1, U32, queueLength);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, S32, send, _mScriptSocketSend, 1, STR, data);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, WSTR, recv, _mScriptSocketRecv, 1, U32, maxBytes);
+mSCRIPT_DECLARE_STRUCT_METHOD(mScriptSocket, S32, select, _mScriptSocketSelectOne, 1, S64, timeoutMillis);
+
+mSCRIPT_DEFINE_STRUCT(mScriptSocket)
+	mSCRIPT_DEFINE_CLASS_DOCSTRING("An internal implementation of a TCP network socket.")
+	mSCRIPT_DEFINE_STRUCT_DEINIT_NAMED(mScriptSocket, close)
+	mSCRIPT_DEFINE_DOCSTRING("Closes the socket. If the socket is already closed, this function does nothing.")
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, close)
+	mSCRIPT_DEFINE_DOCSTRING("Creates a new socket for an incoming connection from a listening server socket.")
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, accept)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Binds the socket to a specified address and port. "
+		"If no address is specified, the socket is bound to all network interfaces."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, open)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Opens a TCP connection to the specified address and port.\n"
+		"**Caution:** This is a blocking call. The emulator will not respond until "
+		"the connection either succeeds or fails."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, connect)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Begins listening for incoming connections. The socket must have first been "
+		"bound with the `open` function."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, listen)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Sends data over a socket. Returns the number of bytes written, or -1 if an "
+		"error occurs."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, send)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Reads data from a socket, up to the specified number of bytes. "
+		"If the socket has been disconnected, this function returns an empty string. "
+		"Use `select` to test if data is available to be read."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, recv)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"Checks the status of the socket. "
+		"Returns 1 if data is available to be read. "
+		"Returns -1 if an error has occurred on the socket."
+	)
+	mSCRIPT_DEFINE_STRUCT_METHOD(mScriptSocket, select)
+	mSCRIPT_DEFINE_DOCSTRING(
+		"One of the `SOCKERR` constants describing the last error on the socket."
+	)
+	mSCRIPT_DEFINE_STRUCT_MEMBER(mScriptSocket, S32, error)
+mSCRIPT_DEFINE_END;
+
+mSCRIPT_DEFINE_STRUCT_BINDING_DEFAULTS(mScriptSocket, listen)
+	mSCRIPT_S32(1)
+mSCRIPT_DEFINE_DEFAULTS_END;
+
+
+void mScriptContextAttachSocket(struct mScriptContext* context) {
+	mScriptContextExportNamespace(context, "_socket", (struct mScriptKVPair[]) {
+		mSCRIPT_KV_PAIR(create, &mScriptSocketCreate_Binding),
+		mSCRIPT_KV_SENTINEL
+	});
+	mScriptContextSetDocstring(context, "_socket", "Basic TCP sockets library");
+	mScriptContextSetDocstring(context, "_socket.create", "Creates a new socket object");
+	mScriptContextExportConstants(context, "SOCKERR", (struct mScriptKVPair[]) {
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, UNKNOWN_ERROR),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, OK),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, AGAIN),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, ADDRESS_IN_USE),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, CONNECTION_REFUSED),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, DENIED),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, FAILED),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, NETWORK_UNREACHABLE),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, NOT_FOUND),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, NO_DATA),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, OUT_OF_MEMORY),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, TIMEOUT),
+		mSCRIPT_CONSTANT_PAIR(mSCRIPT_SOCKERR, UNSUPPORTED),
+		mSCRIPT_KV_SENTINEL
+	});
+}


### PR DESCRIPTION
This PR provides an event-driven TCP socket API for mGBA scripting. Where the behaviors overlap, it roughly imitates the LuaSocket API, but due to the mGBA scripting core not being yieldable, it can't be a perfect match.

Also included are two sample scripts. Both scripts will log messages received over the socket to the console and will send an input viewer. One script will connect to a server; the other will open a server and listen for incoming connections.

Documentation still needs to be written.