### PR TITLE
Debugger: Fix interrupt after continue from GDB stub

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -247,9 +247,9 @@ static void _writeHostInfo(struct GDBStub* stub) {
 }
 
 static void _continue(struct GDBStub* stub, const char* message) {
-	mDebuggerModuleSetNeedsCallback(&stub->d);
 	stub->untilPoll = GDB_STUB_INTERVAL;
 	stub->d.isPaused = false;
+	mDebuggerModuleSetNeedsCallback(&stub->d);
 	// TODO: parse message
 	UNUSED(message);
 }


### PR DESCRIPTION
GDB and LLDB will send a ctrl-c character (\x03) to the stub to interrupt it after a continue where it doesn't stop on its own.

E.g.
```
void foo() {
  foo2();      // Continue from here.
  while (1) {} // Loops here until ctrl-c in the debugger.
}
```

mGBA had code to handle the ctrl-c but because in _continue we set the paused status after calling mDebuggerModuleSetNeedsCallback, the callback was never set so nothing was looking for new messages while we were running. We should instead set the paused state then call mDebuggerModuleSetNeedsCallback.

mDebuggerModuleSetNeedsCallback calls mDebuggerUpdatePaused, and all other calls to mDebuggerUpdatePaused update the paused state before that call so this matches existing usage of that too.

With this fix, after the continue _gdbStubPoll is called periodically and will pick up the ctrl-c as it comes in (_gdbStubWait is used when we are stopped in the debugger).

This fixes ctrl-c to interrupt when using lldb and gdb.