### PR TITLE
Simplify Qt multimedia code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/platform/cmake/")
 
 if(POLICY CMP0025)

--- a/src/core/scripting.c
+++ b/src/core/scripting.c
@@ -1343,6 +1343,8 @@ static uint8_t _readLuminance(struct GBALuminanceSource* luminance) {
 }
 #endif
 
+#pragma push_macro("CALLBACK")
+#undef CALLBACK
 #define CALLBACK(NAME) _mScriptCoreCallback ## NAME
 #define DEFINE_CALLBACK(NAME) \
 	void CALLBACK(NAME) (void* context) { \
@@ -1441,3 +1443,4 @@ void mScriptContextDetachCore(struct mScriptContext* context) {
 
 	mScriptContextRemoveGlobal(context, "emu");
 }
+#pragma pop_macro("CALLBACK")

--- a/src/platform/qt/AudioProcessorQt.cpp
+++ b/src/platform/qt/AudioProcessorQt.cpp
@@ -20,34 +20,51 @@ using namespace QGBA;
 
 AudioProcessorQt::AudioProcessorQt(QObject* parent)
 	: AudioProcessor(parent)
+	, m_device(new AudioDevice(this))
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 	m_recheckTimer.setInterval(1);
 	connect(&m_recheckTimer, &QTimer::timeout, this, &AudioProcessorQt::recheckUnderflow);
 #endif
+	QAudioFormat format;
+	format.setSampleRate(m_sampleRate);
+	format.setChannelCount(2);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+	format.setSampleSize(16);
+	format.setCodec("audio/pcm");
+	format.setByteOrder(QAudioFormat::Endian(QSysInfo::ByteOrder));
+	format.setSampleType(QAudioFormat::SignedInt);
+
+	m_audioOutput = new QAudioOutput(format, this);
+	m_audioOutput->setCategory("game");
+#else
+	format.setSampleFormat(QAudioFormat::Int16);
+
+	QAudioDevice device(QMediaDevices::defaultAudioOutput());
+	m_audioOutput = new QAudioSink(device, format, this);
+	LOG(QT, INFO) << "Audio outputting to " << device.description();
+	connect(m_audioOutput, &QAudioSink::stateChanged, this, [this](QAudio::State state) {
+		if (state != QAudio::IdleState) {
+			return;
+		}
+		recheckUnderflow();
+		m_recheckTimer.start();
+	});
+#endif
 }
 
 void AudioProcessorQt::setInput(std::shared_ptr<CoreController> controller) {
 	AudioProcessor::setInput(std::move(controller));
-	if (m_device) {
-		m_device->setInput(input());
-		if (m_audioOutput) {
-			m_device->setFormat(m_audioOutput->format());
-		}
-	}
+	m_device->setInput(input());
+	m_device->setFormat(m_audioOutput->format());
 }
 
 void AudioProcessorQt::stop() {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 	m_recheckTimer.stop();
 #endif
-	if (m_audioOutput) {
-		m_audioOutput->stop();
-		m_audioOutput.reset();
-	}
-	if (m_device) {
-		m_device.reset();
-	}
+	m_audioOutput->stop();
+	m_device->close();
 	AudioProcessor::stop();
 }
 
@@ -57,45 +74,13 @@ bool AudioProcessorQt::start() {
 		return false;
 	}
 
-	if (!m_device) {
-		m_device = std::make_unique<AudioDevice>(this);
-	}
-
-	if (!m_audioOutput) {
-		QAudioFormat format;
-		format.setSampleRate(m_sampleRate);
-		format.setChannelCount(2);
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-		format.setSampleSize(16);
-		format.setCodec("audio/pcm");
-		format.setByteOrder(QAudioFormat::Endian(QSysInfo::ByteOrder));
-		format.setSampleType(QAudioFormat::SignedInt);
-
-		m_audioOutput = std::make_unique<QAudioOutput>(format);
-		m_audioOutput->setCategory("game");
-#else
-		format.setSampleFormat(QAudioFormat::Int16);
-
-		QAudioDevice device(QMediaDevices::defaultAudioOutput());
-		m_audioOutput = std::make_unique<QAudioSink>(device, format);
-		LOG(QT, INFO) << "Audio outputting to " << device.description();
-		connect(m_audioOutput.get(), &QAudioSink::stateChanged, this, [this](QAudio::State state) {
-			if (state != QAudio::IdleState) {
-				return;
-			}
-			recheckUnderflow();
-			m_recheckTimer.start();
-		});
-#endif
-	}
-
 	if (m_audioOutput->state() == QAudio::SuspendedState) {
 		m_audioOutput->resume();
 	} else {
 		m_device->setBufferSamples(m_samples);
 		m_device->setInput(input());
 		m_device->setFormat(m_audioOutput->format());
-		m_audioOutput->start(m_device.get());
+		m_audioOutput->start(m_device);
 	}
 	return m_audioOutput->state() == QAudio::ActiveState && m_audioOutput->error() == QAudio::NoError;
 }
@@ -104,9 +89,7 @@ void AudioProcessorQt::pause() {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 	m_recheckTimer.stop();
 #endif
-	if (m_audioOutput) {
-		m_audioOutput->suspend();
-	}
+	m_audioOutput->suspend();
 }
 
 void AudioProcessorQt::setBufferSamples(int samples) {
@@ -117,31 +100,24 @@ void AudioProcessorQt::setBufferSamples(int samples) {
 }
 
 void AudioProcessorQt::inputParametersChanged() {
-	if (m_device) {
-		m_device->setFormat(m_audioOutput->format());
-		m_device->setBufferSamples(m_samples);
-	}
+	m_device->setFormat(m_audioOutput->format());
+	m_device->setBufferSamples(m_samples);
 }
 
 void AudioProcessorQt::requestSampleRate(unsigned rate) {
 	m_sampleRate = rate;
-	if (m_device) {
-		QAudioFormat format(m_audioOutput->format());
-		format.setSampleRate(rate);
-		m_device->setFormat(format);
-	}
+	QAudioFormat format(m_audioOutput->format());
+	format.setSampleRate(rate);
+	m_device->setFormat(format);
 }
 
 unsigned AudioProcessorQt::sampleRate() const {
-	if (!m_audioOutput) {
-		return 0;
-	}
 	return m_audioOutput->format().sampleRate();
 }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 void AudioProcessorQt::recheckUnderflow() {
-	if (!m_device) {
+	if (!m_device->isOpen()) {
 		m_recheckTimer.stop();
 		return;
 	}

--- a/src/platform/qt/AudioProcessorQt.h
+++ b/src/platform/qt/AudioProcessorQt.h
@@ -45,12 +45,12 @@ private slots:
 
 private:
 	QTimer m_recheckTimer;
-	std::unique_ptr<QAudioSink> m_audioOutput;
+	QAudioSink* m_audioOutput;
 #else
 private:
-	std::unique_ptr<QAudioOutput> m_audioOutput;
+	QAudioOutput* m_audioOutput;
 #endif
-	std::unique_ptr<AudioDevice> m_device;
+	AudioDevice* m_device;
 	size_t m_samples = 1024;
 	unsigned m_sampleRate = 44100;
 };

--- a/src/platform/qt/InputController.h
+++ b/src/platform/qt/InputController.h
@@ -174,8 +174,7 @@ private:
 	} m_image;
 
 #ifdef BUILD_QT_MULTIMEDIA
-	bool m_cameraActive = false;
-	std::unique_ptr<QCamera> m_camera;
+	QCamera* m_camera;
 	VideoDumper m_videoDumper;
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	QByteArray m_cameraDevice;


### PR DESCRIPTION
I think the unique pointers in `InputController` and `AudioProcessorQt` are unnecessary. I have refactored the code to not use unique pointers and simplified the code.