### PR TITLE
Qt: Fix use-after-free in shader settings

### DIFF
--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -437,9 +437,9 @@ void SettingsView::setShaderSelector(ShaderSelector* shaderSelector) {
 		QObject::disconnect(m_shader, nullptr, this, nullptr);
 	}
 	m_shader = shaderSelector;
-	QObject::connect(this, &SettingsView::saveSettingsRequested, m_shader, &ShaderSelector::saveSettings);
-	QObject::connect(m_ui.buttonBox, &QDialogButtonBox::rejected, m_shader, &ShaderSelector::revert);
 	if (shaderSelector) {
+		QObject::connect(this, &SettingsView::saveSettingsRequested, m_shader, &ShaderSelector::saveSettings);
+		QObject::connect(m_ui.buttonBox, &QDialogButtonBox::rejected, m_shader, &ShaderSelector::revert);
 		addPage(tr("Shaders"), m_shader, Page::SHADERS);
 	} else {
 		addPage(tr("Shaders"), m_dummyShader, Page::SHADERS);

--- a/src/platform/qt/SettingsView.h
+++ b/src/platform/qt/SettingsView.h
@@ -7,10 +7,12 @@
 
 #include <QDialog>
 #include <QMap>
+#include <QPointer>
 #include <QTimer>
 
 #include "ColorPicker.h"
 #include "LogConfigModel.h"
+#include "ShaderSelector.h"
 
 #include <mgba/core/core.h>
 
@@ -25,7 +27,6 @@ namespace QGBA {
 class ConfigController;
 class InputController;
 class ShortcutController;
-class ShaderSelector;
 
 class SettingsView : public QDialog {
 Q_OBJECT
@@ -80,7 +81,7 @@ private:
 
 	ConfigController* m_controller;
 	InputController* m_input;
-	ShaderSelector* m_shader = nullptr;
+	QPointer<ShaderSelector> m_shader;
 	QLabel* m_dummyShader;
 	LogConfigModel m_logModel;
 	QTimer m_checkTimer;


### PR DESCRIPTION
User "Autofire" in Discord reported a crash when saving settings.

```
Thread 1 "mgba-qt" received signal SIGSEGV, Segmentation fault.
0x00007ffff2ba793b in QObject::disconnect (sender=0x555555eec800, signal=0x0, receiver=0x555558be4340, method=0x0)
    at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qobject.cpp:3280
3280        const QMetaObject *smeta = sender->metaObject();
```

I tracked it down to a use-after-free: `Window::reloadDisplayDriver` calls `SettingsView::setShaderSelector` after destroying the old `ShaderSelector`, but the pointer in `SettingsView` didn't get cleared. Fortunately, QPointer exists for exactly this.