### PR TITLE
Fix various macOS related problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,12 @@ if(APPLE)
 	execute_process(COMMAND xcrun --show-sdk-version OUTPUT_VARIABLE MACOSX_SDK)
 	add_definitions(-D_DARWIN_C_SOURCE)
 	list(APPEND OS_LIB "-framework Foundation")
+
+	# Xcode 15 introduced a warning about duplicate libraries that CMake doesn't disable itself, we do it here globally
+	if(MACOSX_SDK VERSION_GREATER_EQUAL 10.15)
+		add_link_options(LINKER:-no_warn_duplicate_libraries)
+	endif()
+
 	if(NOT CMAKE_SYSTEM_VERSION VERSION_LESS "10.0") # Darwin 10.x is Mac OS X 10.6
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.6")
 	endif()

--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -59,7 +59,10 @@ if(APPLE)
 		list(APPEND QT_DEFINES USE_SHARE_WIDGET)
 	endif()
 
-	if(Qt6Widgets_VERSION)
+	# Allows building with Qt that was built with std::filesystem support, which requires macOS 15
+	if(Qt6Widgets_VERSION AND MACOSX_SDK VERSION_GREATER_EQUAL 10.15)
+		set(MIN_VER 10.15)
+	elseif(Qt6Widgets_VERSION)
 		set(MIN_VER 10.14)
 	elseif(Qt5Widgets_VERSION MATCHES "^5.15")
 		set(MIN_VER 10.13)
@@ -478,13 +481,21 @@ endif()
 if(APPLE)
 	if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
 		get_target_property(QTCOCOA ${QT}::QCocoaIntegrationPlugin LOCATION)
-		get_target_property(COREAUDIO ${QT}::CoreAudioPlugin LOCATION)
-		get_target_property(QTAVFSERVICE ${QT}::AVFServicePlugin LOCATION)
+		if(${QT_V} LESS 6)
+			# QtMultimedia plugins were removed with Qt 6, skip checking for them
+			get_target_property(COREAUDIO ${QT}::CoreAudioPlugin LOCATION)
+			get_target_property(QTAVFSERVICE ${QT}::AVFServicePlugin LOCATION)
+		endif()
+
 		set(BUNDLE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.app)
 		target_sources(${BINARY_NAME}-qt PRIVATE "${PLUGINS}")
+
 		set_source_files_properties("${QTCOCOA}" PROPERTIES MACOSX_PACKAGE_LOCATION Contents/PlugIns)
-		set_source_files_properties("${COREAUDIO}" PROPERTIES MACOSX_PACKAGE_LOCATION Contents/PlugIns)
-		set_source_files_properties("${QTAVFSERVICE}" PROPERTIES MACOSX_PACKAGE_LOCATION Contents/PlugIns)
+		if(${QT_V} LESS 6)
+			set_source_files_properties("${COREAUDIO}" PROPERTIES MACOSX_PACKAGE_LOCATION Contents/PlugIns)
+			set_source_files_properties("${QTAVFSERVICE}" PROPERTIES MACOSX_PACKAGE_LOCATION Contents/PlugIns)
+		endif()
+	
 		install(CODE "
 		   include(BundleUtilities)
 		   set(BU_CHMOD_BUNDLE_ITEMS ON)

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1422,7 +1422,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 #endif
 
 	m_actions.addAction(tr("About..."), "about", openTView<AboutScreen>(), "file")->setRole(Action::Role::ABOUT);
-	m_actions.addAction(tr("E&xit"), "quit", static_cast<QWidget*>(this), &QWidget::close, "file", QKeySequence::Quit)->setRole(Action::Role::QUIT);
+	m_actions.addAction(tr("E&xit"), "quit", &QApplication::quit, "file", QKeySequence::Quit)->setRole(Action::Role::QUIT);
 
 	m_actions.addMenu(tr("&Emulation"), "emu");
 	addGameAction(tr("&Reset"), "reset", &CoreController::reset, "emu", QKeySequence("Ctrl+R"));


### PR DESCRIPTION
command q addictions go crazy sometimes

- Disable a duplicate libraries warning that isn't needed
- Quit using QApplication::quit instead of QWidget::close to prevent closing inside a dialog from crashing the application
- Allow Qt 6 builds to use std::filesystem if the proper macOS SDK version is present
- Stop looking for QtMultimedia plugins if Qt 6 is being used for macOS builds