### PR TITLE
Libretro: Fix undeclared constant

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -346,7 +346,7 @@ static void _doDeferredSetup(void) {
 	// On the off-hand chance that a core actually expects its buffers to be populated when
 	// you actually first get them, you're out of luck without workarounds. Yup, seriously.
 	// Here's that workaround, but really the API needs to be thrown out and rewritten.
-	struct VFile* save = VFileFromMemory(savedata, SIZE_CART_FLASH1M);
+	struct VFile* save = VFileFromMemory(savedata, GBA_SIZE_FLASH1M);
 	if (!core->loadSave(core, save)) {
 		save->close(save);
 	}
@@ -930,8 +930,8 @@ bool retro_load_game(const struct retro_game_info* game) {
 	core->setPeripheral(core, mPERIPH_RUMBLE, &rumble);
 	core->setPeripheral(core, mPERIPH_ROTATION, &rotation);
 
-	savedata = anonymousMemoryMap(SIZE_CART_FLASH1M);
-	memset(savedata, 0xFF, SIZE_CART_FLASH1M);
+	savedata = anonymousMemoryMap(GBA_SIZE_FLASH1M);
+	memset(savedata, 0xFF, GBA_SIZE_FLASH1M);
 
 	_reloadSettings();
 	core->loadROM(core, rom);
@@ -1008,7 +1008,7 @@ void retro_unload_game(void) {
 	core->deinit(core);
 	mappedMemoryFree(data, dataSize);
 	data = 0;
-	mappedMemoryFree(savedata, SIZE_CART_FLASH1M);
+	mappedMemoryFree(savedata, GBA_SIZE_FLASH1M);
 	savedata = 0;
 }
 
@@ -1163,7 +1163,7 @@ size_t retro_get_memory_size(unsigned id) {
 		case mPLATFORM_GBA:
 			switch (((struct GBA*) core->board)->memory.savedata.type) {
 			case SAVEDATA_AUTODETECT:
-				return SIZE_CART_FLASH1M;
+				return GBA_SIZE_FLASH1M;
 			default:
 				return GBASavedataSize(&((struct GBA*) core->board)->memory.savedata);
 			}
@@ -1362,7 +1362,7 @@ static void _startImage(struct mImageSource* image, unsigned w, unsigned h, int 
 
 static void _stopImage(struct mImageSource* image) {
 	UNUSED(image);
-	cam.stop();	
+	cam.stop();
 }
 
 static void _requestImage(struct mImageSource* image, const void** buffer, size_t* stride, enum mColorFormat* colorFormat) {


### PR DESCRIPTION
The `SIZE_CART_FLASH1M` constant was renamed to `GBA_SIZE_FLASH1M` in https://github.com/mgba-emu/mgba/commit/8545271e9ee275b9e733bbfa13195365b1fb82e1

These leftovers make the Libretro build fail, when running:
```
cmake -DBUILD_LIBRETRO=ON .. && make
```