### PR TITLE
Qt: Ignore rewind while loading/saving states

### DIFF
--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1464,6 +1464,11 @@ void Window::setupMenu(QMenuBar* menubar) {
 	}, "emu");
 
 	auto rewindHeld = m_actions.addHeldAction(tr("Rewind (held)"), "holdRewind", [this](bool held) {
+		// Prevent rewinding while the load/save state window is active
+		if (held && this->m_stateWindow != nullptr) {
+			return;
+		}
+
 		if (m_controller) {
 			m_controller->setRewinding(held);
 		}


### PR DESCRIPTION
I dunno if I did it right but I've managed to rewind while reloading states by accident (well, at first, it's sorta a guilty pleasure now ) so much that I figured this might be worth Fixing™️