### PR TITLE
Shader configuration improvements

### DIFF
--- a/src/platform/qt/Display.h
+++ b/src/platform/qt/Display.h
@@ -81,7 +81,7 @@ public slots:
 	virtual void filter(bool filter);
 	virtual void swapInterval(int interval) = 0;
 	virtual void framePosted() = 0;
-	virtual void setShaders(struct VDir*) = 0;
+	virtual bool setShaders(struct VDir*) = 0;
 	virtual void clearShaders() = 0;
 	virtual void resizeContext() = 0;
 

--- a/src/platform/qt/DisplayGL.h
+++ b/src/platform/qt/DisplayGL.h
@@ -113,7 +113,7 @@ public slots:
 	void filter(bool filter) override;
 	void swapInterval(int interval) override;
 	void framePosted() override;
-	void setShaders(struct VDir*) override;
+	bool setShaders(struct VDir*) override;
 	void clearShaders() override;
 	void resizeContext() override;
 	void setVideoScale(int scale) override;
@@ -184,7 +184,7 @@ public slots:
 	void resizeContext();
 	void setBackgroundImage(const QImage&);
 
-	void setShaders(struct VDir*);
+	bool setShaders(struct VDir*);
 	void clearShaders();
 	VideoShader* shaders();
 	QSize contentSize() const;

--- a/src/platform/qt/DisplayQt.h
+++ b/src/platform/qt/DisplayQt.h
@@ -41,7 +41,7 @@ public slots:
 	void swapInterval(int) override {};
 	void filter(bool filter) override;
 	void framePosted() override;
-	void setShaders(struct VDir*) override {}
+	bool setShaders(struct VDir*) override { return false; }
 	void clearShaders() override {}
 	void resizeContext() override;
 	void setBackgroundImage(const QImage&) override;

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -423,8 +423,11 @@ void SettingsView::setShaderSelector(ShaderSelector* shaderSelector) {
 	}
 	if (!m_shader) {
 		m_ui.stackedWidget->removeWidget(m_dummyShader);
+	} else {
+		QObject::disconnect(m_shader, nullptr, this, nullptr);
 	}
 	m_shader = shaderSelector;
+	QObject::connect(this, &SettingsView::saveSettingsRequested, m_shader, &ShaderSelector::saveSettings);
 	if (shaderSelector) {
 		addPage(tr("Shaders"), m_shader, Page::SHADERS);
 	} else {
@@ -682,6 +685,8 @@ void SettingsView::updateConfig() {
 	}
 	saveSetting("gb.colors", gbColors);
 #endif
+
+	emit saveSettingsRequested();
 
 	m_controller->write();
 

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -428,6 +428,7 @@ void SettingsView::setShaderSelector(ShaderSelector* shaderSelector) {
 	}
 	m_shader = shaderSelector;
 	QObject::connect(this, &SettingsView::saveSettingsRequested, m_shader, &ShaderSelector::saveSettings);
+	QObject::connect(m_ui.buttonBox, &QDialogButtonBox::rejected, m_shader, &ShaderSelector::revert);
 	if (shaderSelector) {
 		addPage(tr("Shaders"), m_shader, Page::SHADERS);
 	} else {

--- a/src/platform/qt/SettingsView.h
+++ b/src/platform/qt/SettingsView.h
@@ -61,6 +61,7 @@ signals:
 	void pathsChanged();
 	void languageChanged();
 	void libraryCleared();
+	void saveSettingsRequested();
 
 public slots:
 	void selectPage(Page);

--- a/src/platform/qt/ShaderSelector.cpp
+++ b/src/platform/qt/ShaderSelector.cpp
@@ -49,6 +49,10 @@ ShaderSelector::~ShaderSelector() {
 	clear();
 }
 
+void ShaderSelector::saveSettings() {
+	emit saved();
+}
+
 void ShaderSelector::clear() {
 	m_ui.shaderName->setText(tr("No shader active"));
 	m_ui.description->clear();
@@ -268,10 +272,6 @@ void ShaderSelector::buttonPressed(QAbstractButton* button) {
 	switch (m_ui.buttonBox->standardButton(button)) {
 	case QDialogButtonBox::Reset:
 		emit reset();
-		break;
-	case QDialogButtonBox::Ok:
-		emit saved();
-		close();
 		break;
  	case QDialogButtonBox::RestoreDefaults:
 		emit resetToDefault();

--- a/src/platform/qt/ShaderSelector.h
+++ b/src/platform/qt/ShaderSelector.h
@@ -28,6 +28,7 @@ public:
 	~ShaderSelector();
 
 public slots:
+	void saveSettings();
 	void refreshShaders();
 	void clear();
 

--- a/src/platform/qt/ShaderSelector.h
+++ b/src/platform/qt/ShaderSelector.h
@@ -31,15 +31,16 @@ public slots:
 	void saveSettings();
 	void refreshShaders();
 	void clear();
+	void revert();
 
 private slots:
 	void selectShader();
-	void loadShader(const QString& path);
-	void clearShader();
+	void loadShader(const QString& path, bool saveToSettings = false);
+	void clearShader(bool saveToSettings = false);
 	void buttonPressed(QAbstractButton*);
 
 signals:
-	void saved();
+	void saveSettingsRequested();
 	void reset();
 	void resetToDefault();
 


### PR DESCRIPTION
Killing four birds with one stone:

* Shader uniforms haven't saved since 2017 because the code was written to assume the shader settings had its own OK button. I could have addressed this with a direct function call but I thought a `saveSettingsRequested()` signal would allow future settings panels to be self-contained.
* Unlike basically everything else in the settings window, loading a shader saves the user's choice immediately. This means the Cancel button doesn't undo the action. This PR will still apply the shader changes immediately but it won't save the settings to disk until the user clicks OK or Apply, and the shader changes will be reverted upon clicking Cancel.
* It's kind of annoying to work on shader development with a packaged release of mGBA because you can't select an unpacked shader and you don't have the build system to pack it for you. With this PR you can now select the manifest.ini out of an unpacked shader and it'll load just fine.
* Shader load errors fail silently in the current version of mGBA. This PR adds a simple warning message.