### PR TITLE
Remove SDL_WINDOW_OPENGL flag in mSDLSWInit

### DIFF
--- a/src/platform/sdl/sw-sdl2.c
+++ b/src/platform/sdl/sw-sdl2.c
@@ -22,7 +22,7 @@ void mSDLSWCreate(struct mSDLRenderer* renderer) {
 bool mSDLSWInit(struct mSDLRenderer* renderer) {
 	unsigned width, height;
 	renderer->core->baseVideoSize(renderer->core, &width, &height);
-	renderer->window = SDL_CreateWindow(projectName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, renderer->viewportWidth, renderer->viewportHeight, SDL_WINDOW_OPENGL | (SDL_WINDOW_FULLSCREEN_DESKTOP * renderer->player.fullscreen));
+	renderer->window = SDL_CreateWindow(projectName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, renderer->viewportWidth, renderer->viewportHeight, SDL_WINDOW_FULLSCREEN_DESKTOP * renderer->player.fullscreen);
 	SDL_GetWindowSize(renderer->window, &renderer->viewportWidth, &renderer->viewportHeight);
 	renderer->player.window = renderer->window;
 	renderer->sdlRenderer = SDL_CreateRenderer(renderer->window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);


### PR DESCRIPTION
I found that `mSDLSWCreate` is call when `BUILD_GL` not defined, so the flag `SDL_WINDOW_OPENGL` shouldn't be set?

It's really work in my embedded device only after I remove this flag.

https://github.com/mgba-emu/mgba/blob/09f456484cb401856d5dda1af5b80a659b7c2097/src/platform/sdl/main.c#L131-L143