### PR TITLE
Qt: Recreate Window to release old surface and create a OpenGL one

### DIFF
--- a/src/platform/qt/DisplayGL.cpp
+++ b/src/platform/qt/DisplayGL.cpp
@@ -192,6 +192,7 @@ DisplayGL::DisplayGL(const QSurfaceFormat& format, QWidget* parent)
 	setAttribute(Qt::WA_NativeWindow);
 	window()->windowHandle()->setFormat(format);
 	windowHandle()->setSurfaceType(QSurface::OpenGLSurface);
+	windowHandle()->destroy();
 	windowHandle()->create();
 
 #ifdef USE_SHARE_WIDGET


### PR DESCRIPTION
Found while trying to debug a `Couldn't find current GLX or EGL context.` crash

Turns out, the native surface was never updated when the type was changed, the documentation of `QWindow::setSurfaceType` states:
> The [surfaceType](https://doc.qt.io/qt-6/qwindow.html#surfaceType) will be used when the native surface is created in the [create](https://doc.qt.io/qt-6/qwindow.html#create)() function. Calling this function after the native surface has been created requires calling [destroy](https://doc.qt.io/qt-6/qwindow.html#destroy)() and [create](https://doc.qt.io/qt-6/qwindow.html#create)() to release the old native surface and create a new one.

Its probably possible to stop the surface from being created in the first place elsewhere, however this function could be called at any point so its probably best to properly clean things up.