### PR TITLE
Don't try to load non-.sym files as ARMIPS symbols

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -1260,8 +1260,12 @@ static void _GBACoreLoadSymbols(struct mCore* core, struct VFile* vf) {
 	}
 #endif
 	if (!vf && core->dirs.base) {
-		closeAfter = true;
 		vf = mDirectorySetOpenSuffix(&core->dirs, core->dirs.base, ".sym", O_RDONLY);
+		if (vf) {
+			mDebuggerLoadARMIPSSymbols(core->symbolTable, vf);
+			vf->close(vf);
+		}
+		return;
 	}
 #endif
 	if (!vf && gba->mbVf) {
@@ -1286,11 +1290,8 @@ static void _GBACoreLoadSymbols(struct mCore* core, struct VFile* vf) {
 		mCoreLoadELFSymbols(core->symbolTable, elf);
 #endif
 		ELFClose(elf);
-	} else
-#endif
-	{
-		mDebuggerLoadARMIPSSymbols(core->symbolTable, vf);
 	}
+#endif
 	if (closeAfter) {
 		vf->close(vf);
 	} else {


### PR DESCRIPTION
Commit 4c161ff appears to have introduced a performance regression:

* Start mGBA
* Open a GBA ROM
* Open the scripting window

Before 4c161ff, this was instantaneous. After 4c161ff, this takes over 5s on my machine. Profiling reveals that the time is being spent in `mDebuggerLoadARMIPSSymbols`.

It appears that this function is being called to load ARMIPS symbols from the symbol file, even if it's not a .sym file -- which is to say, the GBA ROM itself.