### PR TITLE
Mask away unused GPIO bits

### DIFF
--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -78,15 +78,15 @@ void GBAHardwareGPIOWrite(struct GBACartridgeHardware* hw, uint32_t address, uin
 			hw->pinState &= ~hw->direction;
 			hw->pinState |= value & hw->direction;
 		} else {
-			hw->pinState = value;
+			hw->pinState = value & 0xF;
 		}
 		_readPins(hw);
 		break;
 	case GPIO_REG_DIRECTION:
-		hw->direction = value;
+		hw->direction = value & 0xF;
 		break;
 	case GPIO_REG_CONTROL:
-		hw->readWrite = value;
+		hw->readWrite = value & 0x1;
 		break;
 	default:
 		mLOG(GBA_HW, WARN, "Invalid GPIO address");
@@ -514,6 +514,8 @@ void GBAHardwareDeserialize(struct GBACartridgeHardware* hw, const struct GBASer
 	hw->readWrite = GBASerializedHWFlags1GetReadWrite(flags1);
 	LOAD_16(hw->pinState, 0, &state->hw.pinState);
 	LOAD_16(hw->direction, 0, &state->hw.pinDirection);
+	hw->pinState &= 0xF;
+	hw->direction &= 0xF;
 	hw->devices = state->hw.devices;
 
 	if ((hw->devices & HW_GPIO) && hw->gpioBase) {


### PR DESCRIPTION
Unused GPIO bits are not writable and always return 0. This is documented on gbatek and I've confirmed this is the correct behavior on my own Emerald cartridge.