### PR TITLE
Res: Add gbc-lcd shader, imitates GBC LCD subpixel arrangement with an optional backlight effect

### DIFF
--- a/res/shaders/gbc-lcd.shader/gbc-lcd-light.fs
+++ b/res/shaders/gbc-lcd.shader/gbc-lcd-light.fs
@@ -56,8 +56,10 @@ uniform vec2 ReflectionDistance;
 
 #define M_PI 3.1415926535897932384626433832795
 
-// Helper to compute backlight bleed intensity
-// for a texCoord input.
+/**
+ * Helper to compute backlight bleed intensity
+ * for a texCoord input.
+ */
 float getLightIntensity(vec2 coord) {
     vec2 coordCentered = coord - vec2(0.5, 0.5);
     float coordDistCenter = (
@@ -78,11 +80,13 @@ float getLightIntensity(vec2 coord) {
     return clamp(lightIntensity, 0.0, 1.0);
 }
 
-// Helper to convert an intensity value into a white
-// gray color with that intensity. A radial distortion
-// effect with subtle chromatic abberation is applied that
-// makes it look a little more like a real old or cheap
-// backlight, and also helps to reduce color banding.
+/**
+ * Helper to convert an intensity value into a white
+ * gray color with that intensity. A radial distortion
+ * effect with subtle chromatic abberation is applied that
+ * makes it look a little more like a real old or cheap
+ * backlight, and also helps to reduce color banding.
+ */
 vec3 getWhiteVector(float intensity) {
     const float DeformAmount = 0.0025;
     vec2 texCoordCentered = texCoord - vec2(0.5, 0.5);

--- a/res/shaders/gbc-lcd.shader/gbc-lcd-light.fs
+++ b/res/shaders/gbc-lcd.shader/gbc-lcd-light.fs
@@ -1,0 +1,115 @@
+/**
+ * This shader creates a backlight bleeding effect,
+ * and an internal reflection or ghosting effect.
+ */
+ 
+varying vec2 texCoord;
+uniform sampler2D tex;
+
+/**
+ * Determines the color of the backlight bleed.
+ * Lower values produce less, dimmer light.
+ * Higher values produce brighter or more colorful light.
+ * You'll normally want each of these numbers to be close
+ * to 1, and not normally lower than 0.
+ */
+uniform vec3 LightColor;
+
+/**
+ * Affects the shape of the backlight bleed glow.
+ * Lower values cause the light bleed to fade out quickly
+ * from the edges.
+ * Higher values cause the light bleed to fade out more
+ * softly and gradually toward the center.
+ * You'll normally want this to be a number from 0 to 1.
+ */
+uniform float LightSoftness;
+
+/**
+ * Lower values result in a less visible or intense
+ * backlight bleed.
+ * Higher values make the backlight bleed more pronounced.
+ * You'll normally want this to be a number close to 0,
+ * and not normally higher than 1.
+ */
+uniform float LightIntensity;
+
+/**
+ * Lower values cause the internal reflection or ghosting
+ * effect to be less visible.
+ * Higher values cause the effect to be brighter and more
+ * visible.
+ * You'll normally want this to be a number close to 0,
+ * and not normally higher than 1.
+ */
+uniform float ReflectionBrightness;
+
+/**
+ * Lower values have the internal reflection or ghosting
+ * effect appear offset by a lesser distance.
+ * Higher values have the effect offset by a greater
+ * distance.
+ * You'll normally want each of these numbers to be close
+ * to 0, and not normally higher than 1.
+ */
+uniform vec2 ReflectionDistance;
+
+#define M_PI 3.1415926535897932384626433832795
+
+// Helper to compute backlight bleed intensity
+// for a texCoord input.
+float getLightIntensity(vec2 coord) {
+    vec2 coordCentered = coord - vec2(0.5, 0.5);
+    float coordDistCenter = (
+        length(coordCentered) / sqrt(0.5)
+    );
+    vec2 coordQuadrant = vec2(
+        1.0 - (1.5 * min(coord.x, 1.0 - coord.x)),
+        1.0 - (1.5 * min(coord.y, 1.0 - coord.y))
+    );
+    float lightIntensityEdges = (
+        pow(coordQuadrant.x, 5.0) +
+        pow(coordQuadrant.y, 5.0)
+    );
+    float lightIntensity = (
+        (1.0 - LightSoftness) * lightIntensityEdges +
+        LightSoftness * coordDistCenter
+    );
+    return clamp(lightIntensity, 0.0, 1.0);
+}
+
+// Helper to convert an intensity value into a white
+// gray color with that intensity. A radial distortion
+// effect with subtle chromatic abberation is applied that
+// makes it look a little more like a real old or cheap
+// backlight, and also helps to reduce color banding.
+vec3 getWhiteVector(float intensity) {
+    const float DeformAmount = 0.0025;
+    vec2 texCoordCentered = texCoord - vec2(0.5, 0.5);
+    float radians = atan(texCoordCentered.y, texCoordCentered.x);
+    float rot = pow(2.0, 4.0 + floor(6.0 * length(texCoordCentered)));
+    float deformRed = cos(rot * radians + (2.0 / 3.0 * M_PI));
+    float deformGreen = cos(rot * radians);
+    float deformBlue = cos(rot * radians + (4.0 / 3.0 * M_PI));
+    return clamp(vec3(
+        intensity + (deformRed * DeformAmount),
+        intensity + (deformGreen * DeformAmount),
+        intensity + (deformBlue * DeformAmount)
+    ), 0.0, 1.0);
+}
+
+void main() {
+    vec3 colorSource = texture2D(tex, texCoord).rgb;
+    vec3 lightWhiteVector = getWhiteVector(getLightIntensity(texCoord));
+    vec3 colorLight = LightColor * lightWhiteVector;
+    vec3 colorReflection = texture2D(tex, texCoord - ReflectionDistance).rgb;
+    vec3 colorResult = (
+        colorSource +
+        (colorLight * LightIntensity) +
+        (colorReflection * ReflectionBrightness)
+    );
+    gl_FragColor = vec4(
+        colorResult,
+        1.0
+    );
+}

--- a/res/shaders/gbc-lcd.shader/gbc-lcd.fs
+++ b/res/shaders/gbc-lcd.shader/gbc-lcd.fs
@@ -1,0 +1,212 @@
+/**
+ * This shader imitates the GameBoy Color subpixel
+ * arrangement.
+ */
+
+varying vec2 texCoord;
+uniform sampler2D tex;
+uniform vec2 texSize;
+
+/**
+ * Adds a base color to everything.
+ * Lower values make black colors darker.
+ * Higher values make black colors lighter.
+ * You'll normally want each of these numbers to be close
+ * to 0, and not normally higher than 1.
+ */
+uniform vec3 BaseColor;
+
+/**
+ * Modifies the contrast or saturation of the image.
+ * Lower values make the image more gray and higher values
+ * make it more colorful.
+ * A value of 1 represents a normal, baseline level of
+ * contrast.
+ * You'll normally want this to be somewhere around 1.
+ */
+uniform float SourceContrast;
+
+/**
+ * Modifies the luminosity of the image.
+ * Lower values make the image darker and higher values make
+ * it lighter.
+ * A value of 1 represents normal, baseline luminosity.
+ * You'll normally want this to be somewhere around 1.
+ */
+uniform float SourceLuminosity;
+
+/**
+ * Lower values look more like a sharp, unshaded image.
+ * Higher values look more like an LCD display with subpixels.
+ * You'll normally want this to be a number from 0 to 1.
+ */
+uniform float SubpixelBlendAmount;
+
+/**
+ * Lower values make subpixels darker.
+ * Higher values make them lighter and over-bright.
+ * * A value of 1 represents a normal, baseline gamma value.
+ * You'll normally want this to be somewhere around 1.
+ */
+uniform float SubpixelGamma;
+
+/**
+ * Higher values allow subpixels to be more blended-together
+ * and brighter.
+ * Lower values keep subpixel colors more separated.
+ * You'll normally want this to be a number from 0 to 1.
+ */
+uniform float SubpixelColorBleed;
+
+// Subpixel colors are loosely based on this resource:
+// R: #FF7145, G: #C1D650, B: #3BCEFF
+// https://gbcc.dev/technology/
+const vec3 SubpixelColorRed = vec3(1.00, 0.38, 0.22);
+const vec3 SubpixelColorGreen = vec3(0.60, 0.88, 0.30);
+const vec3 SubpixelColorBlue = vec3(0.23, 0.65, 1.00);
+
+// These values determine the size and fade-off of subpixels.
+const float SubpixelGlowWidthMin = 0.08;
+const float SubpixelGlowWidthMax = 0.36;
+const float SubpixelGlowHeightMin = 0.30;
+const float SubpixelGlowHeightMax = 0.65;
+const float SubpixelGlowWidthDelta = (
+    SubpixelGlowWidthMax - SubpixelGlowWidthMin
+);
+const float SubpixelGlowHeightDelta = (
+    SubpixelGlowHeightMax - SubpixelGlowHeightMin
+);
+
+// Helper to get luminosity of an RGB color.
+float GetColorLumosity(in vec3 rgb) {
+    return (
+        (rgb.r * (5.0 / 16.0)) +
+        (rgb.g * (9.0 / 16.0)) +
+        (rgb.b * (2.0 / 16.0))
+    );
+}
+
+// Helper to convert RGB color to HCL. (Hue, Chroma, Luma)
+vec3 ConvertRgbToHcl(in vec3 rgb) {
+    float xMin = min(rgb.r, min(rgb.g, rgb.b));
+    float xMax = max(rgb.r, max(rgb.g, rgb.b));
+    float c = xMax - xMin;
+    float l = GetColorLumosity(rgb);
+    float h = mod((
+        c == 0 ? 0.0 :
+        xMax == rgb.r ? ((rgb.g - rgb.b) / c) :
+        xMax == rgb.g ? ((rgb.b - rgb.r) / c) + 2.0 :
+        xMax == rgb.b ? ((rgb.r - rgb.g) / c) + 4.0 :
+        0.0
+    ), 6.0);
+    return vec3(h, c, l);
+}
+
+// Helper to convert HCL color to RGB. (Hue, Chroma, Luma)
+vec3 ConvertHclToRgb(in vec3 hcl) {
+    vec3 rgb;
+    float h = mod(hcl.x, 6.0);
+    float c = hcl.y;
+    float l = hcl.z;
+    float x = c * (1.0 - abs(mod(h, 2.0) - 1.0));
+    if(h <= 1.0) {
+        rgb = vec3(c, x, 0.0);
+    }
+    else if(h <= 2.0) {
+        rgb = vec3(x, c, 0.0);
+    }
+    else if(h <= 3.0) {
+        rgb = vec3(0.0, c, x);
+    }
+    else if(h <= 4.0) {
+        rgb = vec3(0.0, x, c);
+    }
+    else if(h <= 5.0) {
+        rgb = vec3(x, 0.0, c);
+    }
+    else {
+        rgb = vec3(c, 0.0, x);
+    }
+    float lRgb = GetColorLumosity(rgb);
+    float m = l - lRgb;
+    return clamp(vec3(m, m, m) + rgb, 0.0, 1.0);
+}
+
+void main() {
+    // Get base color of the pixel, adjust based on contrast
+    // and luminosity settings
+    vec3 colorSource = texture2D(tex, texCoord).rgb;
+    vec3 colorSourceHcl = ConvertRgbToHcl(colorSource);
+    vec3 colorSourceAdjusted = ConvertHclToRgb(vec3(
+        colorSourceHcl.x,
+        colorSourceHcl.y * SourceContrast,
+        colorSourceHcl.z * SourceLuminosity
+    ));
+    // Determine how much each subpixel color should affect
+    // this fragment
+    vec2 subpixelPos = mod(texCoord * texSize, 1.0);
+    float distRed = abs(subpixelPos.x - (1.35 / 8.0));
+    float distGreen = abs(subpixelPos.x - (4.0 / 8.0));
+    float distBlue = abs(subpixelPos.x - (6.65 / 8.0));
+    float mixRed = (
+        max(0.0, (
+            SubpixelGlowWidthDelta -
+            max(0.0, distRed - SubpixelGlowWidthMin)
+        )) /
+        SubpixelGlowWidthDelta
+    );
+    float mixGreen = (
+        max(0.0, (
+            SubpixelGlowWidthDelta -
+            max(0.0, distGreen - SubpixelGlowWidthMin)
+        )) /
+        SubpixelGlowWidthDelta
+    );
+    float mixBlue = (
+        max(0.0, (
+            SubpixelGlowWidthDelta -
+            max(0.0, distBlue - SubpixelGlowWidthMin)
+        )) /
+        SubpixelGlowWidthDelta
+    );
+    float distVertical = abs(subpixelPos.y - 0.55);
+    float mixVertical = (
+        max(0.0, (
+            SubpixelGlowHeightDelta -
+            max(0.0, distVertical - SubpixelGlowHeightMin)
+        )) /
+        SubpixelGlowHeightDelta
+    );
+    mixRed *= (
+        SubpixelColorBleed +
+        ((1.0 - SubpixelColorBleed) * colorSourceAdjusted.r)
+    );
+    mixGreen *= (
+        SubpixelColorBleed +
+        ((1.0 - SubpixelColorBleed) * colorSourceAdjusted.g)
+    );
+    mixBlue *= (
+        SubpixelColorBleed +
+        ((1.0 - SubpixelColorBleed) * colorSourceAdjusted.b)
+    );
+    vec3 subpixelLightColor = SubpixelGamma * mixVertical * (
+        (mixRed * SubpixelColorRed) +
+        (mixGreen * SubpixelColorGreen) +
+        (mixBlue * SubpixelColorBlue)
+    );
+    // Compute final color
+    vec3 colorResult = clamp(
+        subpixelLightColor * colorSourceAdjusted, 0.0, 1.0
+    );
+    vec3 colorResultBlended = (
+        ((1.0 - SubpixelBlendAmount) * colorSourceAdjusted) +
+        (SubpixelBlendAmount * colorResult)
+    );
+    colorResultBlended = BaseColor + (
+        (colorResultBlended * (vec3(1.0, 1.0, 1.0) - BaseColor))
+    );
+    gl_FragColor = vec4(
+        colorResultBlended,
+        1.0
+    );
+}

--- a/res/shaders/gbc-lcd.shader/gbc-lcd.fs
+++ b/res/shaders/gbc-lcd.shader/gbc-lcd.fs
@@ -258,21 +258,21 @@ vec2 getPointRectDistance(
     vec2 v1 = getPointLineDistance(point, rectBottomLeft, rectBottomRight);
     vec2 v2 = getPointLineDistance(point, rectTopLeft, rectBottomLeft);
     vec2 v3 = getPointLineDistance(point, rectTopRight, rectBottomRight);
-    float v0Length = length(v0);
-    float v1Length = length(v1);
-    float v2Length = length(v2);
-    float v3Length = length(v3);
-    float minLength = min(
-        min(v0Length, v1Length),
-        min(v2Length, v3Length)
+    float v0LengthSq = dot(v0, v0);
+    float v1LengthSq = dot(v1, v1);
+    float v2LengthSq = dot(v2, v2);
+    float v3LengthSq = dot(v3, v3);
+    float minLengthSq = min(
+        min(v0LengthSq, v1LengthSq),
+        min(v2LengthSq, v3LengthSq)
     );
-    if(minLength == v0Length) {
+    if(minLengthSq == v0LengthSq) {
         return v0;
     }
-    else if(minLength == v1Length) {
+    else if(minLengthSq == v1LengthSq) {
         return v1;
     }
-    else if(minLength == v2Length) {
+    else if(minLengthSq == v2LengthSq) {
         return v2;
     }
     else {
@@ -307,7 +307,9 @@ vec2 getPointSubpixelDistance(
         vec2(subpixelCenter.x, rectTop),
         vec2(rectRight, rectBottom)
     );
-    if(length(offsetLeft) <= length(offsetRight)) {
+    float offsetLeftLengthSq = dot(offsetLeft, offsetLeft);
+    float offsetRightLengthSq = dot(offsetRight, offsetRight);
+    if(offsetLeftLengthSq <= offsetRightLengthSq) {
         return offsetLeft;
     }
     else {

--- a/res/shaders/gbc-lcd.shader/gbc-lcd.fs
+++ b/res/shaders/gbc-lcd.shader/gbc-lcd.fs
@@ -45,7 +45,7 @@ uniform float SubpixelBlendAmount;
 /**
  * Lower values make subpixels darker.
  * Higher values make them lighter and over-bright.
- * * A value of 1 represents a normal, baseline gamma value.
+ * A value of 1 represents a normal, baseline gamma value.
  * You'll normally want this to be somewhere around 1.
  */
 uniform float SubpixelGamma;

--- a/res/shaders/gbc-lcd.shader/license.txt
+++ b/res/shaders/gbc-lcd.shader/license.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/res/shaders/gbc-lcd.shader/manifest.ini
+++ b/res/shaders/gbc-lcd.shader/manifest.ini
@@ -19,6 +19,27 @@ default[1]=0.128
 default[2]=0.101
 readableName=Screen base color
 
+[pass.0.uniform.SubpixelColorRed]
+type=float3
+default[0]=1.00
+default[1]=0.38
+default[2]=0.22
+readableName=Red subpixel color
+
+[pass.0.uniform.SubpixelColorGreen]
+type=float3
+default[0]=0.60
+default[1]=0.88
+default[2]=0.30
+readableName=Green subpixel color
+
+[pass.0.uniform.SubpixelColorBlue]
+type=float3
+default[0]=0.23
+default[1]=0.65
+default[2]=1.00
+readableName=Blue subpixel color
+
 [pass.0.uniform.SourceContrast]
 type=float
 default=0.85
@@ -32,17 +53,52 @@ readableName=Screen luminosity
 [pass.0.uniform.SubpixelBlendAmount]
 type=float
 default=1.0
-readableName=Subpixel effect intensity
+readableName=Subpixel effect amount
 
 [pass.0.uniform.SubpixelColorBleed]
 type=float
 default=0.31
 readableName=Subpixel color bleeding
 
+[pass.0.uniform.SubpixelSpread]
+type=float
+default=0.333
+readableName=Subpixel spread X
+
+[pass.0.uniform.SubpixelVerticalOffset]
+type=float
+default=0.48
+readableName=Subpixel offset Y
+
 [pass.0.uniform.SubpixelGamma]
 type=float
-default=1.080
+default=1.040
 readableName=Subpixel brightness
+
+[pass.0.uniform.SubpixelLightWidth]
+type=float
+default=0.220
+readableName=Subpixel width
+
+[pass.0.uniform.SubpixelLightHeight]
+type=float
+default=0.850
+readableName=Subpixel height
+
+[pass.0.uniform.SubpixelLightGlow]
+type=float
+default=0.195
+readableName=Subpixel glow size
+
+[pass.0.uniform.SubpixelTabHeight]
+type=float
+default=0.175
+readableName=Subpixel tab shaping
+
+[pass.0.uniform.SubpixelScale]
+type=float
+default=1.0
+readableName=Subpixel scale
 
 [pass.1.uniform.LightColor]
 type=float3

--- a/res/shaders/gbc-lcd.shader/manifest.ini
+++ b/res/shaders/gbc-lcd.shader/manifest.ini
@@ -1,0 +1,73 @@
+[shader]
+name=gbc-lcd
+author=Sophie Kirschner
+description=Imitates the GameBoy Color LCD screen subpixel arrangement, with an optional backlight effect.
+passes=2
+
+[pass.0]
+integerScaling=1
+fragmentShader=gbc-lcd.fs
+blend=1
+
+[pass.1]
+fragmentShader=gbc-lcd-light.fs
+
+[pass.0.uniform.BaseColor]
+type=float3
+default[0]=0.130
+default[1]=0.128
+default[2]=0.101
+readableName=Screen base color
+
+[pass.0.uniform.SourceContrast]
+type=float
+default=0.85
+readableName=Screen contrast
+
+[pass.0.uniform.SourceLuminosity]
+type=float
+default=0.88
+readableName=Screen luminosity
+
+[pass.0.uniform.SubpixelBlendAmount]
+type=float
+default=1.0
+readableName=Subpixel effect intensity
+
+[pass.0.uniform.SubpixelColorBleed]
+type=float
+default=0.31
+readableName=Subpixel color bleeding
+
+[pass.0.uniform.SubpixelGamma]
+type=float
+default=1.080
+readableName=Subpixel brightness
+
+[pass.1.uniform.LightColor]
+type=float3
+default[0]=1.000
+default[1]=0.968
+default[2]=0.882
+readableName=Backlight color
+
+[pass.1.uniform.LightIntensity]
+type=float
+default=0.06
+readableName=Backlight intensity
+
+[pass.1.uniform.LightSoftness]
+type=float
+default=0.67
+readableName=Backlight softness
+
+[pass.1.uniform.ReflectionDistance]
+type=float2
+default[0]=0
+default[1]=0.025
+readableName=Internal reflection distance
+
+[pass.1.uniform.ReflectionBrightness]
+type=float
+default=0.032
+readableName=Internal reflection brightness


### PR DESCRIPTION
I wrote a shader that attempts to reproduce the GBC LCD subpixel pattern. It also supports a backlight bleed effect similar to the existing ags001 shader. I used ags001 as a starting point, but otherwise this is new work and not adapted from any other shader. I wrote it primarily for my own use, but I'm guessing it may be of interest to others too.

The license included with the shader is the Unlicense, i.e. the shader is intended to be public domain.

Some credit belongs to this resource: https://gbcc.dev/technology/

Screenshots:

Settings (it doesn't seem like mGBA currently has any easy way to put the options in an intended order?):

![image](https://github.com/mgba-emu/mgba/assets/7266412/74e113ad-80b6-4477-8765-16fbb3be5016)
![image](https://github.com/mgba-emu/mgba/assets/7266412/1cc107cc-fa8c-40bd-a4cc-3fdb24e7bd6f)

1x (not really intended to be used this way, though I'm sure that if you were really determined you could mess with the default settings enough to get something interesting):
![image](https://github.com/mgba-emu/mgba/assets/7266412/a3a14eb3-6395-4633-a788-58140b614660)
![image](https://github.com/mgba-emu/mgba/assets/7266412/658e3440-9362-44a3-9d4b-b5094c104120)

2x:
![image](https://github.com/mgba-emu/mgba/assets/7266412/be43d1f4-2fca-41ae-8960-c594933c8235)
![image](https://github.com/mgba-emu/mgba/assets/7266412/74becf60-28cc-4ad8-b268-f27764f753c8)

2x (with settings tweaked to better suit the small size, "Subpixel glow size" set to 0.255 instead of default ):
![image](https://github.com/mgba-emu/mgba/assets/7266412/41a2134c-7b1f-4855-9e64-3aaf2ce0457f)
![image](https://github.com/mgba-emu/mgba/assets/7266412/eddcdf6b-f761-4d20-8283-be3eec831910)

3x:
![image](https://github.com/mgba-emu/mgba/assets/7266412/671f1808-9811-4ac8-a6bc-b2718f0b62eb)
![image](https://github.com/mgba-emu/mgba/assets/7266412/156759c6-e365-4080-ba5d-4ab7c5c299e9)

4x:
![image](https://github.com/mgba-emu/mgba/assets/7266412/39a19c56-e40e-4903-896d-45d7059c53ef)
![image](https://github.com/mgba-emu/mgba/assets/7266412/e68078cc-ae32-45bb-8ef0-10827571e6c4)

8x:
![image](https://github.com/mgba-emu/mgba/assets/7266412/f7ae16a4-3e73-415d-b681-b6a2fa25b7b2)
![image](https://github.com/mgba-emu/mgba/assets/7266412/2cb44710-6441-49e0-ae69-9016f8553f05)
![image](https://github.com/mgba-emu/mgba/assets/7266412/aea25ce0-3e47-4879-a6ec-42819764d112)
![image](https://github.com/mgba-emu/mgba/assets/7266412/fe4b8f9c-bd57-4d45-a61f-40bab6ef4431)
![image](https://github.com/mgba-emu/mgba/assets/7266412/9a09a982-8d1e-42c4-8070-d053670beb56)

Zoomed in on an 8x screen, to show the subpixels:
![image](https://github.com/mgba-emu/mgba/assets/7266412/b387b642-b0aa-4a0f-9e2f-8b417d0d6851)

Screenshot of subpixels scaled up with the glow/luminance effect toned down, to show size and shape (achieved by changing the "Subpixel scale" and "Subpixel glow size" settings)
![image](https://github.com/mgba-emu/mgba/assets/7266412/fd8ad793-1c73-4a15-a3f2-682be3a5d99d)




