### PR TITLE
Qt: Fix generic icon on Wayland

### DIFF
--- a/src/platform/qt/main.cpp
+++ b/src/platform/qt/main.cpp
@@ -104,6 +104,10 @@ int main(int argc, char* argv[]) {
 	QApplication::setWindowIcon(QIcon(":/res/mgba-256.png"));
 #endif
 
+#ifdef Q_OS_UNIX
+	QApplication::setDesktopFileName(QString("io.mgba.mGBA"));
+#endif
+
 	QTranslator qtTranslator;
 	qtTranslator.load(locale, "qt", "_", QLibraryInfo::location(QLibraryInfo::TranslationsPath));
 	application.installTranslator(&qtTranslator);


### PR DESCRIPTION
The method used to set the window icon (`setWindowIcon`) does not work anymore on Wayland which results in a generic Wayland icon. To set the icon on Wayland, programs should make use of the `setDesktopFileName` method which hints the graphical shell to use the icon specified in the referenced desktop file. This icon is used for the taskbar and the window border / decorations. The described bug occurs especially when using Plasma with Wayland, but other shells using Wayland may be affected too.

The added method was introduced in Qt 5.7 which eventually raises the minimum required version of Qt.

Testing the new commit on Unix resulted in a working icon when using Plasma regardless of Wayland or X11.

If I've missed anything or should fix something, just ask and I'll try.