### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Setup
         env:
           MINGW_PACKAGE_PREFIX: mingw64
-        run: pacman -Sy --noconfirm --needed base-devel git ${MINGW_PACKAGE_PREFIX}-{cmake,ffmpeg,gcc,gdb,libelf,libepoxy,libzip,lua,pkgconf,qt5,SDL2,ntldd-git,7zip}
-      - name: CMake
         run: |
+          pacman -Sy --noconfirm --needed base-devel git ${MINGW_PACKAGE_PREFIX}-{cmake,ffmpeg,gcc,gdb,libelf,libepoxy,libzip,lua,pkgconf,qt5,SDL2,ntldd-git,7zip}
           mkdir build
-          cd build
-          cmake .. -G"MSYS Makefiles"
+      - name: CMake
+        working-directory: build
+        run: cmake .. -G"MSYS Makefiles"
       - name: Build
         working-directory: build
         run: cmake --build . -j$NUMBER_OF_PROCESSORS
@@ -76,6 +76,7 @@ jobs:
           C:\vcpkg\bootstrap-vcpkg.bat
           vcpkg install ffmpeg[vpx,x264] libepoxy libpng libzip lua sdl2 sqlite3
           vcpkg --no-dry-run upgrade
+          mkdir build
       - uses: jurplel/install-qt-action@v3.2.1
         with:
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup
         run: |
-          C:\vcpkg\bootstrap-vcpkg.bat
+          #C:\vcpkg\bootstrap-vcpkg.bat
           vcpkg install ffmpeg[vpx,x264] libepoxy libpng libzip lua sdl2 sqlite3
           vcpkg --no-dry-run upgrade
           mkdir build
@@ -83,7 +83,7 @@ jobs:
           #setup-python: false
       - name: CMake
         working-directory: build
-        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DZLIB_LIBRARY=zlib
+        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=${env:VCPKG_INSTALLATION_ROOT}\scripts\buildsystems\vcpkg.cmake #-DZLIB_LIBRARY=zlib
       - name: Build
         working-directory: build
         run: cmake --build . -j$env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           #setup-python: false
       - name: CMake
         working-directory: build
-        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DZLIB_LIBRARY=zlib -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
       - name: Build
         working-directory: build
         run: cmake --build . -j$env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Setup
         env:
           MINGW_PACKAGE_PREFIX: mingw64
-        run: |
-          pacman -Sy --noconfirm --needed base-devel git ${MINGW_PACKAGE_PREFIX}-{cmake,ffmpeg,gcc,gdb,libelf,libepoxy,libzip,lua,pkgconf,qt5,SDL2,ntldd-git,7zip}
-          mkdir -p build
+        run: pacman -Sy --noconfirm --needed base-devel git ${MINGW_PACKAGE_PREFIX}-{cmake,ffmpeg,gcc,gdb,libelf,libepoxy,libzip,lua,pkgconf,qt5,SDL2,ntldd-git,7zip}
       - name: CMake
-        working-directory: build
-        run: cmake .. -G"MSYS Makefiles"
+        run: |
+          mkdir build
+          cd build
+          cmake .. -G"MSYS Makefiles"
       - name: Build
         working-directory: build
         run: cmake --build . -j$NUMBER_OF_PROCESSORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           vcpkg install ffmpeg[vpx,x264] libepoxy libpng libzip lua sdl2 sqlite3
           vcpkg --no-dry-run upgrade
           vcpkg integrate install
+          echo "${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows-release\bin" >> "$GITHUB_PATH"
           cd -
           mkdir build
       - uses: jurplel/install-qt-action@v3.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,157 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - 'CHANGES'
+      - '.github/*'
+      - '.gitignore'
+      - '*.yml'
+      - 'docs/**'
+#  pull_request:
+
+jobs:
+  build-windows-docker:
+    runs-on: ubuntu-latest
+    #container: mgba/windows:w64
+    steps:
+      - uses: actions/checkout@v3
+      #- run: mkdir -p build-win64
+      - name: Docker
+        run: docker run --rm -v ${PWD}:/home/mgba/src mgba/windows:w64
+      - run: ls
+
+  build-windows-msys2:
+    runs-on: windows-latest
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+      - name: Setup
+        env:
+          MINGW_PACKAGE_PREFIX: mingw64
+        run: |
+          pacman -Sy --noconfirm --needed base-devel git ${MINGW_PACKAGE_PREFIX}-{cmake,ffmpeg,gcc,gdb,libelf,libepoxy,libzip,lua,pkgconf,qt5,SDL2,ntldd-git,7zip}
+          mkdir -p build
+      - name: CMake
+        working-directory: build
+        run: cmake .. -G"MSYS Makefiles"
+      - name: Build
+        working-directory: build
+        run: cmake --build . -j$NUMBER_OF_PROCESSORS
+      - name: Create artifact
+        id: artifact
+        working-directory: build
+        run: |
+          cpack -G ZIP
+          zip=$(ls *.zip)
+          7z x "$zip"
+          echo "name=${zip//.zip}" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: build\${{ steps.artifact.outputs.name }}
+          if-no-files-found: error
+
+  build-windows-vcpkg:
+    runs-on: windows-2019 #latest
+    strategy:
+      #fail-fast: false
+      matrix:
+        configuration: [Release] #, Debug
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+      VCPKG_BUILD_TYPE: ${{ matrix.configuration }}
+      VCPKG_DEFAULT_TRIPLET: x64-windows-release
+      VCPKG_DISABLE_METRICS: 1
+      #VCPKG_TARGET_ARCHITECTURE: x64
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          C:\vcpkg\bootstrap-vcpkg.bat
+          vcpkg install ffmpeg[vpx,x264] libepoxy libpng libzip lua sdl2 sqlite3
+          vcpkg --no-dry-run upgrade
+      - uses: jurplel/install-qt-action@v3.2.1
+        with:
+          cache: true
+          #setup-python: false
+      - name: CMake
+        working-directory: build
+        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DZLIB_LIBRARY=zlib
+      - name: Build
+        working-directory: build
+        run: cmake --build . -j$env:NUMBER_OF_PROCESSORS
+
+  build-windows-cross:
+    runs-on: ubuntu-latest
+    #env:
+    #  CC: x86_64-w64-mingw32-gcc
+    #  CXX: x86_64-w64-mingw32-g++
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libepoxy-dev libsdl2-dev libglu1-mesa-dev mesa-common-dev mingw-w64
+          mkdir -p build
+      - uses: jurplel/install-qt-action@v3.2.1
+        with:
+          cache: true
+          setup-python: false
+      - name: CMake
+        working-directory: build
+        run: cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++
+      - name: Build
+        working-directory: build
+        #env:
+        #  CC: x86_64-w64-mingw32-gcc
+        #  CXX: x86_64-w64-mingw32-g++
+        #run: make -j$(nproc)
+        run: cmake --build . -j$(nproc)
+      - name: Create artifacts
+        working-directory: build
+        run: cpack -G ZIP
+      - uses: actions/upload-artifact@v3
+        with:
+          name: mgba-windows-cross
+          path: build/*.zip
+          if-no-files-found: error
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libsdl2-dev
+      - uses: jurplel/install-qt-action@v3.2.1
+        with:
+          cache: true
+          setup-python: false
+      - name: CMake
+        run: cmake -Bbuild
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+  build-macos:
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        run: brew install cmake ffmpeg libzip qt5 sdl2 libedit lua pkg-config
+      #- uses: jurplel/install-qt-action@v3.2.1
+      #  with:
+      #    cache: true
+      #    #setup-python: false
+      - name: CMake
+        run: cmake -Bbuild #-DCMAKE_PREFIX_PATH=$(brew --prefix qt5) # prefix might not be needed
+      - name: Build
+        run: cmake --build build -j$(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           #setup-python: false
       - name: CMake
         working-directory: build
-        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=${env:VCPKG_INSTALLATION_ROOT}\scripts\buildsystems\vcpkg.cmake #-DZLIB_LIBRARY=zlib
+        run: cmake .. -DCMAKE_CONFIGURATION_TYPES=$env:VCPKG_BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
       - name: Build
         working-directory: build
         run: cmake --build . -j$env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup
         run: |
-          #C:\vcpkg\bootstrap-vcpkg.bat
+          cd $env:VCPKG_INSTALLATION_ROOT
+          .\bootstrap-vcpkg
+          vcpkg integrate install
           vcpkg install ffmpeg[vpx,x264] libepoxy libpng libzip lua sdl2 sqlite3
           vcpkg --no-dry-run upgrade
+          vcpkg integrate install
+          cd -
           mkdir build
       - uses: jurplel/install-qt-action@v3.2.1
         with:


### PR DESCRIPTION
AppVeyor is slow (only one job at a time) and requires additional setup (registering an account, adding the repository, etc) while GitHub Actions doesn't.

Example run: https://github.com/Margen67/mgba/actions/runs/5160558114
Linux and macOS seemingly build fine.

Windows is a different story:
* Docker:
  `mkdir: cannot create directory 'build-win64': Permission denied`
  https://github.com/Margen67/mgba/actions/runs/5161053167/jobs/9297716540#step:3:86
  Running docker with `sudo` doesn't fix this.
  If I create the `build-win64` folder beforehand it spews a bunch of other strange errors, possibly due to not having write permission:
  https://github.com/Margen67/mgba/actions/runs/5160690280/jobs/9296967058#step:4:85
  I'm not sure if the other Docker images are broken.
* vcpkg:
  `Windows requires epoxy module!`
  Without `-DZLIB_LIBRARY=zlib`:
    * Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.11")
* msys2:
  * Works*
    Slow to setup/build, and not very useful since it requires tons of DLLs which cpack doesn't include in it's archive.
* Cross-compiling from Linux:
  ```
  Failed to find "GL/gl.h" in "/usr/include/libdrm".
  ```
  Installing `libglu1-mesa-dev` and `mesa-common-dev` doesn't fix this.

#
Hopefully someone who knows what they're doing can help :^)