### PR TITLE
Allow truncation to work within VFileFromMemory

### DIFF
--- a/src/util/vfs/vfs-mem.c
+++ b/src/util/vfs/vfs-mem.c
@@ -299,6 +299,10 @@ void _vfmTruncateNoExpand(struct VFile* vf, size_t size) {
 		size = vfm->bufferSize;
 	}
 
+	if (size > vfm->size) {
+		memset((void*) ((uintptr_t) vfm->mem + vfm->size), 0, size - vfm->size);
+	}
+
 	vfm->size = size;
 }
 


### PR DESCRIPTION
Truncation here is limited to buffer size (allowing for shrinking but not growing the VFile size)