### PR TITLE
GBA: Verify ELF entrypoint against ROM header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,10 +12,10 @@ Other fixes:
  - VFS: Fix minizip write returning 0 on success instead of size
 Misc:
  - GB Serialize: Add missing savestate support for MBC6 and NT (newer)
+ - GBA: Improve detection of valid ELF ROMs
+ - Qt: Keep track of current pslette preset name (fixes mgba.io/i/2680)
  - macOS: Add category to plist (closes mgba.io/i/2691)
  - macOS: Fix modern build with libepoxy (fixes mgba.io/i/2700)
- - Qt: Keep track of current pslette preset name (fixes mgba.io/i/2680)
- - GBA: Improve detection of valid ELF ROMs
 
 0.10.0: (2022-10-11)
 Features:

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Misc:
  - macOS: Add category to plist (closes mgba.io/i/2691)
  - macOS: Fix modern build with libepoxy (fixes mgba.io/i/2700)
  - Qt: Keep track of current pslette preset name (fixes mgba.io/i/2680)
+ - GBA: Improve detection of valid ELF ROMs
 
 0.10.0: (2022-10-11)
 Features:

--- a/CHANGES
+++ b/CHANGES
@@ -13,9 +13,9 @@ Other fixes:
 Misc:
  - GB Serialize: Add missing savestate support for MBC6 and NT (newer)
  - GBA: Improve detection of valid ELF ROMs
- - Qt: Keep track of current pslette preset name (fixes mgba.io/i/2680)
  - macOS: Add category to plist (closes mgba.io/i/2691)
  - macOS: Fix modern build with libepoxy (fixes mgba.io/i/2700)
+ - Qt: Keep track of current pslette preset name (fixes mgba.io/i/2680)
 
 0.10.0: (2022-10-11)
 Features:

--- a/include/mgba/internal/gba/gba.h
+++ b/include/mgba/internal/gba/gba.h
@@ -55,10 +55,6 @@ struct GBA;
 struct Patch;
 struct VFile;
 
-#ifdef USE_ELF
-struct ELF;
-#endif
-
 mLOG_DECLARE_CATEGORY(GBA);
 mLOG_DECLARE_CATEGORY(GBA_DEBUG);
 
@@ -159,6 +155,8 @@ void GBAStop(struct GBA* gba);
 void GBADebug(struct GBA* gba, uint16_t value);
 
 #ifdef USE_ELF
+struct ELF;
+
 bool GBAVerifyELFEntry(struct ELF* elf, uint32_t target);
 #endif
 

--- a/include/mgba/internal/gba/gba.h
+++ b/include/mgba/internal/gba/gba.h
@@ -19,10 +19,6 @@ CXX_GUARD_START
 #include <mgba/internal/gba/sio.h>
 #include <mgba/internal/gba/timer.h>
 
-#ifdef USE_ELF
-#include <mgba-util/elf-read.h>
-#endif
-
 #define GBA_ARM7TDMI_FREQUENCY 0x1000000U
 
 enum GBAIRQ {
@@ -58,6 +54,10 @@ struct ARMCore;
 struct GBA;
 struct Patch;
 struct VFile;
+
+#ifdef USE_ELF
+struct ELF;
+#endif
 
 mLOG_DECLARE_CATEGORY(GBA);
 mLOG_DECLARE_CATEGORY(GBA_DEBUG);

--- a/include/mgba/internal/gba/gba.h
+++ b/include/mgba/internal/gba/gba.h
@@ -19,6 +19,10 @@ CXX_GUARD_START
 #include <mgba/internal/gba/sio.h>
 #include <mgba/internal/gba/timer.h>
 
+#ifdef USE_ELF
+#include <mgba-util/elf-read.h>
+#endif
+
 #define GBA_ARM7TDMI_FREQUENCY 0x1000000U
 
 enum GBAIRQ {
@@ -153,6 +157,10 @@ void GBATestIRQ(struct GBA* gba, uint32_t cyclesLate);
 void GBAHalt(struct GBA* gba);
 void GBAStop(struct GBA* gba);
 void GBADebug(struct GBA* gba, uint16_t value);
+
+#ifdef USE_ELF
+bool GBAVerifyELFEntry(struct ELF* elf, uint32_t target);
+#endif
 
 #ifdef USE_DEBUGGERS
 struct mDebugger;

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -237,7 +237,7 @@ static bool _GBACoreInit(struct mCore* core) {
 #if !defined(MINIMAL_CORE) || MINIMAL_CORE < 2
 	mDirectorySetInit(&core->dirs);
 #endif
-	
+
 	return true;
 }
 
@@ -512,7 +512,7 @@ static bool _GBACoreLoadROM(struct mCore* core, struct VFile* vf) {
 #ifdef USE_ELF
 	struct ELF* elf = ELFOpen(vf);
 	if (elf) {
-		if (ELFEntry(elf) == BASE_CART0) {
+		if (GBAVerifyELFEntry(elf, BASE_CART0)) {
 			GBALoadNull(core->board);
 		}
 		bool success = mCoreLoadELF(core, elf);

--- a/src/gba/gba.c
+++ b/src/gba/gba.c
@@ -595,6 +595,58 @@ void GBADebug(struct GBA* gba, uint16_t flags) {
 	gba->debugFlags = GBADebugFlagsClearSend(gba->debugFlags);
 }
 
+#ifdef USE_ELF
+bool GBAVerifyELFEntry(struct ELF* elf, uint32_t target) {
+	if (ELFEntry(elf) == target) {
+		return true;
+	}
+
+	struct ELFProgramHeaders ph;
+	ELFProgramHeadersInit(&ph, 0);
+	ELFGetProgramHeaders(elf, &ph);
+	size_t i;
+	for (i = 0; i < ELFProgramHeadersSize(&ph); ++i) {
+		Elf32_Phdr* phdr = ELFProgramHeadersGetPointer(&ph, i);
+		if (!phdr->p_filesz) {
+			continue;
+		}
+
+		size_t phdr_s = phdr->p_paddr;
+		size_t phdr_e = phdr_s + phdr->p_filesz;
+
+		// Does the segment contain our target address?
+		if ((target >= phdr_s) && ((target + 4) <= phdr_e)) {
+			size_t esize;
+			char* bytes = ELFBytes(elf, &esize);
+
+			// File offset to what should be the rom entry instruction
+			size_t off = phdr->p_offset + (target - phdr_s);
+
+			if (off >= esize) {
+				continue;
+			}
+
+			uint32_t opcode;
+			LOAD_32(opcode, 0, &bytes[off]);
+			struct ARMInstructionInfo info;
+			ARMDecodeARM(opcode, &info);
+
+			if ((info.branchType == ARM_BRANCH) || (info.branchType == ARM_BRANCH_LINKED)) {
+				uint32_t b_target = target + (info.op1.immediate + 8);
+
+				if (ELFEntry(elf) == b_target) {
+					ELFProgramHeadersDeinit(&ph);
+					return true;
+				}
+			}
+		}
+	}
+
+	ELFProgramHeadersDeinit(&ph);
+	return false;
+}
+#endif
+
 bool GBAIsROM(struct VFile* vf) {
 	if (!vf) {
 		return false;
@@ -606,7 +658,7 @@ bool GBAIsROM(struct VFile* vf) {
 		uint32_t entry = ELFEntry(elf);
 		bool isGBA = true;
 		isGBA = isGBA && ELFMachine(elf) == EM_ARM;
-		isGBA = isGBA && (entry == BASE_CART0 || entry == BASE_WORKING_RAM + 0xC0);
+		isGBA = isGBA && (GBAVerifyELFEntry(elf, BASE_CART0) || GBAVerifyELFEntry(elf, BASE_WORKING_RAM + 0xC0));
 		ELFClose(elf);
 		return isGBA;
 	}
@@ -662,7 +714,7 @@ bool GBAIsMB(struct VFile* vf) {
 #ifdef USE_ELF
 	struct ELF* elf = ELFOpen(vf);
 	if (elf) {
-		bool isMB = ELFEntry(elf) == BASE_WORKING_RAM + 0xC0;
+		bool isMB = GBAVerifyELFEntry(elf, BASE_WORKING_RAM + 0xC0);
 		ELFClose(elf);
 		return isMB;
 	}


### PR DESCRIPTION
Detect more ELF binaries as valid by checking if the ROM/Multiboot entry branches in the header branch to `e_entry`.

We do this by locating the program header containing the entry branch address, decoding it, checking if it's a branch or branch-with-link instruction, and checking if the branch's target address is `e_entry`.

Should fix detection of Multiboot ROMs built with devkitARM and gba-toolchain.