### PR TITLE
Qt: fix blank rows in library rendering

### DIFF
--- a/src/platform/qt/library/LibraryModel.cpp
+++ b/src/platform/qt/library/LibraryModel.cpp
@@ -336,6 +336,26 @@ QVariant LibraryModel::folderData(const QModelIndex& index, int role) const {
 	return QVariant();
 }
 
+bool LibraryModel::validateIndex(const QModelIndex& index) const
+{
+	if (index.model() != this || index.row() < 0 || index.column() < 0 || index.column() > MAX_COLUMN) {
+		// Obviously invalid index
+		return false;
+	}
+
+	if (index.parent().isValid() && !validateIndex(index.parent())) {
+		// Parent index is invalid
+		return false;
+	}
+
+	if (index.row() >= rowCount(index.parent())) {
+		// Row is out of bounds for this level of hierarchy
+		return false;
+	}
+
+	return true;
+}
+
 QVariant LibraryModel::data(const QModelIndex& index, int role) const {
 	switch (role) {
 		case Qt::DisplayRole:
@@ -357,7 +377,7 @@ QVariant LibraryModel::data(const QModelIndex& index, int role) const {
 			return QVariant();
 	}
 
-	if (index.model() != this || index.row() < 0 || index.row() > rowCount() || index.column() < 0 || index.column() > columnCount()) {
+	if (!validateIndex(index)) {
 		return QVariant();
 	}
 

--- a/src/platform/qt/library/LibraryModel.h
+++ b/src/platform/qt/library/LibraryModel.h
@@ -70,6 +70,8 @@ private:
 
 	QVariant folderData(const QModelIndex& index, int role = Qt::DisplayRole) const;
 
+	bool validateIndex(const QModelIndex& index) const;
+
 	void addEntriesList(const QList<LibraryEntry>& items);
 	void addEntriesTree(const QList<LibraryEntry>& items);
 	void addEntryInternal(const LibraryEntry& item);


### PR DESCRIPTION
Discord user "NisioAyano" reported that between a75c6c41e and d79579d1c, the library view started rendering a lot of blank lines even though the underlying data was still correct.

I tracked this down to a mistake in https://github.com/mgba-emu/mgba/pull/3463.