### PR TITLE
qt: Add text input for specifying the portable directory.

### DIFF
--- a/src/platform/qt/ConfigController.cpp
+++ b/src/platform/qt/ConfigController.cpp
@@ -365,8 +365,8 @@ void ConfigController::write() {
 	mCoreConfigMap(&m_config, &m_opts);
 }
 
-void ConfigController::makePortable() {
-	mCoreConfigMakePortable(&m_config, nullptr);
+void ConfigController::makePortable(const char* path) {
+	mCoreConfigMakePortable(&m_config, path);
 
 	QString fileName(configDir());
 	fileName.append(QDir::separator());

--- a/src/platform/qt/ConfigController.h
+++ b/src/platform/qt/ConfigController.h
@@ -116,7 +116,7 @@ public slots:
 	void setOption(const char* key, const QVariant& value);
 	void setQtOption(const QString& key, const QVariant& value, const QString& group = QString());
 
-	void makePortable();
+	void makePortable(const char* path);
 	void write();
 
 private:

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "Window.h"
 
+#include <QInputDialog>
 #include <QKeyEvent>
 #include <QKeySequence>
 #include <QMenuBar>
@@ -1117,12 +1118,14 @@ void Window::changeRenderer() {
 }
 
 void Window::tryMakePortable() {
-	QMessageBox* confirm = new QMessageBox(QMessageBox::Question, tr("Really make portable?"),
-	                                       tr("This will make the emulator load its configuration from the same directory as the executable. Do you want to continue?"),
-	                                       QMessageBox::Yes | QMessageBox::Cancel, this, Qt::Sheet);
-	confirm->setAttribute(Qt::WA_DeleteOnClose);
-	connect(confirm->button(QMessageBox::Yes), &QAbstractButton::clicked, m_config, &ConfigController::makePortable);
-	confirm->show();
+	bool accepted;
+	QString text = QInputDialog::getText(this, tr("Make portable"),
+	                                     tr("This will make the emulator load its configuration from the specified directory.\n\n"
+	                                        "Portable Directory (leave empty for the executable directory):"),
+	                                     QLineEdit::Normal, "", &accepted);
+	if (accepted) {
+		m_config->makePortable(text.toLocal8Bit().data());
+	}
 }
 
 void Window::mustRestart() {


### PR DESCRIPTION
Follow up to https://github.com/mgba-emu/mgba/pull/3117 with the GUI component, for separate review. This adds a more user-friendly way to decide where the portable directory should be. Input can be either absolute or relative; for example the user could just put `data` and the directory would be named `data` next to the `portable.ini`.

Screenshot:
<img width="519" alt="Screenshot 2024-01-21 at 4 37 07 PM" src="https://github.com/mgba-emu/mgba/assets/1269164/151e5e1f-082a-4859-8c81-f5c3604f8999">