### PR TITLE
GBA Memory: Support the Chinese version of Digimon Sapphire by Vast Fame

### DIFF
--- a/include/mgba/internal/gba/cart/vfame.h
+++ b/include/mgba/internal/gba/cart/vfame.h
@@ -13,11 +13,13 @@
 
 CXX_GUARD_START
 
+#define DIGIMON_SAPPHIRE_CHINESE_CRC32 0x793A328F
+
 enum GBAVFameCartType {
 	VFAME_NO = 0,
 	VFAME_STANDARD = 1,
-	VFAME_ALTERNATE = 2,
-	VFAME_GEORGE = 3
+	VFAME_GEORGE = 2,
+	VFAME_ALTERNATE = 3,
 };
 
 struct GBAVFameCart {
@@ -29,7 +31,7 @@ struct GBAVFameCart {
 };
 
 void GBAVFameInit(struct GBAVFameCart* cart);
-void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize);
+void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize, uint32_t crc32);
 void GBAVFameSramWrite(struct GBAVFameCart* cart, uint32_t address, uint8_t value, uint8_t* sramData);
 uint32_t GBAVFameModifyRomAddress(struct GBAVFameCart* cart, uint32_t address, size_t romSize);
 uint32_t GBAVFameGetPatternValue(uint32_t address, int bits);

--- a/include/mgba/internal/gba/cart/vfame.h
+++ b/include/mgba/internal/gba/cart/vfame.h
@@ -16,7 +16,8 @@ CXX_GUARD_START
 enum GBAVFameCartType {
 	VFAME_NO = 0,
 	VFAME_STANDARD = 1,
-	VFAME_GEORGE = 2
+	VFAME_ALTERNATE = 2,
+	VFAME_GEORGE = 3
 };
 
 struct GBAVFameCart {

--- a/src/gba/cart/vfame.c
+++ b/src/gba/cart/vfame.c
@@ -7,37 +7,36 @@
 
 #include <mgba/internal/gba/gba.h>
 #include <mgba/internal/gba/memory.h>
-#include <mgba-util/crc32.h>
 
 static const uint8_t ADDRESS_REORDERING[4][16] = {
 	{ 15, 14, 9, 1, 8, 10, 7, 3, 5, 11, 4, 0, 13, 12, 2, 6 },
 	{ 15, 7, 13, 5, 11, 6, 0, 9, 12, 2, 10, 14, 3, 1, 8, 4 },
 	{ 15, 0, 3, 12, 2, 4, 14, 13, 1, 8, 6, 7, 9, 5, 11, 10 }
 };
-static const uint8_t ADDRESS_REORDERING_ALTERNATE[4][16] = {
-	{ 15, 0, 13, 5, 8, 4, 7, 3, 1, 2, 10, 14, 9, 12, 11, 6 },
-	{ 15, 7, 9, 1, 2, 6, 14, 13, 12, 11, 4, 0, 3, 5, 8, 10 },
-	{ 15, 14, 3, 12, 11, 10, 0, 9, 5, 8, 6, 7, 13, 1, 2, 4 }
-};
 static const uint8_t ADDRESS_REORDERING_GEORGE[4][16] = {
 	{ 15, 7, 13, 1, 11, 10, 14, 9, 12, 2, 4, 0, 3, 5, 8, 6 },
 	{ 15, 14, 3, 12, 8, 4, 0, 13, 5, 11, 6, 7, 9, 1, 2, 10 },
 	{ 15, 0, 9, 5, 2, 6, 7, 3, 1, 8, 10, 14, 13, 12, 11, 4 }
+};
+static const uint8_t ADDRESS_REORDERING_ALTERNATE[4][16] = {
+	{ 15, 0, 13, 5, 8, 4, 7, 3, 1, 2, 10, 14, 9, 12, 11, 6 },
+	{ 15, 7, 9, 1, 2, 6, 14, 13, 12, 11, 4, 0, 3, 5, 8, 10 },
+	{ 15, 14, 3, 12, 11, 10, 0, 9, 5, 8, 6, 7, 13, 1, 2, 4 }
 };
 static const uint8_t VALUE_REORDERING[4][16] = {
 	{ 5, 4, 3, 2, 1, 0, 7, 6 },
 	{ 3, 2, 1, 0, 7, 6, 5, 4 },
 	{ 1, 0, 7, 6, 5, 4, 3, 2 }
 };
-static const uint8_t VALUE_REORDERING_ALTERNATE[4][16] = {
-	{ 5, 4, 7, 2, 1, 0, 3, 6 },
-	{ 1, 2, 3, 0, 5, 6, 7, 4 },
-	{ 3, 0, 1, 6, 7, 4, 5, 2 }
-};
 static const uint8_t VALUE_REORDERING_GEORGE[4][16] = {
 	{ 3, 0, 7, 2, 1, 4, 5, 6 },
 	{ 1, 4, 3, 0, 5, 6, 7, 2 },
 	{ 5, 2, 1, 6, 7, 0, 3, 4 }
+};
+static const uint8_t VALUE_REORDERING_ALTERNATE[4][16] = {
+	{ 5, 4, 7, 2, 1, 0, 3, 6 },
+	{ 1, 2, 3, 0, 5, 6, 7, 4 },
+	{ 3, 0, 1, 6, 7, 4, 5, 2 }
 };
 
 static const int8_t MODE_CHANGE_START_SEQUENCE[5] = { 0x99, 0x02, 0x05, 0x02, 0x03 };
@@ -60,7 +59,7 @@ void GBAVFameInit(struct GBAVFameCart* cart) {
 	cart->acceptingModeChange = false;
 }
 
-void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize) {
+void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize, uint32_t crc32) {
 	cart->cartType = VFAME_NO;
 
 	// The initialisation code is also present & run in the dumps of Digimon Ruby & Sapphire from hacked/deprotected reprint carts,
@@ -82,11 +81,10 @@ void GBAVFameDetect(struct GBAVFameCart* cart, uint32_t* rom, size_t romSize) {
 	if (memcmp("George Sango", &((struct GBACartridge*) rom)->title, 12) == 0) {
 		cart->cartType = VFAME_GEORGE;
 		mLOG(GBA_MEM, INFO, "George mode");
-	}
-	// Chinese version of Digimon Sapphire; header is identical to the English version which uses the normal reordering
-	// so we have to use some other way to detect it
-	else if (doCrc32(rom, romSize) == 0x793A328F) {
-		cart->cartType = VFAME_STANDARD;
+	} else if (crc32 == DIGIMON_SAPPHIRE_CHINESE_CRC32) {
+		// Chinese version of Digimon Sapphire; header is identical to the English version which uses the normal reordering
+		// so we have to use some other way to detect it
+		cart->cartType = VFAME_ALTERNATE;
 	}
 }
 

--- a/src/gba/gba.c
+++ b/src/gba/gba.c
@@ -493,7 +493,7 @@ bool GBALoadROM(struct GBA* gba, struct VFile* vf) {
 		gba->cpu->memory.setActiveRegion(gba->cpu, gba->cpu->gprs[ARM_PC]);
 	}
 	GBAHardwareInit(&gba->memory.hw, &((uint16_t*) gba->memory.rom)[GPIO_REG_DATA >> 1]);
-	GBAVFameDetect(&gba->memory.vfame, gba->memory.rom, gba->memory.romSize);
+	GBAVFameDetect(&gba->memory.vfame, gba->memory.rom, gba->memory.romSize, gba->romCrc32);
 	// TODO: error check
 	return true;
 }


### PR DESCRIPTION
The Chinese version of Digimon Sapphire by Vast Fame uses a third set of address reordering modes. This adds those modes and uses the CRC of the ROM to determine which to use. The header of the Chinese version is identical to the English version, so I couldn't use the header name to determine the mode unlike with George Sango.