### PR TITLE
Fix Input Mapping Typo for GameCube Controllers on Wii

### DIFF
--- a/src/platform/wii/main.c
+++ b/src/platform/wii/main.c
@@ -1374,7 +1374,7 @@ void _setup(struct mGUIRunner* runner) {
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_B, GBA_KEY_B);
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_START, GBA_KEY_START);
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_X, GBA_KEY_SELECT);
-	_mapKey(&runner->core->inputMap, GCN2_INPUT, PAD_BUTTON_Y, GBA_KEY_SELECT);
+	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_Y, GBA_KEY_SELECT);
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_UP, GBA_KEY_UP);
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_DOWN, GBA_KEY_DOWN);
 	_mapKey(&runner->core->inputMap, GCN1_INPUT, PAD_BUTTON_LEFT, GBA_KEY_LEFT);


### PR DESCRIPTION
The Wii port of mGBA contains an error that causes the input mapping for the Y button on GameCube controllers to reset whenever a game is loaded in the emulator. This error is caused by a typo in the code that causes the emulator to load that button's mapping from GCN2_INPUT instead of GCN1_INPUT. This pull request addresses this issue.