### PR TITLE
Qt: don't restrict by model when loading from the library

### DIFF
--- a/src/platform/qt/library/LibraryController.cpp
+++ b/src/platform/qt/library/LibraryController.cpp
@@ -152,6 +152,7 @@ VFile* LibraryController::selectedVFile() {
 		libentry.base = baseUtf8.constData();
 		libentry.filename = filenameUtf8.constData();
 		libentry.platform = mPLATFORM_NONE;
+		libentry.platformModels = M_LIBRARY_MODEL_UNKNOWN;
 		return mLibraryOpenVFile(m_library.get(), &libentry);
 	} else {
 		return nullptr;


### PR DESCRIPTION
User "Menergy" on Discord noticed that the new library code can't launch games.

Upon further investigation, this is because a zero-initialized struct is no longer sufficient to call `mLibraryGetEntries` without any constraints.