### PR TITLE
Qt: Ensure that the correct OpenGL variant is version checked

### DIFF
--- a/src/platform/qt/DisplayGL.cpp
+++ b/src/platform/qt/DisplayGL.cpp
@@ -285,6 +285,7 @@ void DisplayGL::startDrawing(std::shared_ptr<CoreController> controller) {
 
 bool DisplayGL::highestCompatible(QSurfaceFormat& format) {
 #if defined(BUILD_GLES2) || defined(BUILD_GLES3) || defined(USE_EPOXY)
+	format.setRenderableType(QSurfaceFormat::OpenGLES);
 	if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
 		format.setVersion(3, 3);
 		format.setProfile(QSurfaceFormat::CoreProfile);
@@ -311,6 +312,7 @@ bool DisplayGL::highestCompatible(QSurfaceFormat& format) {
 #if defined(BUILD_GLES2) || defined(BUILD_GLES3) || defined(USE_EPOXY)
 	LOG(QT, WARN) << tr("Failed to create an OpenGL 3 context, trying old-style...");
 #endif
+	format.setRenderableType(QSurfaceFormat::OpenGL);
 	if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
 		format.setVersion(1, 4);
 	} else {


### PR DESCRIPTION
Without this the code compared the desired OpenGLES profile version against the core profile version which in my case succeeded and later on failed when trying to create a context.

Setting the renderable type ensures the correct OpenGL variant is checked.

glxinfo output:
```
    Max core profile version: 4.6
    Max compat profile version: 4.6
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.2
```