### PR TITLE
Added the `disass-style` command to the debugger

### DIFF
--- a/include/mgba/debugger/debugger.h
+++ b/include/mgba/debugger/debugger.h
@@ -56,6 +56,11 @@ enum mDebuggerEntryReason {
 	DEBUGGER_ENTER_STACK
 };
 
+enum mDisassemblyStyle {
+    DISASSEMBLY_STYLE_DECIMAL,
+    DISASSEMBLY_STYLE_HEX
+};
+
 struct mDebuggerEntryInfo {
 	uint32_t address;
 	union {
@@ -102,6 +107,7 @@ struct mDebugger;
 struct ParseTree;
 struct mDebuggerPlatform {
 	struct mDebugger* p;
+    enum mDisassemblyStyle disassemblyStyle;
 
 	void (*init)(void* cpu, struct mDebuggerPlatform*);
 	void (*deinit)(struct mDebuggerPlatform*);

--- a/include/mgba/debugger/debugger.h
+++ b/include/mgba/debugger/debugger.h
@@ -57,8 +57,8 @@ enum mDebuggerEntryReason {
 };
 
 enum mDisassemblyStyle {
-    DISASSEMBLY_STYLE_DECIMAL,
-    DISASSEMBLY_STYLE_HEX
+	DISASSEMBLY_STYLE_DECIMAL,
+	DISASSEMBLY_STYLE_HEX
 };
 
 struct mDebuggerEntryInfo {
@@ -107,7 +107,7 @@ struct mDebugger;
 struct ParseTree;
 struct mDebuggerPlatform {
 	struct mDebugger* p;
-    enum mDisassemblyStyle disassemblyStyle;
+	enum mDisassemblyStyle disassemblyStyle;
 
 	void (*init)(void* cpu, struct mDebuggerPlatform*);
 	void (*deinit)(struct mDebuggerPlatform*);

--- a/include/mgba/internal/arm/decoder.h
+++ b/include/mgba/internal/arm/decoder.h
@@ -11,6 +11,7 @@
 CXX_GUARD_START
 
 #include <mgba/internal/arm/arm.h>
+#include <mgba/debugger/debugger.h>
 
 // Bit 0: a register is involved with this operand
 // Bit 1: an immediate is invovled with this operand
@@ -223,7 +224,7 @@ uint32_t ARMResolveMemoryAccess(struct ARMInstructionInfo* info, struct ARMRegis
 
 #ifdef USE_DEBUGGERS
 struct mDebuggerSymbols;
-int ARMDisassemble(const struct ARMInstructionInfo* info, struct ARMCore* core, const struct mDebuggerSymbols* symbols, uint32_t pc, char* buffer, int blen);
+int ARMDisassemble(const struct ARMInstructionInfo* info, struct ARMCore* core, const struct mDebuggerSymbols* symbols, uint32_t pc, enum mDisassemblyStyle disassemblyStyle, char* buffer, int blen);
 #endif
 
 CXX_GUARD_END

--- a/include/mgba/internal/arm/decoder.h
+++ b/include/mgba/internal/arm/decoder.h
@@ -10,8 +10,8 @@
 
 CXX_GUARD_START
 
-#include <mgba/internal/arm/arm.h>
 #include <mgba/debugger/debugger.h>
+#include <mgba/internal/arm/arm.h>
 
 // Bit 0: a register is involved with this operand
 // Bit 1: an immediate is invovled with this operand

--- a/include/mgba/internal/sm83/decoder.h
+++ b/include/mgba/internal/sm83/decoder.h
@@ -10,6 +10,8 @@
 
 CXX_GUARD_START
 
+#include <mgba/debugger/debugger.h>
+
 enum SM83Condition {
 	SM83_COND_NONE = 0x0,
 	SM83_COND_C = 0x1,
@@ -105,7 +107,7 @@ struct SM83InstructionInfo {
 };
 
 size_t SM83Decode(uint8_t opcode, struct SM83InstructionInfo* info);
-int SM83Disassemble(struct SM83InstructionInfo* info, uint16_t pc, char* buffer, int blen);
+int SM83Disassemble(struct SM83InstructionInfo* info, uint16_t pc, enum mDisassemblyStyle, char* buffer, int blen);
 
 CXX_GUARD_END
 

--- a/src/arm/debugger/cli-debugger.c
+++ b/src/arm/debugger/cli-debugger.c
@@ -106,7 +106,7 @@ static inline uint32_t _printLine(struct CLIDebugger* debugger, uint32_t address
 	if (mode == MODE_ARM) {
 		uint32_t instruction = core->busRead32(core, address & ~(WORD_SIZE_ARM - 1));
 		ARMDecodeARM(instruction, &info);
-		ARMDisassemble(&info, core->cpu, core->symbolTable, address + WORD_SIZE_ARM * 2, disassembly, sizeof(disassembly));
+		ARMDisassemble(&info, core->cpu, core->symbolTable, address + WORD_SIZE_ARM * 2, debugger->d.platform->disassemblyStyle, disassembly, sizeof(disassembly));
 		be->printf(be, "%08X\t%s\n", instruction, disassembly);
 		return WORD_SIZE_ARM;
 	} else {
@@ -117,11 +117,11 @@ static inline uint32_t _printLine(struct CLIDebugger* debugger, uint32_t address
 		ARMDecodeThumb(instruction, &info);
 		ARMDecodeThumb(instruction2, &info2);
 		if (ARMDecodeThumbCombine(&info, &info2, &combined)) {
-			ARMDisassemble(&combined, core->cpu, core->symbolTable, address + WORD_SIZE_THUMB * 2, disassembly, sizeof(disassembly));
+			ARMDisassemble(&combined, core->cpu, core->symbolTable, address + WORD_SIZE_THUMB * 2, debugger->d.platform->disassemblyStyle, disassembly, sizeof(disassembly));
 			be->printf(be, "%04X %04X\t%s\n", instruction, instruction2, disassembly);
 			return WORD_SIZE_THUMB * 2;
 		} else {
-			ARMDisassemble(&info, core->cpu, core->symbolTable, address + WORD_SIZE_THUMB * 2, disassembly, sizeof(disassembly));
+			ARMDisassemble(&info, core->cpu, core->symbolTable, address + WORD_SIZE_THUMB * 2, debugger->d.platform->disassemblyStyle, disassembly, sizeof(disassembly));
 			be->printf(be, "%04X     \t%s\n", instruction, disassembly);
 			return WORD_SIZE_THUMB;
 		}

--- a/src/arm/debugger/debugger.c
+++ b/src/arm/debugger/debugger.c
@@ -472,17 +472,17 @@ static void ARMDebuggerTrace(struct mDebuggerPlatform* d, char* out, size_t* len
 	if (cpu->executionMode == MODE_ARM) {
 		uint32_t instruction = cpu->prefetch[0];
 		sprintf(disassembly, "%08X: ", instruction);
-		ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
+		ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], d->disassemblyStyle, disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
 	} else {
 		uint16_t instruction = cpu->prefetch[0];
 		ARMDecodeThumb(instruction, &info);
 		if (isWideInstruction) {
 			uint16_t instruction2 = cpu->prefetch[1];
 			sprintf(disassembly, "%04X%04X: ", instruction, instruction2);
-			ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
+			ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], d->disassemblyStyle, disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
 		} else {
 			sprintf(disassembly, "    %04X: ", instruction);
-			ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
+			ARMDisassemble(&info, cpu, core->symbolTable, cpu->gprs[ARM_PC], d->disassemblyStyle, disassembly + strlen("00000000: "), sizeof(disassembly) - strlen("00000000: "));
 		}
 	}
 

--- a/src/arm/decoder.c
+++ b/src/arm/decoder.c
@@ -48,14 +48,14 @@ static const char* _armConditions[] = {
 };
 
 static int _decodeImmediate(int imm, enum mDisassemblyStyle disassemblyStyle, char* buffer, int blen) {
-   switch(disassemblyStyle) {
-   case DISASSEMBLY_STYLE_DECIMAL:
-        return snprintf(buffer, blen, "#%i", imm);
-   case DISASSEMBLY_STYLE_HEX:
-        return snprintf(buffer, blen, "#0x%x", imm);
-   default:
-        return snprintf(buffer, blen, "#%i", imm);
-   }
+	switch(disassemblyStyle) {
+	case DISASSEMBLY_STYLE_DECIMAL:
+		return snprintf(buffer, blen, "#%i", imm);
+	case DISASSEMBLY_STYLE_HEX:
+		return snprintf(buffer, blen, "#0x%x", imm);
+	default:
+	return snprintf(buffer, blen, "#%i", imm);
+	}
 }
 
 static int _decodeRegister(int reg, char* buffer, int blen) {
@@ -240,10 +240,10 @@ static int _decodeMemory(struct ARMMemoryAccess memory, struct ARMCore* cpu, con
 	}
 	if (memory.format & ARM_MEMORY_IMMEDIATE_OFFSET && memory.baseReg != ARM_PC) {
 		if (memory.format & ARM_MEMORY_OFFSET_SUBTRACT) {
-            written = _decodeImmediate(-memory.offset.immediate, disassemblyStyle, buffer, blen);
+			written = _decodeImmediate(-memory.offset.immediate, disassemblyStyle, buffer, blen);
 			ADVANCE(written);
 		} else {
-            written = _decodeImmediate(memory.offset.immediate, disassemblyStyle, buffer, blen);
+			written = _decodeImmediate(memory.offset.immediate, disassemblyStyle, buffer, blen);
 			ADVANCE(written);
 		}
 	} else if (memory.format & ARM_MEMORY_REGISTER_OFFSET) {
@@ -305,7 +305,7 @@ static int _decodeShift(union ARMOperand op, bool reg, enum mDisassemblyStyle di
 		return total;
 	}
 	if (!reg) {
-        written = _decodeImmediate(op.shifterImm, disassemblyStyle, buffer, blen);
+		written = _decodeImmediate(op.shifterImm, disassemblyStyle, buffer, blen);
 	} else {
 		written = _decodeRegister(op.shifterReg, buffer, blen);
 	}
@@ -525,7 +525,7 @@ int ARMDisassemble(const struct ARMInstructionInfo* info, struct ARMCore* cpu, c
 				ADVANCE(2);
 			}
 			if (info->operandFormat & ARM_OPERAND_IMMEDIATE_3) {
-                written = _decodeImmediate(info->op3.immediate, disassemblyStyle, buffer, blen);
+				written = _decodeImmediate(info->op3.immediate, disassemblyStyle, buffer, blen);
 				ADVANCE(written);
 			} else if (info->operandFormat & ARM_OPERAND_MEMORY_3) {
 				written = _decodeMemory(info->memory, cpu, symbols, pc, disassemblyStyle, buffer, blen);
@@ -547,7 +547,7 @@ int ARMDisassemble(const struct ARMInstructionInfo* info, struct ARMCore* cpu, c
 			ADVANCE(2);
 		}
 		if (info->operandFormat & ARM_OPERAND_IMMEDIATE_4) {
-            written = _decodeImmediate(info->op4.immediate, disassemblyStyle, buffer, blen);
+			written = _decodeImmediate(info->op4.immediate, disassemblyStyle, buffer, blen);
 			ADVANCE(written);
 		} else if (info->operandFormat & ARM_OPERAND_MEMORY_4) {
 			written = _decodeMemory(info->memory, cpu, symbols, pc, disassemblyStyle, buffer, blen);

--- a/src/arm/decoder.c
+++ b/src/arm/decoder.c
@@ -49,12 +49,10 @@ static const char* _armConditions[] = {
 
 static int _decodeImmediate(int imm, enum mDisassemblyStyle disassemblyStyle, char* buffer, int blen) {
 	switch(disassemblyStyle) {
-	case DISASSEMBLY_STYLE_DECIMAL:
-		return snprintf(buffer, blen, "#%i", imm);
 	case DISASSEMBLY_STYLE_HEX:
 		return snprintf(buffer, blen, "#0x%x", imm);
 	default:
-	return snprintf(buffer, blen, "#%i", imm);
+		return snprintf(buffer, blen, "#%i", imm);
 	}
 }
 

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -126,7 +126,7 @@ static struct CLIDebuggerCommandSummary _debuggerCommands[] = {
 	{ "x/1", _dumpByte, "Ii", "Examine bytes at a specified offset" },
 	{ "x/2", _dumpHalfword, "Ii", "Examine halfwords at a specified offset" },
 	{ "x/4", _dumpWord, "Ii", "Examine words at a specified offset" },
-	{ "disass-style", _setDisassemblyStyle, "S", "Set the disassembly style" },
+	{ "disasm-style", _setDisassemblyStyle, "S", "Set the disassembly style" },
 #ifdef ENABLE_SCRIPTING
 	{ "source", _source, "S", "Load a script" },
 #endif
@@ -598,9 +598,9 @@ static void _setDisassemblyStyle(struct CLIDebugger* debugger, struct CLIDebugVe
 	}
 	struct mDebuggerPlatform* platform = debugger->d.platform;
 	if (strcmp(dv->charValue, "decimal") == 0) {
-        platform->disassemblyStyle = DISASSEMBLY_STYLE_DECIMAL;
+		platform->disassemblyStyle = DISASSEMBLY_STYLE_DECIMAL;
 	} else if (strcmp(dv->charValue, "hex") == 0) {
-        platform->disassemblyStyle = DISASSEMBLY_STYLE_HEX;
+		platform->disassemblyStyle = DISASSEMBLY_STYLE_HEX;
 	} else {
 		debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
 	}
@@ -831,14 +831,14 @@ static void _listWatchpoints(struct CLIDebugger* debugger, struct CLIDebugVector
 }
 
 static void _trace(struct CLIDebugger* debugger, struct CLIDebugVector* dv) {
-    if (!dv) {
+	if (!dv) {
 		debugger->backend->printf(debugger->backend, "%s\n", ERROR_MISSING_ARGS);
 		return;
 	}
-    if (dv->type != CLIDV_INT_TYPE || dv->intValue < 0) {
-        debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
-        return;
-    }
+	if (dv->type != CLIDV_INT_TYPE || dv->intValue < 0) {
+		debugger->backend->printf(debugger->backend, "%s\n", ERROR_INVALID_ARGS);
+		return;
+	}
 
 	debugger->traceRemaining = dv->intValue;
 	if (debugger->traceVf) {

--- a/src/sm83/debugger/cli-debugger.c
+++ b/src/sm83/debugger/cli-debugger.c
@@ -71,7 +71,7 @@ static inline uint16_t _printLine(struct CLIDebugger* debugger, uint16_t address
 	};
 	disPtr[0] = '\t';
 	++disPtr;
-	SM83Disassemble(&info, address, disPtr, sizeof(disassembly) - (disPtr - disassembly));
+	SM83Disassemble(&info, address, debugger->d.platform->disassemblyStyle, disPtr, sizeof(disassembly) - (disPtr - disassembly));
 	be->printf(be, "%s\n", disassembly);
 	return address;
 }

--- a/src/sm83/debugger/debugger.c
+++ b/src/sm83/debugger/debugger.c
@@ -214,7 +214,7 @@ static void SM83DebuggerTrace(struct mDebuggerPlatform* d, char* out, size_t* le
 	disPtr[0] = ':';
 	disPtr[1] = ' ';
 	disPtr += 2;
-	SM83Disassemble(&info, address, disPtr, sizeof(disassembly) - (disPtr - disassembly));
+	SM83Disassemble(&info, address, d->disassemblyStyle, disPtr, sizeof(disassembly) - (disPtr - disassembly));
 
 	*length = snprintf(out, *length, "A: %02X F: %02X B: %02X C: %02X D: %02X E: %02X H: %02X L: %02X SP: %04X PC: %02X:%04X | %s",
 		               cpu->a, cpu->f.packed, cpu->b, cpu->c,

--- a/src/sm83/decoder.c
+++ b/src/sm83/decoder.c
@@ -522,15 +522,15 @@ static int _decodeOperand(struct SM83Operand op, uint16_t pc, enum mDisassemblyS
 		int written;
 		if (op.flags & SM83_OP_FLAG_RELATIVE) {
 			if (disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
-				written = snprintf(buffer, blen, "$0x%04X", pc + (int8_t) op.immediate);
+				written = snprintf(buffer, blen, "$%04X", pc + (int8_t) op.immediate);
 			} else {
-				written = snprintf(buffer, blen, "$%05i", pc + (int8_t) op.immediate);
+				written = snprintf(buffer, blen, "%05i", pc + (int8_t) op.immediate);
 			}
 		} else {
 			if(disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
-				written = snprintf(buffer, blen, "$0x%02X", pc + (int8_t) op.immediate);
+				written = snprintf(buffer, blen, "$%02X", pc + (int8_t) op.immediate);
 			} else {
-				written = snprintf(buffer, blen, "$%03i", pc + (int8_t) op.immediate);
+				written = snprintf(buffer, blen, "%03i", pc + (int8_t) op.immediate);
 			}
 		}
 		ADVANCE(written);

--- a/src/sm83/decoder.c
+++ b/src/sm83/decoder.c
@@ -521,18 +521,17 @@ static int _decodeOperand(struct SM83Operand op, uint16_t pc, enum mDisassemblyS
 	} else {
 		int written;
 		if (op.flags & SM83_OP_FLAG_RELATIVE) {
-            if(disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
-                written = snprintf(buffer, blen, "$0x%04X", pc + (int8_t) op.immediate);
-            } else {
-                written = snprintf(buffer, blen, "$%05i", pc + (int8_t) op.immediate);
-            }
-
+			if (disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
+				written = snprintf(buffer, blen, "$0x%04X", pc + (int8_t) op.immediate);
+			} else {
+				written = snprintf(buffer, blen, "$%05i", pc + (int8_t) op.immediate);
+			}
 		} else {
-            if(disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
-                written = snprintf(buffer, blen, "$0x%02X", pc + (int8_t) op.immediate);
-            } else {
-                written = snprintf(buffer, blen, "$%03i", pc + (int8_t) op.immediate);
-            }
+			if(disassemblyStyle == DISASSEMBLY_STYLE_HEX) {
+				written = snprintf(buffer, blen, "$0x%02X", pc + (int8_t) op.immediate);
+			} else {
+				written = snprintf(buffer, blen, "$%03i", pc + (int8_t) op.immediate);
+			}
 		}
 		ADVANCE(written);
 		if (op.reg) {


### PR DESCRIPTION
The command will set the disassembler to either output decimal or hex representations of immediates. This is to make disassembly more clear so you don't have to convert values in a different tool. The command works on both ARM and sm83 code. This commit was originally made to solve #2553. Unfortunately that issue was actually invalid. However I already had the functionality of changing between decimal and hex for immediates implemented, so I added a command that would control it.