### PR TITLE
Implement GPIO internal write latch

### DIFF
--- a/include/mgba/internal/gba/cart/gpio.h
+++ b/include/mgba/internal/gba/cart/gpio.h
@@ -69,8 +69,8 @@ struct GBACartridgeHardware {
 	uint16_t* gpioBase;
 
 	uint8_t writeLatch;
-	uint16_t pinState;
-	uint16_t direction;
+	uint8_t pinState;
+	uint8_t direction;
 
 	struct GBARTC rtc;
 

--- a/include/mgba/internal/gba/cart/gpio.h
+++ b/include/mgba/internal/gba/cart/gpio.h
@@ -68,6 +68,7 @@ struct GBACartridgeHardware {
 	enum GPIODirection readWrite;
 	uint16_t* gpioBase;
 
+	uint8_t writeLatch;
 	uint16_t pinState;
 	uint16_t direction;
 

--- a/include/mgba/internal/gba/serialize.h
+++ b/include/mgba/internal/gba/serialize.h
@@ -376,7 +376,8 @@ struct GBASerializedState {
 	} dma[4];
 
 	struct {
-		uint16_t pinState;
+		uint8_t pinState;
+		uint8_t writeLatch;
 		uint16_t pinDirection;
 		int32_t rtcBytesRemaining;
 		int32_t rtcTransferStep;

--- a/include/mgba/internal/gba/serialize.h
+++ b/include/mgba/internal/gba/serialize.h
@@ -165,8 +165,10 @@ mLOG_DECLARE_CATEGORY(GBA_STATE);
  * | 0x00288 - 0x0028B: DMA next count
  * | 0x0028C - 0x0028F: DMA next event
  * 0x00290 - 0x002C3: GPIO state
- * | 0x00290 - 0x00291: Pin state
- * | 0x00292 - 0x00293: Direction state
+ * | 0x00290: Pin state
+ * | 0x00291: Write latch
+ * | 0x00292: Direction state
+ * | 0x00293: Reserved
  * | 0x00294 - 0x002B6: RTC state (see hardware.h for format)
  * | 0x002B7 - 0x002B7: GPIO devices
  *   | bit 0: Has RTC values
@@ -378,7 +380,8 @@ struct GBASerializedState {
 	struct {
 		uint8_t pinState;
 		uint8_t writeLatch;
-		uint16_t pinDirection;
+		uint8_t pinDirection;
+		uint8_t reserved0;
 		int32_t rtcBytesRemaining;
 		int32_t rtcTransferStep;
 		int32_t rtcBitsRead;
@@ -386,7 +389,7 @@ struct GBASerializedState {
 		int32_t rtcCommandActive;
 		RTCCommandData rtcCommand;
 		uint8_t rtcControl;
-		uint8_t reserved[3];
+		uint8_t reserved1[3];
 		uint8_t time[7];
 		uint8_t devices;
 		uint16_t gyroSample;

--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -485,7 +485,7 @@ void GBAHardwareSerialize(const struct GBACartridgeHardware* hw, struct GBASeria
 	flags1 = GBASerializedHWFlags1SetReadWrite(flags1, hw->readWrite);
 	state->hw.writeLatch = hw->writeLatch;
 	state->hw.pinState = hw->pinState;
-	STORE_16(hw->direction, 0, &state->hw.pinDirection);
+	state->hw.pinDirection = hw->direction;
 	state->hw.devices = hw->devices;
 
 	STORE_32(hw->rtc.bytesRemaining, 0, &state->hw.rtcBytesRemaining);
@@ -521,10 +521,9 @@ void GBAHardwareDeserialize(struct GBACartridgeHardware* hw, const struct GBASer
 	GBASerializedHWFlags1 flags1;
 	LOAD_16(flags1, 0, &state->hw.flags1);
 	hw->readWrite = GBASerializedHWFlags1GetReadWrite(flags1);
-	hw->writeLatch = state->hw.writeLatch;
-	hw->pinState = state->hw.pinState;
-	LOAD_16(hw->direction, 0, &state->hw.pinDirection);
-	hw->direction &= 0xF;
+	hw->writeLatch = state->hw.writeLatch & 0xF;
+	hw->pinState = state->hw.pinState & 0xF;
+	hw->direction = state->hw.pinDirection & 0xF;
 	hw->devices = state->hw.devices;
 
 	if ((hw->devices & HW_GPIO) && hw->gpioBase) {

--- a/src/gba/serialize.c
+++ b/src/gba/serialize.c
@@ -15,7 +15,7 @@
 #include <fcntl.h>
 
 MGBA_EXPORT const uint32_t GBASavestateMagic = 0x01000000;
-MGBA_EXPORT const uint32_t GBASavestateVersion = 0x00000007;
+MGBA_EXPORT const uint32_t GBASavestateVersion = 0x00000008;
 
 mLOG_DEFINE_CATEGORY(GBA_STATE, "GBA Savestate", "gba.serialize");
 


### PR DESCRIPTION
Regardless of direction, a write to GPIO data actually succeeds fully with all 4 bits. However, this does not directly touch the pin state. It instead places it into an internal write only latch. This latch asserts bits onto the pin state if direction allows for such, otherwise the other side (e.g. RTC) will be the one asserting bits (but this does not end up touching the internal write latch).

The implementation here is likely not entirely accurate for direction changes from out to in (as that depends on each external device implementation), but it should be correct for in to out changes.