### PR TITLE
Qt: improve AutorunScriptModel, add unit tests

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -307,6 +307,10 @@ if(ENABLE_SCRIPTING)
 	list(APPEND UI_FILES
 		scripting/AutorunScriptView.ui
 		scripting/ScriptingView.ui)
+
+	set(TEST_QT_autoscript_SRC
+		test/autoscript.cpp
+		scripting/AutorunScriptModel.cpp)
 endif()
 
 if(TARGET Qt6::Core)

--- a/src/platform/qt/CheckBoxDelegate.cpp
+++ b/src/platform/qt/CheckBoxDelegate.cpp
@@ -13,7 +13,7 @@ using namespace QGBA;
 CheckBoxDelegate::CheckBoxDelegate(QObject* parent)
 	: QStyledItemDelegate(parent)
 {
-	// initializers only
+	// Nothing to do
 }
 
 void CheckBoxDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const {

--- a/src/platform/qt/ConfigController.cpp
+++ b/src/platform/qt/ConfigController.cpp
@@ -123,7 +123,9 @@ QString ConfigController::s_configDir;
 ConfigController::ConfigController(QObject* parent)
 	: QObject(parent)
 {
-	qRegisterMetaType<AutorunScriptModel::ScriptInfo>();
+#ifdef ENABLE_SCRIPTING
+	AutorunScriptModel::registerMetaTypes();
+#endif
 
 	QString fileName = configDir();
 	fileName.append(QDir::separator());

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -554,10 +554,12 @@ void Window::openSettingsWindow(SettingsView::Page page) {
 #ifdef USE_SQLITE3
 	connect(settingsWindow, &SettingsView::libraryCleared, m_libraryView, &LibraryController::clear);
 #endif
+#ifdef ENABLE_SCRIPTING
 	connect(settingsWindow, &SettingsView::openAutorunScripts, this, [this]() {
 		ensureScripting();
 		m_scripting->openAutorunEdit();
 	});
+#endif
 	connect(this, &Window::shaderSelectorAdded, settingsWindow, &SettingsView::setShaderSelector);
 	openView(settingsWindow);
 	settingsWindow->selectPage(page);
@@ -2056,6 +2058,7 @@ void Window::updateMRU() {
 }
 
 void Window::ensureScripting() {
+#ifdef ENABLE_SCRIPTING
 	if (m_scripting) {
 		return;
 	}
@@ -2072,6 +2075,7 @@ void Window::ensureScripting() {
 	}
 
 	connect(m_scripting.get(), &ScriptingController::autorunScriptsOpened, this, &Window::openView);
+#endif
 }
 
 std::shared_ptr<Action> Window::addGameAction(const QString& visibleName, const QString& name, Action::Function function, const QString& menu, const QKeySequence& shortcut) {

--- a/src/platform/qt/scripting/AutorunScriptModel.h
+++ b/src/platform/qt/scripting/AutorunScriptModel.h
@@ -17,42 +17,42 @@ Q_OBJECT
 
 public:
 	struct ScriptInfo {
+		static const uint16_t VERSION = 1;
+
 		QString filename;
 		bool active;
-
-		friend QDataStream& operator<<(QDataStream& stream, const ScriptInfo& object) {
-			stream << object.filename;
-			stream << object.active;
-			return stream;
-		}
-
-		friend QDataStream& operator>>(QDataStream& stream, ScriptInfo& object) {
-			stream >> object.filename;
-			stream >> object.active;
-			return stream;
-		}
-
 	};
 
-	AutorunScriptModel(ConfigController* config, QObject* parent = nullptr);
+	static void registerMetaTypes();
+
+	AutorunScriptModel(QObject* parent = nullptr);
+
+	void deserialize(const QList<QVariant>& autorun);
+	QList<QVariant> serialize() const;
 
 	virtual int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 	virtual bool setData(const QModelIndex& index, const QVariant& data, int role = Qt::DisplayRole) override;
 	virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 	virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
+	virtual Qt::DropActions supportedDropActions() const override;
+
 	virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 	virtual bool moveRows(const QModelIndex& sourceParent, int sourceRow, int count, const QModelIndex& destinationParent, int destinationChild) override;
 
 	void addScript(const QString& filename);
-	QList<QString> activeScripts() const;
+	QStringList activeScripts() const;
+
+signals:
+	void scriptsChanged(const QList<QVariant>& serialized);
 
 private:
-	ConfigController* m_config;
 	QList<ScriptInfo> m_scripts;
 
-	void save();
+	void emitScriptsChanged();
 };
 
 }
 
 Q_DECLARE_METATYPE(QGBA::AutorunScriptModel::ScriptInfo);
+QDataStream& operator<<(QDataStream& stream, const QGBA::AutorunScriptModel::ScriptInfo& object);
+QDataStream& operator>>(QDataStream& stream, QGBA::AutorunScriptModel::ScriptInfo& object);

--- a/src/platform/qt/scripting/AutorunScriptView.cpp
+++ b/src/platform/qt/scripting/AutorunScriptView.cpp
@@ -18,6 +18,10 @@ AutorunScriptView::AutorunScriptView(AutorunScriptModel* model, ScriptingControl
 	m_ui.setupUi(this);
 
 	m_ui.autorunList->setModel(model);
+	m_ui.autorunList->setDragEnabled(true);
+	m_ui.autorunList->viewport()->setAcceptDrops(true);
+	m_ui.autorunList->setDropIndicatorShown(true);
+	m_ui.autorunList->setDragDropMode(QAbstractItemView::InternalMove);
 }
 
 void AutorunScriptView::addScript() {
@@ -48,5 +52,5 @@ void AutorunScriptView::moveUp() {
 void AutorunScriptView::moveDown() {
 	QModelIndex index = m_ui.autorunList->currentIndex();
 	QAbstractItemModel* model = m_ui.autorunList->model();
-	model->moveRows(index.parent(), index.row(), 1, index.parent(), index.row() + 1);
+	model->moveRows(index.parent(), index.row(), 1, index.parent(), index.row() + 2);
 }

--- a/src/platform/qt/scripting/ScriptingController.cpp
+++ b/src/platform/qt/scripting/ScriptingController.cpp
@@ -30,8 +30,12 @@ using namespace QGBA;
 
 ScriptingController::ScriptingController(ConfigController* config, QObject* parent)
 	: QObject(parent)
-	, m_model(config)
+	, m_config(config)
 {
+	QList<QVariant> autorun = m_config->getList("autorunSettings");
+	m_model.deserialize(autorun);
+	QObject::connect(&m_model, &AutorunScriptModel::scriptsChanged, this, &ScriptingController::saveAutorun);
+
 	m_logger.p = this;
 	m_logger.log = [](mLogger* log, int, enum mLogLevel level, const char* format, va_list args) {
 		Logger* logger = static_cast<Logger*>(log);
@@ -504,4 +508,8 @@ uint16_t ScriptingController::qtToScriptingModifiers(Qt::KeyboardModifiers modif
 		mod |= mSCRIPT_KMOD_SUPER;
 	}
 	return mod;
+}
+
+void ScriptingController::saveAutorun(const QList<QVariant>& autorun) {
+	m_config->setList("autorunSettings", autorun);
 }

--- a/src/platform/qt/scripting/ScriptingController.h
+++ b/src/platform/qt/scripting/ScriptingController.h
@@ -75,6 +75,7 @@ protected:
 private slots:
 	void updateGamepad();
 	void attach();
+	void saveAutorun(const QList<QVariant>& autorun);
 
 private:
 	void init();
@@ -101,6 +102,7 @@ private:
 	AutorunScriptModel m_model;
 	std::shared_ptr<CoreController> m_controller;
 	InputController* m_inputController = nullptr;
+	ConfigController* m_config = nullptr;
 
 	QTimer m_storageFlush;
 };

--- a/src/platform/qt/test/autoscript.cpp
+++ b/src/platform/qt/test/autoscript.cpp
@@ -1,0 +1,167 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "platform/qt/scripting/AutorunScriptModel.h"
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#include <QAbstractItemModelTester>
+#endif
+
+#include <QDataStream>
+#include <QSignalSpy>
+#include <QTest>
+
+using namespace QGBA;
+
+class AutorunScriptModelTest : public QObject {
+Q_OBJECT
+
+private:
+	AutorunScriptModel* model = nullptr;
+	QSignalSpy* spy = nullptr;
+
+	void addEntries(bool deactivateSecond) {
+		model->addScript("foo");
+		model->addScript("bar");
+		model->addScript("baz");
+		QCOMPARE(spy->count(), 3);
+		if (deactivateSecond) {
+			bool ok = model->setData(model->index(1, 0), Qt::Unchecked, Qt::CheckStateRole);
+			QCOMPARE(ok, true);
+		}
+	}
+
+	void checkScripts(const QStringList& names) {
+		int count = names.size();
+		for (int i = 0; i < count; i++) {
+			QCOMPARE(model->data(model->index(i, 0)), names[i]);
+		}
+	}
+
+	QVariantList parseRawData(const char* source, int size) {
+		QByteArray rawData(source, size);
+		QVariantList data;
+		QDataStream ds(&rawData, QIODevice::ReadOnly);
+		ds >> data;
+		return data;
+	}
+
+private slots:
+	void initTestCase() {
+		AutorunScriptModel::registerMetaTypes();
+	}
+
+	void init() {
+		model = new AutorunScriptModel(nullptr);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+		new QAbstractItemModelTester(model, QAbstractItemModelTester::FailureReportingMode::QtTest, model);
+#endif
+		spy = new QSignalSpy(model, SIGNAL(scriptsChanged(QList<QVariant>)));
+	}
+
+	void cleanup() {
+		delete model;
+		model = nullptr;
+		delete spy;
+		spy = nullptr;
+	}
+
+	void testAdd() {
+		addEntries(false);
+		QCOMPARE(model->rowCount(), 3);
+	}
+
+	void testEdit() {
+		addEntries(true);
+		int before = spy->count();
+		bool ok = model->setData(model->index(0, 0), Qt::Unchecked, Qt::CheckStateRole);
+		QCOMPARE(ok, true);
+		QCOMPARE(model->data(model->index(0, 0), Qt::CheckStateRole), Qt::Unchecked);
+		QCOMPARE(model->activeScripts(), (QStringList{ "baz" }));
+		QCOMPARE(spy->count() - before, 1);
+	}
+
+	void testMoveUp() {
+		addEntries(true);
+		int before = spy->count();
+		bool ok = model->moveRow(QModelIndex(), 1, QModelIndex(), 0);
+		QCOMPARE(ok, true);
+		checkScripts({ "bar", "foo", "baz" });
+		QCOMPARE(model->data(model->index(0, 0), Qt::CheckStateRole), Qt::Unchecked);
+		QCOMPARE(spy->count() - before, 1);
+	}
+
+	void testMoveDown() {
+		addEntries(true);
+		int before = spy->count();
+		bool ok = model->moveRow(QModelIndex(), 1, QModelIndex(), 3);
+		QCOMPARE(ok, true);
+		checkScripts({ "foo", "baz", "bar" });
+		QCOMPARE(model->data(model->index(2, 0), Qt::CheckStateRole), Qt::Unchecked);
+		QCOMPARE(spy->count() - before, 1);
+	}
+
+	void testRemove() {
+		addEntries(false);
+		int before = spy->count();
+		bool ok = model->removeRow(1);
+		QCOMPARE(ok, true);
+		checkScripts({ "foo", "baz" });
+		QCOMPARE(model->activeScripts(), (QStringList{ "foo", "baz" }));
+		QCOMPARE(spy->count() - before, 1);
+	}
+
+	void testSerialize() {
+		addEntries(true);
+		int before = spy->count();
+		auto data = model->serialize();
+		QCOMPARE(data.size(), 3);
+		auto first = data.first().value<AutorunScriptModel::ScriptInfo>();
+		QCOMPARE(first.filename, "foo");
+		QCOMPARE(first.active, true);
+		auto second = data[1].value<AutorunScriptModel::ScriptInfo>();
+		QCOMPARE(second.filename, "bar");
+		QCOMPARE(second.active, false);
+		QCOMPARE(spy->count() - before, 0);
+	}
+
+	void testDeserialize() {
+		QVariantList data;
+		data << QVariant::fromValue(AutorunScriptModel::ScriptInfo{ "foo", true });
+		data << QVariant::fromValue(AutorunScriptModel::ScriptInfo{ "bar", false });
+		QByteArray rawData;
+		QDataStream ds(&rawData, QIODevice::WriteOnly);
+		ds << data;
+		model->deserialize(data);
+		QCOMPARE(model->rowCount(), 2);
+		checkScripts({ "foo", "bar" });
+		QCOMPARE(model->data(model->index(0, 0), Qt::CheckStateRole), Qt::Checked);
+		QCOMPARE(model->data(model->index(1, 0), Qt::CheckStateRole), Qt::Unchecked);
+		QCOMPARE(spy->count(), 1);
+	}
+
+	void testDeserializeInvalid() {
+		static const char v0Data[] =
+			"\0\0\0\1"
+			"\0\0\4\0\0\0\0\0%QGBA::AutorunScriptModel::ScriptInfo\0\0\0\0\0\3foo\1";
+		model->deserialize(parseRawData(v0Data, sizeof(v0Data)));
+		QCOMPARE(model->rowCount(), 0);
+	}
+
+	void testDeserializeV1() {
+		static const char v1Data[] =
+			"\0\0\0\2"
+			"\0\0\4\0\0\0\0\0%QGBA::AutorunScriptModel::ScriptInfo\0\0\1\0\0\0\3foo\1"
+			"\0\0\4\0\0\0\0\0%QGBA::AutorunScriptModel::ScriptInfo\0\0\1\0\0\0\3bar\0";
+		model->deserialize(parseRawData(v1Data, sizeof(v1Data)));
+		QCOMPARE(model->rowCount(), 2);
+		checkScripts({ "foo", "bar" });
+		QCOMPARE(model->data(model->index(0, 0), Qt::CheckStateRole), Qt::Checked);
+		QCOMPARE(model->data(model->index(1, 0), Qt::CheckStateRole), Qt::Unchecked);
+	}
+};
+
+QTEST_MAIN(AutorunScriptModelTest)
+#include "autoscript.moc"


### PR DESCRIPTION
This PR depends on https://github.com/mgba-emu/mgba/pull/3483 as a prerequisite. (These changes will appear in this PR. You can view the last commit to review the changes in isolation.)

Qt's item models are notoriously tricky to get right. This PR adds some unit tests for `AutorunScriptModel` and makes sure all of them pass. It also cleans up the boundaries of `AutorunScriptModel` so that it can be unit tested.

Fixes of note:
* `setData` was not emitting `dataChanged`
* `removeRows` was not emitting `aboutToRemoveRows` / `rowsRemoved`
* `removeRows` did not have appropriate bounds checking, so clicking the Remove button would crash if no scripts were selected
* `moveRows` did not implement the correct API contract (which is painfully difficult to begin with)
* `moveRows` was not emitting `layoutAboutToBeChanged` / `layoutChanged`
* Qt5 requires registering the QDataStream operators, but that was missing. (Qt6 does not.)
* `#ifdef ENABLE_SCRIPTING` was missing in ConfigController and a couple places in Window.

While I was in here, I also took the opportunity to improve the serialization of `ScriptInfo`. Since endrift expressed that the struct might change in the future, I added versioning. And because I added versioning, I added forwards compatibility. (I took advantage of the fact that QString's serialization starts with a big-endian length, which will never realistically have anything but 0x00 in the first byte.) And because it now has forwards compatibility, I made the serialized data slightly less unreadable in qt.ini.