### PR TITLE
Debugger: Fix GDB no-ack mode

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -469,7 +469,7 @@ static void _processQSupportedCommand(struct GDBStub* stub, const char* message)
 		}
 		message = end + 1;
 	}
-	strncpy(stub->outgoing, "swbreak+;hwbreak+;qXfer:features:read+;qXfer:memory-map:read+", GDB_STUB_MAX_LINE - 4);
+	strncpy(stub->outgoing, "swbreak+;hwbreak+;qXfer:features:read+;qXfer:memory-map:read+;QStartNoAckMode+", GDB_STUB_MAX_LINE - 4);
 }
 
 static void _processQXferCommand(struct GDBStub* stub, const char* params, const char* data) {

--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -554,7 +554,7 @@ static void _processQReadCommand(struct GDBStub* stub, const char* message) {
 
 static void _processQWriteCommand(struct GDBStub* stub, const char* message) {
 	stub->outgoing[0] = '\0';
-	if (!strncmp("StartNoAckMode#", message, 16)) {
+	if (!strncmp("StartNoAckMode#", message, 15)) {
 		stub->lineAck = GDB_ACK_OFF;
 		strncpy(stub->outgoing, "OK", GDB_STUB_MAX_LINE - 4);
 	}


### PR DESCRIPTION
[No-ack mode](https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html) is an optimization in the GDB protocol when running over a reliable transport mechanism like TCP. It's already implemented in the GDB stub, but the stub doesn't advertise support for it, and it's broken by an off-by-one in a comparison. These fixes make it work as intended.