### PR TITLE
GDB Debugger default to loopback address

### DIFF
--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -54,7 +54,11 @@ struct mDebuggerModule* mDebuggerCreateModule(enum mDebuggerType type, struct mC
 	case DEBUGGER_GDB:
 #ifdef USE_GDB_STUB
 		GDBStubCreate(&debugger->gdb);
-		GDBStubListen(&debugger->gdb, 2345, 0, GDB_WATCHPOINT_STANDARD_LOGIC);
+		struct Address localHost = {
+			.version = IPV4,
+			.ipv4 = 0x7F000001
+		};
+		GDBStubListen(&debugger->gdb, 2345, &localHost, GDB_WATCHPOINT_STANDARD_LOGIC);
 		break;
 #endif
 	case DEBUGGER_NONE:

--- a/src/platform/qt/GDBWindow.cpp
+++ b/src/platform/qt/GDBWindow.cpp
@@ -44,7 +44,7 @@ GDBWindow::GDBWindow(GDBController* controller, QWidget* parent)
 	connect(m_portEdit, &QLineEdit::textChanged, this, &GDBWindow::portChanged);
 	settingsGrid->addWidget(m_portEdit, 0, 1, Qt::AlignLeft);
 
-	m_bindAddressEdit = new QLineEdit("0.0.0.0");
+	m_bindAddressEdit = new QLineEdit("127.0.0.1");
 	m_bindAddressEdit->setMaxLength(15);
 	connect(m_bindAddressEdit, &QLineEdit::textChanged, this, &GDBWindow::bindAddressChanged);
 	settingsGrid->addWidget(m_bindAddressEdit, 1, 1, Qt::AlignLeft);


### PR DESCRIPTION
The current version of mGBA binds the GDB server to 0.0.0.0 which makes it publicly accessible. This allows an outside attacker to connect to mGBA's GDB server and execute arbitrary code. Although the Qt window allows for changing the bind address, there is no way (as far as I am aware) to automatically change the bind address when running mGBA from the command line with the argument --gdb. These commits change the default bind address from 0.0.0.0 to the loopback address 127.0.0.1.