### PR TITLE
Fix misplaced return in previous PR

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -1264,8 +1264,8 @@ static void _GBACoreLoadSymbols(struct mCore* core, struct VFile* vf) {
 		if (vf) {
 			mDebuggerLoadARMIPSSymbols(core->symbolTable, vf);
 			vf->close(vf);
+			return;
 		}
-		return;
 	}
 #endif
 	if (!vf && gba->mbVf) {


### PR DESCRIPTION
My previous PR misplaced the `return` statement. Oops.