### PR TITLE
Fix typo in spanish translation file

### DIFF
--- a/src/platform/qt/ts/mgba-es.ts
+++ b/src/platform/qt/ts/mgba-es.ts
@@ -3780,7 +3780,7 @@ Tamaño de descarga: %3</translation>
     <message>
         <location filename="../ObjView.ui" line="389"/>
         <source>Export</source>
-        <translation>Esportar</translation>
+        <translation>Exportar</translation>
     </message>
     <message>
         <location filename="../ObjView.ui" line="402"/>


### PR DESCRIPTION
I have fixed a typo in the word "esportar," which should be "exportar." I couldn't find any other similar typos. However, there are some translations that don't feel quite right. For instance, "Frame" is typically not translated in Spanish, so seeing it translated as "Cuadro," although technically correct, feels unusual.

Please let me know if you would like me to address this in a new PR as well.