### PR TITLE
Ability to load shader on launch from command line

### DIFF
--- a/include/mgba/feature/commandline.h
+++ b/include/mgba/feature/commandline.h
@@ -20,6 +20,7 @@ struct mArguments {
 	char* cheatsFile;
 	char* savestate;
 	char* bios;
+	char* shader;
 	int logLevel;
 	int frameskip;
 

--- a/src/feature/commandline.c
+++ b/src/feature/commandline.c
@@ -37,6 +37,7 @@ static const struct option _options[] = {
 	{ "log-level", required_argument, 0, 'l' },
 	{ "savestate", required_argument, 0, 't' },
 	{ "patch",     required_argument, 0, 'p' },
+	{ "shader",    required_argument, 0, 'a'},
 	{ "version",   no_argument, 0, '\0' },
 	{ 0, 0, 0, 0 }
 };
@@ -71,7 +72,7 @@ static void _tableApply(const char* key, void* value, void* user) {
 bool mArgumentsParse(struct mArguments* args, int argc, char* const* argv, struct mSubParser* subparsers, int nSubparsers) {
 	int ch;
 	char options[128] =
-		"b:c:C:hl:p:s:t:"
+		"b:c:C:hl:p:s:t:a:"
 #ifdef USE_EDITLINE
 		"d"
 #endif
@@ -166,6 +167,9 @@ bool mArgumentsParse(struct mArguments* args, int argc, char* const* argv, struc
 		case 't':
 			args->savestate = strdup(optarg);
 			break;
+		case 'a':
+			args->shader = strdup(optarg);
+			break;
 		default:
 			for (i = 0; i < nSubparsers; ++i) {
 				if (subparsers[i].parse) {
@@ -201,6 +205,9 @@ void mArgumentsApply(const struct mArguments* args, struct mSubParser* subparser
 		mCoreConfigSetOverrideValue(config, "bios", args->bios);
 		mCoreConfigSetOverrideIntValue(config, "useBios", true);
 	}
+	if (args->shader) {
+		mCoreConfigSetOverrideValue(config, "shader", args->shader);
+	}
 	HashTableEnumerate(&args->configOverrides, _tableApply, config);
 	int i;
 	for (i = 0; i < nSubparsers; ++i) {
@@ -225,6 +232,9 @@ void mArgumentsDeinit(struct mArguments* args) {
 
 	free(args->bios);
 	args->bios = 0;
+
+	free(args->shader);
+	args->shader = 0;
 
 	HashTableDeinit(&args->configOverrides);
 }


### PR DESCRIPTION
Using "--shader" option followed by shader folder, that shader can be loaded on launch.

My personal reason for implementing this was to launch some games with gba-color.shader and some not depending on whether the game oversaturates colors to counter original GBA's dark screen or not, but it may have other uses.