### PR TITLE
RTC state machine improvements

### DIFF
--- a/include/mgba/internal/gba/cart/gpio.h
+++ b/include/mgba/internal/gba/cart/gpio.h
@@ -53,6 +53,7 @@ struct GBARTC {
 	int32_t bits;
 	int32_t commandActive;
 	bool sckEdge;
+	bool sioOutput;
 	RTCCommandData command;
 	RTCControl control;
 	uint8_t time[7];

--- a/include/mgba/internal/gba/cart/gpio.h
+++ b/include/mgba/internal/gba/cart/gpio.h
@@ -49,10 +49,10 @@ DECL_BIT(RTCCommandData, Reading, 7);
 
 struct GBARTC {
 	int32_t bytesRemaining;
-	int32_t transferStep;
 	int32_t bitsRead;
 	int32_t bits;
 	int32_t commandActive;
+	bool sckEdge;
 	RTCCommandData command;
 	RTCControl control;
 	uint8_t time[7];

--- a/include/mgba/internal/gba/serialize.h
+++ b/include/mgba/internal/gba/serialize.h
@@ -185,7 +185,7 @@ mLOG_DECLARE_CATEGORY(GBA_STATE);
  *   | bit 0: Is read enabled
  *   | bit 1: Gyroscope sample is edge
  *   | bit 2: Light sample is edge
- *   | bit 3: Reserved
+ *   | bit 3: RTC SCK is edge
  *   | bits 4 - 15: Light counter
  * | 0x002C0 - 0x002C0: Light sample
  * | 0x002C1: Flags
@@ -284,6 +284,7 @@ DECL_BITFIELD(GBASerializedHWFlags1, uint16_t);
 DECL_BIT(GBASerializedHWFlags1, ReadWrite, 0);
 DECL_BIT(GBASerializedHWFlags1, GyroEdge, 1);
 DECL_BIT(GBASerializedHWFlags1, LightEdge, 2);
+DECL_BIT(GBASerializedHWFlags1, RtcSckEdge, 3);
 DECL_BITS(GBASerializedHWFlags1, LightCounter, 4, 12);
 
 DECL_BITFIELD(GBASerializedHWFlags2, uint8_t);
@@ -383,13 +384,13 @@ struct GBASerializedState {
 		uint8_t pinDirection;
 		uint8_t reserved0;
 		int32_t rtcBytesRemaining;
-		int32_t rtcTransferStep;
+		int32_t reserved1;
 		int32_t rtcBitsRead;
 		int32_t rtcBits;
 		int32_t rtcCommandActive;
 		RTCCommandData rtcCommand;
 		uint8_t rtcControl;
-		uint8_t reserved1[3];
+		uint8_t reserved2[3];
 		uint8_t time[7];
 		uint8_t devices;
 		uint16_t gyroSample;

--- a/include/mgba/internal/gba/serialize.h
+++ b/include/mgba/internal/gba/serialize.h
@@ -389,13 +389,13 @@ struct GBASerializedState {
 		uint8_t pinDirection;
 		GBASerializedHWFlags3 flags3;
 		int32_t rtcBytesRemaining;
-		int32_t reserved1;
+		int32_t reserved0;
 		int32_t rtcBitsRead;
 		int32_t rtcBits;
 		int32_t rtcCommandActive;
 		RTCCommandData rtcCommand;
 		uint8_t rtcControl;
-		uint8_t reserved2[3];
+		uint8_t reserved1[3];
 		uint8_t time[7];
 		uint8_t devices;
 		uint16_t gyroSample;

--- a/include/mgba/internal/gba/serialize.h
+++ b/include/mgba/internal/gba/serialize.h
@@ -168,7 +168,9 @@ mLOG_DECLARE_CATEGORY(GBA_STATE);
  * | 0x00290: Pin state
  * | 0x00291: Write latch
  * | 0x00292: Direction state
- * | 0x00293: Reserved
+ * | 0x00293: Flags
+ *   | bit 0: RTC SIO output
+ *   | bit 1 - 7: Reserved
  * | 0x00294 - 0x002B6: RTC state (see hardware.h for format)
  * | 0x002B7 - 0x002B7: GPIO devices
  *   | bit 0: Has RTC values
@@ -292,6 +294,9 @@ DECL_BITS(GBASerializedHWFlags2, TiltState, 0, 2);
 DECL_BITS(GBASerializedHWFlags2, GbpInputsPosted, 2, 2);
 DECL_BITS(GBASerializedHWFlags2, GbpTxPosition, 4, 4);
 
+DECL_BITFIELD(GBASerializedHWFlags3, uint8_t);
+DECL_BITS(GBASerializedHWFlags3, RtcSioOutput, 0, 1);
+
 DECL_BITFIELD(GBASerializedUnlCartFlags, uint16_t);
 DECL_BITS(GBASerializedUnlCartFlags, Type, 0, 5);
 DECL_BITS(GBASerializedUnlCartFlags, Subtype, 5, 3);
@@ -382,7 +387,7 @@ struct GBASerializedState {
 		uint8_t pinState;
 		uint8_t writeLatch;
 		uint8_t pinDirection;
-		uint8_t reserved0;
+		GBASerializedHWFlags3 flags3;
 		int32_t rtcBytesRemaining;
 		int32_t reserved1;
 		int32_t rtcBitsRead;

--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -493,6 +493,10 @@ void GBAHardwareSerialize(const struct GBACartridgeHardware* hw, struct GBASeria
 	state->hw.pinDirection = hw->direction;
 	state->hw.devices = hw->devices;
 
+	GBASerializedHWFlags3 flags3 = 0;
+	flags3 = GBASerializedHWFlags3SetRtcSioOutput(flags3, hw->rtc.sioOutput);
+	state->hw.flags3 = flags3;
+
 	STORE_32(hw->rtc.bytesRemaining, 0, &state->hw.rtcBytesRemaining);
 	STORE_32(hw->rtc.bitsRead, 0, &state->hw.rtcBitsRead);
 	STORE_32(hw->rtc.bits, 0, &state->hw.rtcBits);
@@ -543,6 +547,8 @@ void GBAHardwareDeserialize(struct GBACartridgeHardware* hw, const struct GBASer
 			hw->gpioBase[2] = 0;
 		}
 	}
+
+	hw->rtc.sioOutput = GBASerializedHWFlags3GetRtcSioOutput(state->hw.flags3);
 
 	LOAD_32(hw->rtc.bytesRemaining, 0, &state->hw.rtcBytesRemaining);
 	LOAD_32(hw->rtc.bitsRead, 0, &state->hw.rtcBitsRead);

--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -114,11 +114,10 @@ void GBAHardwareInitRTC(struct GBACartridgeHardware* hw) {
 	hw->devices |= HW_RTC;
 	hw->rtc.bytesRemaining = 0;
 
-	hw->rtc.sckEdge = true;
-
 	hw->rtc.bitsRead = 0;
 	hw->rtc.bits = 0;
 	hw->rtc.commandActive = 0;
+	hw->rtc.sckEdge = true;
 	hw->rtc.command = 0;
 	hw->rtc.control = 0x40;
 	memset(hw->rtc.time, 0, sizeof(hw->rtc.time));

--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -404,6 +404,7 @@ void _lightReadPins(struct GBACartridgeHardware* hw) {
 		struct GBALuminanceSource* lux = hw->p->luminanceSource;
 		mLOG(GBA_HW, DEBUG, "[SOLAR] Got reset");
 		hw->lightCounter = 0;
+		hw->lightEdge = true; // unverified (perhaps reset only happens on bit 1 rising edge?)
 		if (lux) {
 			if (lux->sample) {
 				lux->sample(lux);
@@ -419,7 +420,7 @@ void _lightReadPins(struct GBACartridgeHardware* hw) {
 	hw->lightEdge = !(hw->pinState & 1);
 
 	bool sendBit = hw->lightCounter >= hw->lightSample;
-	_outputPins(hw, sendBit << 3);
+	_outputPins(hw, (sendBit << 3) | (hw->pinState & 0x7));
 	mLOG(GBA_HW, DEBUG, "[SOLAR] Output %u with pins %u", hw->lightCounter, hw->pinState);
 }
 

--- a/src/gba/serialize.c
+++ b/src/gba/serialize.c
@@ -15,7 +15,7 @@
 #include <fcntl.h>
 
 MGBA_EXPORT const uint32_t GBASavestateMagic = 0x01000000;
-MGBA_EXPORT const uint32_t GBASavestateVersion = 0x00000008;
+MGBA_EXPORT const uint32_t GBASavestateVersion = 0x00000009;
 
 mLOG_DEFINE_CATEGORY(GBA_STATE, "GBA Savestate", "gba.serialize");
 


### PR DESCRIPTION
Unsure if all of this is entirely right (haven't ran any tests to confirm behavior here). Fixes RTC within Pokemon games (and maybe other games) due to the added write latch code adding a _readPins call to direction writes.