### PR TITLE
Memory search and memory view rework

### DIFF
--- a/include/mgba/core/mem-search.h
+++ b/include/mgba/core/mem-search.h
@@ -15,19 +15,27 @@ CXX_GUARD_START
 enum mCoreMemorySearchType {
 	mCORE_MEMORY_SEARCH_INT,
 	mCORE_MEMORY_SEARCH_STRING,
-	mCORE_MEMORY_SEARCH_GUESS,
 };
 
 enum mCoreMemorySearchOp {
 	mCORE_MEMORY_SEARCH_EQUAL,
+	mCORE_MEMORY_SEARCH_NOT_EQUAL,
 	mCORE_MEMORY_SEARCH_GREATER,
+	mCORE_MEMORY_SEARCH_NOT_GREATER,
 	mCORE_MEMORY_SEARCH_LESS,
+	mCORE_MEMORY_SEARCH_NOT_LESS,
 	mCORE_MEMORY_SEARCH_ANY,
-	mCORE_MEMORY_SEARCH_DELTA,
-	mCORE_MEMORY_SEARCH_DELTA_POSITIVE,
-	mCORE_MEMORY_SEARCH_DELTA_NEGATIVE,
-	mCORE_MEMORY_SEARCH_DELTA_ANY,
+	mCORE_MEMORY_SEARCH_CHANGED,
+	mCORE_MEMORY_SEARCH_NOT_CHANGED,
+	mCORE_MEMORY_SEARCH_CHANGED_BY,
+	mCORE_MEMORY_SEARCH_INCREASE,
+	mCORE_MEMORY_SEARCH_NOT_INCREASE,
+	mCORE_MEMORY_SEARCH_INCREASE_BY,
+	mCORE_MEMORY_SEARCH_DECREASE,
+	mCORE_MEMORY_SEARCH_NOT_DECREASE,
+	mCORE_MEMORY_SEARCH_DECREASE_BY,
 };
+
 
 struct mCoreMemorySearchParams {
 	int memoryFlags;
@@ -37,18 +45,21 @@ struct mCoreMemorySearchParams {
 	int width;
 	union {
 		const char* valueStr;
-		int32_t valueInt;
+		int64_t valueInt;
 	};
+	uint32_t start;
+	uint32_t end;
+	bool signedNum;
 };
 
 struct mCoreMemorySearchResult {
 	uint32_t address;
 	int segment;
-	uint32_t guessDivisor;
-	uint32_t guessMultiplier;
 	enum mCoreMemorySearchType type;
 	int width;
-	int32_t oldValue;
+	int64_t curValue;
+	int64_t oldValue;
+	bool signedNum;
 };
 
 DECLARE_VECTOR(mCoreMemorySearchResults, struct mCoreMemorySearchResult);

--- a/src/platform/qt/MemorySearch.cpp
+++ b/src/platform/qt/MemorySearch.cpp
@@ -3,30 +3,31 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include <climits>
+#include <QTextCodec>
 
 #include "MemorySearch.h"
 
 #include <mgba/core/core.h>
 
 #include "CoreController.h"
-#include "MemoryView.h"
 
 using namespace QGBA;
+
 
 MemorySearch::MemorySearch(std::shared_ptr<CoreController> controller, QWidget* parent)
 	: QWidget(parent)
 	, m_controller(controller)
 {
 	m_ui.setupUi(this);
-
+	memView = nullptr;
 	mCoreMemorySearchResultsInit(&m_results, 0);
 	connect(m_ui.search, &QPushButton::clicked, this, &MemorySearch::search);
 	connect(m_ui.value, &QLineEdit::returnPressed, this, &MemorySearch::search); 
 	connect(m_ui.searchWithin, &QPushButton::clicked, this, &MemorySearch::searchWithin);
-	connect(m_ui.refresh, &QPushButton::clicked, this, &MemorySearch::refresh);
 	connect(m_ui.numHex, &QPushButton::clicked, this, &MemorySearch::refresh);
 	connect(m_ui.numDec, &QPushButton::clicked, this, &MemorySearch::refresh);
-	connect(m_ui.viewMem, &QPushButton::clicked, this, &MemorySearch::openMemory);
+	connect(m_ui.results, &QTableWidget::cellDoubleClicked, this, &openMemory);
 
 	connect(controller.get(), &CoreController::stopping, this, &QWidget::close);
 }
@@ -35,133 +36,207 @@ MemorySearch::~MemorySearch() {
 	mCoreMemorySearchResultsDeinit(&m_results);
 }
 
-bool MemorySearch::createParams(mCoreMemorySearchParams* params) {
+bool MemorySearch::createParams(mCoreMemorySearchParams* params, QByteArray &string) {
 	params->memoryFlags = mCORE_MEMORY_WRITE;
 	if (m_ui.searchROM->isChecked()) {
 		params->memoryFlags |= mCORE_MEMORY_READ;
 	}
-
-	QByteArray string;
+		
 	bool ok = false;
+
+	params->start = 0x2000000;
+	uint32_t s = m_ui.start->text().toUInt(&ok, 16);
+	if (ok && m_ui.start->text() != "") {
+		params->start = s;
+	}
+	if (params->start < 0x2000000) {
+		params->start = 0x2000000;
+	}
+	if (params->start > 0xA000000) {
+		params->start = 0xA000000;
+	}
+	params->end = 0x7000400;
+	uint32_t e = m_ui.end->text().toUInt(&ok, 16);
+	if (ok && m_ui.end->text() != "") {
+		params->end = e;
+	} else {
+		if (m_ui.searchROM->isChecked()) {
+			params->end = 0xA000000;
+		}
+	}
+	if (params->end < 0x2000000) {
+		params->end = 0x3008000;  
+	}
+	if (params->end > 0xA000000) {
+		params->end = 0xA000000;
+	}
+	QString str_addr;
+	str_addr = QString("%1").arg(params->start, 0, 16);
+	m_ui.label_s->setText(str_addr);
+	str_addr = QString("%1").arg(params->end, 0, 16);
+	m_ui.label_e->setText(str_addr);
+	
+	params->align = -1;
+	params->width = 0;
+	params->signedNum = false;
+
+	if (m_ui.bits8->isChecked()) {
+		params->width |= 1;
+	}
+	if (m_ui.bits16->isChecked()) {
+		params->width |= 2;
+	}
+	if (m_ui.bits32->isChecked()) {
+		params->width |= 4;
+	}
 	if (m_ui.typeNum->isChecked()) {
 		params->type = mCORE_MEMORY_SEARCH_INT;
-		if (m_ui.opDelta->isChecked() || m_ui.opDelta0->isChecked()) {
-			params->op = mCORE_MEMORY_SEARCH_DELTA;
-		} else if (m_ui.opGreater->isChecked()) {
-			params->op = mCORE_MEMORY_SEARCH_GREATER;
-		} else if (m_ui.opLess->isChecked()) {
-			params->op = mCORE_MEMORY_SEARCH_LESS;
+		if (m_ui.opChangedBy->isChecked()) {
+			params->op = mCORE_MEMORY_SEARCH_CHANGED_BY;
+		} else if (m_ui.opChanged->isChecked()) {
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_CHANGED : mCORE_MEMORY_SEARCH_CHANGED;
+		} else if (m_ui.opIncBy->isChecked()) {
+			params->op = mCORE_MEMORY_SEARCH_INCREASE_BY;
+		} else if (m_ui.opInc->isChecked()) {
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_INCREASE : mCORE_MEMORY_SEARCH_INCREASE;
+		} else if (m_ui.opDecBy->isChecked()) {
+			params->op = mCORE_MEMORY_SEARCH_DECREASE_BY;
+		} else if (m_ui.opDec->isChecked()) {
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_DECREASE : mCORE_MEMORY_SEARCH_DECREASE;
 		} else if (m_ui.opUnknown->isChecked()) {
 			params->op = mCORE_MEMORY_SEARCH_ANY;
-		} else if (m_ui.opDeltaPositive->isChecked()) {
-			params->op = mCORE_MEMORY_SEARCH_DELTA_POSITIVE;
-		} else if (m_ui.opDeltaNegative->isChecked()) {
-			params->op = mCORE_MEMORY_SEARCH_DELTA_NEGATIVE;
+		} else if (m_ui.opGreater->isChecked()) {
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_GREATER : mCORE_MEMORY_SEARCH_GREATER;
+		} else if (m_ui.opLess->isChecked()) {
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_LESS: mCORE_MEMORY_SEARCH_LESS;
 		} else {
-			params->op = mCORE_MEMORY_SEARCH_EQUAL;
+			params->op = m_ui.opNot->isChecked() ? mCORE_MEMORY_SEARCH_NOT_EQUAL : mCORE_MEMORY_SEARCH_EQUAL;
 		}
-		params->align = -1;
-		if (m_ui.bits8->isChecked()) {
-			params->width = 1;
-		}
-		if (m_ui.bits16->isChecked()) {
-			params->width = 2;
-		}
-		if (m_ui.bits32->isChecked()) {
-			params->width = 4;
-		}
-		if (m_ui.bitsGuess->isChecked()) {
-			params->width = -1;
-		}
-		if (m_ui.numHex->isChecked()) {
-			uint32_t v = m_ui.value->text().toUInt(&ok, 16);
+		
+		if (m_ui.numHex->isChecked() && m_ui.value->text() != "") {
+			uint32_t v = m_ui.value->text().toULong(&ok, 16);
 			if (ok) {
 				params->valueInt = v;
-				switch (params->width) {
-				case 1:
-					ok = v < 0x100;
-					break;
-				case 2:
-					ok = v < 0x10000;
-					break;
-				case 4:
-					break;
-				default:
-					ok = false;
-					break;
+				if (v > UCHAR_MAX) {
+					params->width &= 0x6;
+				}
+				if (v > USHRT_MAX) {
+					params->width &= 0x4;
 				}
 			}
 		}
-		if (m_ui.numDec->isChecked()) {
-			uint32_t v = m_ui.value->text().toUInt(&ok, 10);
-			if (ok) {
-				params->valueInt = v;
-				switch (params->width) {
-				case 1:
-					ok = v < 0x100;
-					break;
-				case 2:
-					ok = v < 0x10000;
-					break;
-				case 4:
-					break;
-				default:
-					ok = false;
-				}
-			}
-		}
-		if (m_ui.numGuess->isChecked()) {
-			params->type = mCORE_MEMORY_SEARCH_GUESS;
-			if (m_ui.opDelta0->isChecked()) {
-				m_string = QString("0").toLocal8Bit();
+	
+		else if (m_ui.numDec->isChecked() && m_ui.value->text() != "") {
+			int64_t v;
+			if (m_ui.value->text().indexOf('-') > -1) {
+				v = m_ui.value->text().toLong(&ok, 10);
+				params->signedNum = true;
 			} else {
-				m_string = m_ui.value->text().toLocal8Bit();
+				v = m_ui.value->text().toULong(&ok, 10);
 			}
-			params->valueStr = m_string.constData();
-			ok = true;
-		} else if (m_ui.opDelta0->isChecked()) {
-			params->valueInt = 0;
+			if (ok) {
+				params->valueInt = v;
+				 if (params->signedNum) {
+					if (v > SCHAR_MAX || v < SCHAR_MIN) {
+						params->width &= 0x6;
+					}
+					if (v > SHRT_MAX || v < SHRT_MIN) {
+						params->width &= 0x4;
+					}
+				 } else {
+					if (v > UCHAR_MAX) {
+						params->width &= 0x6;
+					}
+					if (v > USHRT_MAX) {
+						params->width &= 0x4;
+					}
+				 }
+			}
+		}
+		if (!ok) {
+			switch (params->op) {
+			case mCORE_MEMORY_SEARCH_INCREASE:
+			case mCORE_MEMORY_SEARCH_NOT_INCREASE:
+			case mCORE_MEMORY_SEARCH_DECREASE:
+			case mCORE_MEMORY_SEARCH_NOT_DECREASE:
+			case mCORE_MEMORY_SEARCH_CHANGED:
+			case mCORE_MEMORY_SEARCH_NOT_CHANGED:
+			case mCORE_MEMORY_SEARCH_ANY:
+				 ok = params->width;
+				 break;
+			case mCORE_MEMORY_SEARCH_GREATER:
+			case mCORE_MEMORY_SEARCH_NOT_GREATER:
+			case mCORE_MEMORY_SEARCH_LESS:
+			case mCORE_MEMORY_SEARCH_NOT_LESS:
+			case mCORE_MEMORY_SEARCH_EQUAL:
+			case mCORE_MEMORY_SEARCH_NOT_EQUAL:
+			case mCORE_MEMORY_SEARCH_CHANGED_BY:
+			case mCORE_MEMORY_SEARCH_INCREASE_BY:
+			case mCORE_MEMORY_SEARCH_DECREASE_BY:
+			default:
+				 break;
+			}
 		}
 	}
-	if (m_ui.typeStr->isChecked()) {
+	else if (m_ui.typeByteArr->isChecked()) {
 		params->type = mCORE_MEMORY_SEARCH_STRING;
-		m_string = m_ui.value->text().toLocal8Bit();
-		params->valueStr = m_string.constData();
-		params->width = m_ui.value->text().size();
+		QString str = m_ui.value->text().simplified().remove(' ');
+		if (str.length() % 2 != 0) {
+			ok = false;
+		}
+		string = QByteArray::fromHex(str.toLatin1());
+		params->valueStr = string.constData();
+		params->width = string.size();
+		ok = true;
+	} else {
+		params->type = mCORE_MEMORY_SEARCH_STRING;
+		QString enc = m_ui.encoding->currentText();
+		if (enc == "ASCII") {
+			string = m_ui.value->text().toLatin1();
+		} else {
+			QTextCodec* codec = QTextCodec::codecForName(enc.toLatin1());
+			string = codec->fromUnicode(m_ui.value->text());
+		}
+		params->valueStr = string.constData();
+		params->width = string.size();
 		ok = true;
 	}
+
+	m_ui.msg->setText(ok ? QString("MSG:") : QString("MSG: Invalid input parameters. Skip searching."));
 	return ok;
 }
 
 void MemorySearch::search() {
 	mCoreMemorySearchResultsClear(&m_results);
-
 	mCoreMemorySearchParams params;
-
+	QByteArray string;
 	CoreController::Interrupter interrupter(m_controller);
 	mCore* core = m_controller->thread()->core;
 
-	if (createParams(&params)) {
+	if (createParams(&params, string)) {
 		mCoreMemorySearch(core, &params, &m_results, LIMIT);
-	}
-
-	refresh();
+		if (mCoreMemorySearchResultsSize(&m_results) > 0) {
+			m_ui.opChangedBy->setEnabled(true);
+			m_ui.opChanged->setEnabled(true);
+			m_ui.opDec->setEnabled(true);
+			m_ui.opInc->setEnabled(true);
+			m_ui.opDecBy->setEnabled(true);
+			m_ui.opIncBy->setEnabled(true);
+		}
+		refresh();
+	}	
 }
 
 void MemorySearch::searchWithin() {
 	mCoreMemorySearchParams params;
-
+	QByteArray string;
 	CoreController::Interrupter interrupter(m_controller);
 	mCore* core = m_controller->thread()->core;
 
-	if (createParams(&params)) {
-		if (m_ui.opUnknown->isChecked()) {
-			params.op = mCORE_MEMORY_SEARCH_DELTA_ANY;
-		}
+	if (createParams(&params, string)) {
 		mCoreMemorySearchRepeat(core, &params, &m_results);
+		refresh();
 	}
-
-	refresh();
 }
 
 void MemorySearch::refresh() {
@@ -169,109 +244,62 @@ void MemorySearch::refresh() {
 	mCore* core = m_controller->thread()->core;
 
 	m_ui.results->clearContents();
-	m_ui.results->setRowCount(mCoreMemorySearchResultsSize(&m_results));
-	m_ui.opDelta->setEnabled(false);
-	m_ui.opDelta0->setEnabled(false);
-	m_ui.opDeltaPositive->setEnabled(false);
-	m_ui.opDeltaNegative->setEnabled(false);
-	for (size_t i = 0; i < mCoreMemorySearchResultsSize(&m_results); ++i) {
+	size_t resSize = mCoreMemorySearchResultsSize(&m_results);
+	size_t dispCount = m_ui.dispAll->isChecked() ? resSize : (resSize > DISP_LIMIT ? DISP_LIMIT : resSize);
+	m_ui.results->setRowCount(dispCount);
+	for (size_t i = 0; i < dispCount; ++i) {
 		mCoreMemorySearchResult* result = mCoreMemorySearchResultsGetPointer(&m_results, i);
 		QTableWidgetItem* item = new QTableWidgetItem(QString("%1").arg(result->address, 8, 16, QChar('0')));
 		m_ui.results->setItem(i, 0, item);
+		QTableWidgetItem* prev = nullptr;
 		QTableWidgetItem* type = nullptr;
 		QByteArray string;
-		if (result->type == mCORE_MEMORY_SEARCH_INT && m_ui.numHex->isChecked()) {
-			switch (result->width) {
-			case 1:
-				item = new QTableWidgetItem(QString("%1").arg(core->rawRead8(core, result->address, result->segment), 2, 16, QChar('0')));
-				break;
-			case 2:
-				item = new QTableWidgetItem(QString("%1").arg(core->rawRead16(core, result->address, result->segment), 4, 16, QChar('0')));
-				break;
-			case 4:
-				item = new QTableWidgetItem(QString("%1").arg(core->rawRead32(core, result->address, result->segment), 8, 16, QChar('0')));
-				break;
+		if (result->type == mCORE_MEMORY_SEARCH_INT) {
+			if (m_ui.numHex->isChecked()) {
+				 item = new QTableWidgetItem(
+				     QString("%1").arg(result->curValue, result->width << 1, 16, QChar('0')).right(result->width << 1));
+				 prev = new QTableWidgetItem(
+				     QString("%1").arg(result->oldValue, result->width << 1, 16, QChar('0')).right(result->width << 1));
+			} else {
+				 item = new QTableWidgetItem(QString("%1").arg(result->curValue, 0, 10));
+				 prev = new QTableWidgetItem(QString("%1").arg(result->oldValue, 0, 10));
 			}
 		} else {
-			switch (result->type) {
-			case mCORE_MEMORY_SEARCH_INT:
-				switch (result->width) {
-				case 1:
-					item = new QTableWidgetItem(QString::number(core->rawRead8(core, result->address, result->segment)));
-					break;
-				case 2:
-					item = new QTableWidgetItem(QString::number(core->rawRead16(core, result->address, result->segment)));
-					break;
-				case 4:
-					item = new QTableWidgetItem(QString::number(core->rawRead32(core, result->address, result->segment)));
-					break;
-				}
-				break;
-			case mCORE_MEMORY_SEARCH_STRING:
-				string.reserve(result->width);
-				for (int i = 0; i < result->width; ++i) {
-					string.append(core->rawRead8(core, result->address + i, result->segment));
-				}
-				item = new QTableWidgetItem(QLatin1String(string)); // TODO
-				break;
-			case mCORE_MEMORY_SEARCH_GUESS:
-				item = nullptr;
-				break;
+			string.reserve(result->width);
+			for (int i = 0; i < result->width; ++i) {
+				 string.append(core->rawRead8(core, result->address + i, result->segment));
 			}
+			item = new QTableWidgetItem(QString(string.toHex())); // TODO
+
 			Q_ASSERT(item);
-		}
-		QString divisor;
-		if (result->guessDivisor > 1) {
-			if (result->guessMultiplier > 1) {
-				divisor = tr(" (%0/%1×)").arg(result->guessMultiplier).arg(result->guessMultiplier);
-			} else {
-				divisor = tr(" (⅟%0×)").arg(result->guessDivisor);
-			}
-		} else if (result->guessMultiplier > 1) {
-			divisor = tr(" (%0×)").arg(result->guessMultiplier);
 		}
 		switch (result->type) {
 		case mCORE_MEMORY_SEARCH_INT:
-			type = new QTableWidgetItem(tr("%1 byte%2").arg(result->width).arg(divisor));
+			type = new QTableWidgetItem(tr("%1 byte(s)").arg(result->width));
 			break;
 		case mCORE_MEMORY_SEARCH_STRING:
 			type = new QTableWidgetItem("string");
-			break;
-		case mCORE_MEMORY_SEARCH_GUESS:
+			prev = new QTableWidgetItem("");
 			break;
 		}
 		Q_ASSERT(type);
 
 		m_ui.results->setItem(i, 1, item);
-		m_ui.results->setItem(i, 2, type);
-		m_ui.opDelta->setEnabled(true);
-		m_ui.opDelta0->setEnabled(true);
-		m_ui.opDeltaPositive->setEnabled(true);
-		m_ui.opDeltaNegative->setEnabled(true);
-	}
-	if (m_ui.opDelta->isChecked() && !m_ui.opDelta->isEnabled()) {
-		m_ui.opEqual->setChecked(true);
-	} else if (m_ui.opDelta0->isChecked() && !m_ui.opDelta0->isEnabled()) {
-		m_ui.opEqual->setChecked(true);
-	} else if (m_ui.opDeltaPositive->isChecked() && !m_ui.opDeltaPositive->isEnabled()) {
-		m_ui.opEqual->setChecked(true);
-	} else if (m_ui.opDeltaNegative->isChecked() && !m_ui.opDeltaNegative->isEnabled()) {
-		m_ui.opEqual->setChecked(true);
+		m_ui.results->setItem(i, 2, prev);
+		m_ui.results->setItem(i, 3, type);
 	}
 	m_ui.results->sortItems(0);
+	m_ui.msg->setText(QString("MSG: display %1 of %2 results").arg(dispCount).arg(resSize));
 }
 
-void MemorySearch::openMemory() {
-	auto items = m_ui.results->selectedItems();
-	if (items.empty()) {
-		return;
+void MemorySearch::openMemory(int row, int col) {
+	
+	uint32_t address = m_ui.results->item(row, 0)->text().toUInt(nullptr, 16);
+
+	if (memView == nullptr) {
+		memView = new MemoryView(m_controller);
 	}
-	QTableWidgetItem* item = items[0];
-	uint32_t address = item->text().toUInt(nullptr, 16);
 
-	MemoryView* memView = new MemoryView(m_controller);
 	memView->jumpToAddress(address);
-
-	memView->setAttribute(Qt::WA_DeleteOnClose);
 	memView->show();
 }

--- a/src/platform/qt/MemorySearch.h
+++ b/src/platform/qt/MemorySearch.h
@@ -11,6 +11,8 @@
 
 #include <mgba/core/mem-search.h>
 
+#include "MemoryView.h"
+
 namespace QGBA {
 
 class CoreController;
@@ -19,7 +21,8 @@ class MemorySearch : public QWidget {
 Q_OBJECT
 
 public:
-	static constexpr size_t LIMIT = 10000;
+	static constexpr size_t LIMIT = 0x48000; //WRAM size 256KB +32KB
+	static constexpr size_t DISP_LIMIT = 100;
 
 	MemorySearch(std::shared_ptr<CoreController> controller, QWidget* parent = nullptr);
 	~MemorySearch();
@@ -30,15 +33,15 @@ public slots:
 	void searchWithin();
 
 private slots:
-	void openMemory();
+	void openMemory(int, int);
 
 private:
-	bool createParams(mCoreMemorySearchParams*);
+	bool createParams(mCoreMemorySearchParams*, QByteArray&);
 
 	Ui::MemorySearch m_ui;
+	MemoryView* memView;
 
 	std::shared_ptr<CoreController> m_controller;
-
 	mCoreMemorySearchResults m_results;
 	QByteArray m_string;
 };

--- a/src/platform/qt/MemorySearch.ui
+++ b/src/platform/qt/MemorySearch.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>725</width>
-    <height>813</height>
+    <width>632</width>
+    <height>477</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,347 +18,702 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>540</width>
-    <height>400</height>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>616</width>
+    <height>584</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Memory Search</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="QTableWidget" name="results">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QFrame" name="frame_3">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="showGrid">
-      <bool>false</bool>
-     </property>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Address</string>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
       </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Current Value</string>
+      <property name="topMargin">
+       <number>0</number>
       </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Type</string>
+      <property name="rightMargin">
+       <number>0</number>
       </property>
-     </column>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QFrame" name="frame_9">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Value</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="value"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame_4">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>0</number>
+         </property>
+         <item row="2" column="5">
+          <widget class="QCheckBox" name="dispAll">
+           <property name="text">
+            <string>Show all results</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" rowspan="3">
+          <widget class="QFrame" name="frame_8">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="typeText">
+              <property name="text">
+               <string>Text</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QRadioButton" name="typeByteArr">
+              <property name="text">
+               <string>Byte sequence</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="typeNum">
+              <property name="text">
+               <string>Number</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="encoding">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <item>
+               <property name="text">
+                <string>ASCII</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>UTF-8</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>UTF-16LE</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Shift-JIS</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="1" colspan="6">
+          <widget class="QFrame" name="frame_7">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="bits8">
+              <property name="text">
+               <string>1 Byte</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="bits16">
+              <property name="text">
+               <string>2 Bytes</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="bits32">
+              <property name="text">
+               <string>4 Bytes</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="numDec">
+              <property name="text">
+               <string>Dec</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="numHex">
+              <property name="text">
+               <string>Hex</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QLabel" name="msg">
+           <property name="text">
+            <string>MSG:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>33</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="4">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>432</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="frame_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>240</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="Line" name="line">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="frame_5">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>9</number>
+               </property>
+               <property name="horizontalSpacing">
+                <number>0</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>2</number>
+               </property>
+               <item row="2" column="1">
+                <widget class="QRadioButton" name="opChanged">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Changed</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QRadioButton" name="opUnknown">
+                 <property name="text">
+                  <string>Unknown</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QRadioButton" name="opInc">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Increase</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QRadioButton" name="opDecBy">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Decreased by</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QRadioButton" name="opDec">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Decrease</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QRadioButton" name="opGreater">
+                 <property name="text">
+                  <string>Greater than</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="opNot">
+                 <property name="text">
+                  <string>Not</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QRadioButton" name="opChangedBy">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Changed by</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="opEqual">
+                 <property name="text">
+                  <string>Equal</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QRadioButton" name="opIncBy">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Increased by</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QRadioButton" name="opLess">
+                 <property name="text">
+                  <string>Less than</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_5">
+                 <property name="text">
+                  <string>Number search type</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_3">
+              <property name="lineWidth">
+               <number>1</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="frame_6">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_3">
+               <property name="leftMargin">
+                <number>1</number>
+               </property>
+               <property name="topMargin">
+                <number>1</number>
+               </property>
+               <property name="rightMargin">
+                <number>1</number>
+               </property>
+               <property name="bottomMargin">
+                <number>1</number>
+               </property>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="start"/>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_s">
+                 <property name="text">
+                  <string>Start</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="end"/>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_e">
+                 <property name="text">
+                  <string>End</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="searchROM">
+                 <property name="text">
+                  <string>Search ROM</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTableWidget" name="results">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
+           <property name="showGrid">
+            <bool>false</bool>
+           </property>
+           <attribute name="verticalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>Address</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Current Value</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Prev Value</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame3">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="search">
+           <property name="text">
+            <string>New Search</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="searchWithin">
+           <property name="text">
+            <string>Search Within</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QDialogButtonBox" name="buttonBox">
+           <property name="standardButtons">
+            <set>QDialogButtonBox::Close</set>
+           </property>
+           <property name="centerButtons">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Value</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="value"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QRadioButton" name="typeNum">
-       <property name="text">
-        <string>Numeric</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">type</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QRadioButton" name="typeStr">
-       <property name="text">
-        <string>Text</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">type</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QRadioButton" name="bitsGuess">
-       <property name="text">
-        <string>Guess</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">width</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QRadioButton" name="bits8">
-       <property name="text">
-        <string>1 Byte (8-bit)</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">width</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QRadioButton" name="bits16">
-       <property name="text">
-        <string>2 Bytes (16-bit)</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">width</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QRadioButton" name="bits32">
-       <property name="text">
-        <string>4 Bytes (32-bit)</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">width</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="9" column="0" colspan="2">
-      <widget class="Line" name="line_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Number type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QRadioButton" name="numGuess">
-       <property name="text">
-        <string>Guess</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QRadioButton" name="numDec">
-       <property name="text">
-        <string>Decimal</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QRadioButton" name="numHex">
-       <property name="text">
-        <string>Hexadecimal</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0" colspan="2">
-      <widget class="Line" name="line_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Search type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="1">
-      <widget class="QRadioButton" name="opEqual">
-       <property name="text">
-        <string>Equal to value</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="15" column="1">
-      <widget class="QRadioButton" name="opGreater">
-       <property name="text">
-        <string>Greater than value</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="16" column="1">
-      <widget class="QRadioButton" name="opLess">
-       <property name="text">
-        <string>Less than value</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="17" column="1">
-      <widget class="QRadioButton" name="opUnknown">
-       <property name="text">
-        <string>Unknown/changed</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="18" column="1">
-      <widget class="QRadioButton" name="opDelta">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Changed by value</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="21" column="1">
-      <widget class="QRadioButton" name="opDelta0">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Unchanged</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="19" column="1">
-      <widget class="QRadioButton" name="opDeltaPositive">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Increased</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="20" column="1">
-      <widget class="QRadioButton" name="opDeltaNegative">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Decreased</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">op</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="searchROM">
-       <property name="text">
-        <string>Search ROM</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="search">
-       <property name="text">
-        <string>New Search</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="searchWithin">
-       <property name="text">
-        <string>Search Within</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="viewMem">
-       <property name="text">
-        <string>Open in Memory Viewer</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="refresh">
-       <property name="text">
-        <string>Refresh</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>
@@ -371,8 +726,8 @@
    <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>315</x>
-     <y>357</y>
+     <x>612</x>
+     <y>466</y>
     </hint>
     <hint type="destinationlabel">
      <x>315</x>
@@ -381,25 +736,276 @@
    </hints>
   </connection>
   <connection>
-   <sender>opDelta0</sender>
+   <sender>typeNum</sender>
    <signal>toggled(bool)</signal>
-   <receiver>value</receiver>
+   <receiver>frame_7</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>69</x>
+     <y>59</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>210</x>
+     <y>72</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>typeText</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>encoding</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>56</x>
+     <y>88</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>190</x>
+     <y>89</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opChanged</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>231</x>
-     <y>768</y>
+     <x>142</x>
+     <y>188</y>
     </hint>
     <hint type="destinationlabel">
-     <x>272</x>
-     <y>26</y>
+     <x>26</x>
+     <y>459</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opChangedBy</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>175</x>
+     <y>244</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>44</x>
+     <y>449</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opIncBy</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>187</x>
+     <y>280</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>59</x>
+     <y>452</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opDecBy</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>149</x>
+     <y>304</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>72</x>
+     <y>450</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opEqual</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>112</x>
+     <y>189</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>27</x>
+     <y>161</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opGreater</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>93</x>
+     <y>199</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>52</x>
+     <y>165</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opLess</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>53</x>
+     <y>230</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>49</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opChanged</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>209</x>
+     <y>187</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>35</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opInc</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>156</x>
+     <y>212</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>74</x>
+     <y>446</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opDec</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>146</x>
+     <y>225</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>81</x>
+     <y>445</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opInc</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>196</x>
+     <y>202</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>98</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opDec</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opNot</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>207</x>
+     <y>221</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>113</x>
+     <y>161</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>typeNum</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>frame_5</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>91</x>
+     <y>43</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>142</x>
+     <y>146</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>typeText</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>84</x>
+     <y>79</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>83</x>
+     <y>445</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>typeByteArr</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>search</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>77</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>80</x>
+     <y>465</y>
     </hint>
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="type"/>
-  <buttongroup name="op"/>
-  <buttongroup name="width"/>
- </buttongroups>
 </ui>

--- a/src/platform/qt/MemoryView.ui
+++ b/src/platform/qt/MemoryView.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>874</width>
-    <height>900</height>
+    <height>458</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -179,72 +179,215 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Unsigned Integer:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="uintVal">
-         <property name="maxLength">
-          <number>10</number>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="1" column="0" colspan="2">
+      <widget class="QFrame" name="frame0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="leftMargin">
+         <number>1</number>
+        </property>
+        <property name="topMargin">
+         <number>1</number>
+        </property>
+        <property name="rightMargin">
+         <number>1</number>
+        </property>
+        <property name="bottomMargin">
+         <number>1</number>
+        </property>
+        <item>
+         <widget class="QComboBox" name="encoding">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string>ASCII</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>UTF-8</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>UTF-16LE</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Shift-JIS</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>String:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="stringVal">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="loadTBL">
+          <property name="text">
+           <string>Load TBL</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item row="0" column="0">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Signed Integer:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="sintVal">
-         <property name="maxLength">
-          <number>11</number>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="0" colspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>String:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="stringVal">
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="loadTBL">
-         <property name="text">
-          <string>Load TBL</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QFrame" name="frame1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>int8</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="int8">
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>4</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>uint8</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="uint8">
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>3</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>int16</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="int16">
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>6</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>uint16</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="uint16">
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>5</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>int32</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="int32">
+          <property name="maximumSize">
+           <size>
+            <width>160</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>11</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>uint32</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="uint32">
+          <property name="maximumSize">
+           <size>
+            <width>160</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maxLength">
+           <number>10</number>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
    </item>
@@ -317,8 +460,7 @@
   <tabstop>width8</tabstop>
   <tabstop>width16</tabstop>
   <tabstop>width32</tabstop>
-  <tabstop>sintVal</tabstop>
-  <tabstop>uintVal</tabstop>
+  <tabstop>int8</tabstop>
   <tabstop>stringVal</tabstop>
   <tabstop>loadTBL</tabstop>
   <tabstop>copy</tabstop>


### PR DESCRIPTION
Memory Search:
- limit displayed results & change ui layout
- change guess type -> ability to pick multiple number type
- support signed number,  common encoding text & byte array
- results caching & show previous results
- allow searching within specific memory region
- double click row to open memory view & limit number of MemoryView children to 1
Memory View:
- allow changing text encoding of stringVal
- display all int8, uint8, int16, uin16, int32, uint32 interpretation of value at cursor instead of switching between alignment 