### PR TITLE
Qt: honor control characters in ScriptingTextBuffer::print

### DIFF
--- a/src/platform/qt/scripting/ScriptingTextBuffer.h
+++ b/src/platform/qt/scripting/ScriptingTextBuffer.h
@@ -36,6 +36,8 @@ signals:
 	void bufferNameChanged(const QString&);
 
 private:
+	enum { tabStop = 4 };
+
 	struct ScriptingBufferShim : public mScriptTextBuffer {
 		ScriptingTextBuffer* p;
 		QTextCursor cursor;
@@ -43,6 +45,11 @@ private:
 	QTextDocument m_document;
 	QMutex m_mutex;
 	QString m_name;
+
+	void lineBreak();
+	void carriageReturn();
+	void tab();
+	void insertString(const QString& text);
 
 	static void init(struct mScriptTextBuffer*, const char* name);
 	static void deinit(struct mScriptTextBuffer*);


### PR DESCRIPTION
My [previous PR](https://github.com/mgba-emu/mgba/pull/3314) fixed line wrapping for strings with embedded newlines, but in the process it completely broke newline handling.

This PR makes sure that the cursor moves to the next block / a new block after each line.