### PR TITLE
[UI bug] mGBA doesn't update savestate screenshots until you move the cursor over other savestates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Emulation fixes:
  - GBA BIOS: Fix clobbering registers with word-sized CpuSet
  - GBA Video: Disable BG target 1 blending when OBJ blending (fixes mgba.io/i/2722)
 Other fixes:
+ - mGUI: Fix cases where an older save state screenshot would be shown. (fixes mgba.io/i/2183)
  - Qt: Fix savestate preview sizes with different scales (fixes mgba.io/i/2560)
 Misc:
  - Core: Handle relative paths for saves, screenshots, etc consistently (fixes mgba.io/i/2826)

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -658,8 +658,9 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				break;
 			case RUNNER_SAVE_STATE:
 				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
-				gbaBackground->screenshotId = (item->data.v.u >> 16) | SCREENSHOT_STALE;
-				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
+				unsigned stateId = item->data.v.u >> 16;
+				gbaBackground->screenshotId = stateId | SCREENSHOT_STALE;
+				mCoreSaveState(runner->core, stateId, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;
 			case RUNNER_LOAD_STATE:
 				mCoreLoadState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_RTC);

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -658,11 +658,10 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				break;
 			case RUNNER_SAVE_STATE:
 				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
-				unsigned stateId = item->data.v.u >> 16;
 				// If we are saving state, then the screenshot stored for the state previously should no longer be considered up-to-date.
 				// Therefore, mark it as stale, so that at draw time, we will re-draw to the new save state's screenshot.
-				gbaBackground->screenshotId = stateId | SCREENSHOT_STALE;
-				mCoreSaveState(runner->core, stateId, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
+				gbaBackground->screenshotId |= SCREENSHOT_STALE;
+				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;
 			case RUNNER_LOAD_STATE:
 				mCoreLoadState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_RTC);

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -51,7 +51,6 @@ enum {
 enum {
 	SCREENSHOT_VALID = 0x10000,
 	SCREENSHOT_INVALID = 0x20000,
-	SCREENSHOT_STALE = 0x30000,
 };
 
 static const struct mInputPlatformInfo _mGUIKeyInfo = {
@@ -128,7 +127,7 @@ static void _drawState(struct GUIBackground* background, void* id) {
 		if (pixels && gbaBackground->screenshotId == (stateId | SCREENSHOT_VALID)) {
 			gbaBackground->p->drawScreenshot(gbaBackground->p, pixels, gbaBackground->w, gbaBackground->h, true);
 			return;
-		} else if ((gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID)) || (gbaBackground->screenshotId == (stateId | SCREENSHOT_STALE))) {
+		} else if ((gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID))) {
 			struct VFile* vf = mCoreGetState(gbaBackground->p->core, stateId, false);
 			bool success = false;
 			unsigned w, h;
@@ -660,7 +659,7 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
 				// If we are saving state, then the screenshot stored for the state previously should no longer be considered up-to-date.
 				// Therefore, mark it as stale, so that at draw time, we will re-draw to the new save state's screenshot.
-				gbaBackground->screenshotId |= SCREENSHOT_STALE;
+				gbaBackground->screenshotId |= SCREENSHOT_INVALID;
 				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;
 			case RUNNER_LOAD_STATE:

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -659,6 +659,8 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 			case RUNNER_SAVE_STATE:
 				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
 				unsigned stateId = item->data.v.u >> 16;
+				// If we are saving state, then the screenshot stored for the state previously should no longer be considered up-to-date.
+				// Therefore, mark it as stale, so that at draw time, we will re-draw to the new save state's screenshot.
 				gbaBackground->screenshotId = stateId | SCREENSHOT_STALE;
 				mCoreSaveState(runner->core, stateId, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -51,6 +51,7 @@ enum {
 enum {
 	SCREENSHOT_VALID = 0x10000,
 	SCREENSHOT_INVALID = 0x20000,
+	SCREENSHOT_STALE = 0x30000,
 };
 
 static const struct mInputPlatformInfo _mGUIKeyInfo = {
@@ -127,7 +128,7 @@ static void _drawState(struct GUIBackground* background, void* id) {
 		if (pixels && gbaBackground->screenshotId == (stateId | SCREENSHOT_VALID)) {
 			gbaBackground->p->drawScreenshot(gbaBackground->p, pixels, gbaBackground->w, gbaBackground->h, true);
 			return;
-		} else if (gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID)) {
+		} else if ((gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID)) || (gbaBackground->screenshotId == (stateId | SCREENSHOT_STALE))) {
 			struct VFile* vf = mCoreGetState(gbaBackground->p->core, stateId, false);
 			bool success = false;
 			unsigned w, h;
@@ -656,6 +657,8 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				runner->core->reset(runner->core);
 				break;
 			case RUNNER_SAVE_STATE:
+				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
+				gbaBackground->screenshotId = (item->data.v.u >> 16) | SCREENSHOT_STALE;
 				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;
 			case RUNNER_LOAD_STATE:

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -127,7 +127,7 @@ static void _drawState(struct GUIBackground* background, void* id) {
 		if (pixels && gbaBackground->screenshotId == (stateId | SCREENSHOT_VALID)) {
 			gbaBackground->p->drawScreenshot(gbaBackground->p, pixels, gbaBackground->w, gbaBackground->h, true);
 			return;
-		} else if ((gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID))) {
+		} else if (gbaBackground->screenshotId != (stateId | SCREENSHOT_INVALID)) {
 			struct VFile* vf = mCoreGetState(gbaBackground->p->core, stateId, false);
 			bool success = false;
 			unsigned w, h;

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -657,7 +657,7 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				break;
 			case RUNNER_SAVE_STATE:
 				// If we are saving state, then the screenshot stored for the state previously should no longer be considered up-to-date.
-				// Therefore, mark it as stale, so that at draw time, we will re-draw to the new save state's screenshot.
+				// Therefore, mark it as stale so that at draw time we load the new save state's screenshot.
 				((struct mGUIBackground*) stateSaveMenu.background)->screenshotId |= SCREENSHOT_INVALID;
 				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;

--- a/src/feature/gui/gui-runner.c
+++ b/src/feature/gui/gui-runner.c
@@ -656,10 +656,9 @@ void mGUIRun(struct mGUIRunner* runner, const char* path) {
 				runner->core->reset(runner->core);
 				break;
 			case RUNNER_SAVE_STATE:
-				struct mGUIBackground* gbaBackground = (struct mGUIBackground*) stateSaveMenu.background;
 				// If we are saving state, then the screenshot stored for the state previously should no longer be considered up-to-date.
 				// Therefore, mark it as stale, so that at draw time, we will re-draw to the new save state's screenshot.
-				gbaBackground->screenshotId |= SCREENSHOT_INVALID;
+				((struct mGUIBackground*) stateSaveMenu.background)->screenshotId |= SCREENSHOT_INVALID;
 				mCoreSaveState(runner->core, item->data.v.u >> 16, SAVESTATE_SCREENSHOT | SAVESTATE_SAVEDATA | SAVESTATE_RTC | SAVESTATE_METADATA);
 				break;
 			case RUNNER_LOAD_STATE:


### PR DESCRIPTION
Fixes #2183.

Hi, this is my first PR and @endrift may remember me asking a question or two on the Discord server.

> :warning: I haven't touched C in about... 5 years. And this is my first time making changes to this codebase. Please let me know if I'm doing anything wrong or if I'm making any style mistakes etc.

The change itself is quite small but I'll explain it anyways: extend the `SCREENSHOT_*` enums in the `gui-runner.c` file to include a `SCREENSHOT_STALE`. This is distinct from `SCREENSHOT_INVALID` because we do not want to just draw the current frame onto the background, we want to draw the actual save state screenshot PNG. This is a case that I considered to be equivalent to the `!= SCREENSHOT_INVALID` case in terms of handling, since we basically just want to reload the new PNG image bytes into the background buffer.

_P.S._ `CONTRIBUTING.md` states that my commit messages should be tagged with their relevant components, but I am not familiar enough with this codebase to be know which components I'm touching. I didn't see any components in the document referring to `mGUI`.