### PR TITLE
Crop frame view exports to current video size

### DIFF
--- a/src/platform/qt/FrameView.cpp
+++ b/src/platform/qt/FrameView.cpp
@@ -594,7 +594,16 @@ void FrameView::exportFrame() {
 		return;
 	}
 	CoreController::Interrupter interrupter(m_controller);
-	m_framebuffer.save(filename, "PNG");
+
+	unsigned width, height;
+	m_vl->currentVideoSize(m_vl, &width, &height);
+
+	if ((int)width != m_framebuffer.width() || (int)height != m_framebuffer.height()) {
+		QImage crop = m_framebuffer.copy(0, 0, width, height);
+		crop.save(filename, "PNG");
+	} else {
+		m_framebuffer.save(filename, "PNG");
+	}
 }
 
 void FrameView::reset() {


### PR DESCRIPTION
The base video size of the Game Boy core is the Super Game Boy’s resolution of 256×224 pixels. Previously frames were exported at that size, leading to a 160×144 frame surrounded by uninitialized memory.

This assumes that the base size is always greater or equal to the current video size.

-------------------------

Examples of bad exports:
![badge_screen](https://github.com/user-attachments/assets/e0f444c5-7888-472a-9d25-ac354dc81ca7) ![badge_screen2](https://github.com/user-attachments/assets/6617932a-6a3f-448f-81a5-8644aac2a7cf)

Cropped:
![test1](https://github.com/user-attachments/assets/7b10c9cf-463f-4081-9706-29d6f1bc401c)
With border:
![test2](https://github.com/user-attachments/assets/456f3996-5f65-4cd0-ae54-da197406b7ed)

