### PR TITLE
Add AppImage Scripts for Linux

### DIFF
--- a/scripts/makeappimage_32-bit.sh
+++ b/scripts/makeappimage_32-bit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [ ! -f appimagetool-i686.AppImage ]; then
+    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-i686.AppImage
+    chmod +x appimagetool-i686.AppImage
+fi
+
+if [ ! -f linuxdeploy-i386.AppImage ]; then
+    wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-i386.AppImage
+    chmod +x linuxdeploy-i386.AppImage
+fi
+
+DESTDIR=AppDir make install
+./linuxdeploy-i386.AppImage --appimage-extract-and-run --appdir=AppDir \
+	--exclude-library="libX*" \
+	--exclude-library="libglib*" \
+	--exclude-library="libgobject*" \
+	--exclude-library="libgdk_pixbuf*" \
+	--exclude-library="libwayland*" \
+	--exclude-library="libgmodule*" \
+	--exclude-library="libgio*" \
+	--exclude-library="libxcb*" \
+	--exclude-library="libxkbcommon*" \
+	--exclude-library="libdb*"
+
+rm AppDir/mgba-256.png
+pushd AppDir
+ln -s usr/share/icons/hicolor/256x256/apps/mgba-256.png
+chmod +x AppRun
+popd
+./appimagetool-i686.AppImage --appimage-extract-and-run AppDir

--- a/scripts/makeappimage_64-bit.sh
+++ b/scripts/makeappimage_64-bit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [ ! -f appimagetool-x86_64.AppImage ]; then
+    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+    chmod +x appimagetool-x86_64.AppImage
+fi
+
+if [ ! -f linuxdeploy-x86_64.AppImage ]; then
+    wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+    chmod +x linuxdeploy-x86_64.AppImage
+fi
+
+DESTDIR=AppDir make install
+./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir=AppDir \
+	--exclude-library="libX*" \
+	--exclude-library="libglib*" \
+	--exclude-library="libgobject*" \
+	--exclude-library="libgdk_pixbuf*" \
+	--exclude-library="libwayland*" \
+	--exclude-library="libgmodule*" \
+	--exclude-library="libgio*" \
+	--exclude-library="libxcb*" \
+	--exclude-library="libxkbcommon*" \
+	--exclude-library="libdb*"
+
+rm AppDir/mgba-256.png
+pushd AppDir
+ln -s usr/share/icons/hicolor/256x256/apps/mgba-256.png
+chmod +x AppRun
+popd
+./appimagetool-x86_64.AppImage --appimage-extract-and-run AppDir


### PR DESCRIPTION
I am proposing to add two scripts to create 32-bit or 64-bit AppImage files.

For a 32-bit AppImage, enter the following code in a command-line window with ~/mgba/build/ as the directory after a build has been made:

~/mgba/scripts/makeappimage_32-bit.sh

For a 64-bit AppImage, enter the following code in a command-line window with ~/mgba/build/ as the directory after a build has been made:

~/mgba/scripts/makeappimage_64-bit.sh