### PR TITLE
fix hang in AudioDevice

### DIFF
--- a/src/platform/qt/AudioDevice.cpp
+++ b/src/platform/qt/AudioDevice.cpp
@@ -64,11 +64,15 @@ qint64 AudioDevice::writeData(const char*, qint64) {
 }
 
 bool AudioDevice::atEnd() const {
+	return !bytesAvailable();
+}
+
+qint64 AudioDevice::bytesAvailable() const {
 	if (!m_context->core) {
 		return true;
 	}
 	mCoreSyncLockAudio(&m_context->impl->sync);
-	bool available = blip_samples_avail(m_context->core->getAudioChannel(m_context->core, 0)) == 0;
+	int available = blip_samples_avail(m_context->core->getAudioChannel(m_context->core, 0));
 	mCoreSyncUnlockAudio(&m_context->impl->sync);
-	return available;
+	return available * sizeof(mStereoSample);
 }

--- a/src/platform/qt/AudioDevice.h
+++ b/src/platform/qt/AudioDevice.h
@@ -21,6 +21,7 @@ public:
 	void setInput(mCoreThread* input);
 	void setFormat(const QAudioFormat& format);
 	bool atEnd() const override;
+	qint64 bytesAvailable() const override;
 
 protected:
 	virtual qint64 readData(char* data, qint64 maxSize) override;


### PR DESCRIPTION
So I tried the latest version e3edca1f4168c1eee36cd213ef8d5e91fd35e400 and games do not boot they just hang. This is my attempt to fix it. I don't know if it is correct, but it actually works. Games boot and are playable.