### PR TITLE
Qt: refactor popup window handling

### DIFF
--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCE_FILES
 	ConfigController.cpp
 	ColorPicker.cpp
 	CoreManager.cpp
+	CoreConsumer.cpp
 	CoreController.cpp
 	Display.cpp
 	DisplayGL.cpp
@@ -152,6 +153,7 @@ set(SOURCE_FILES
 	OverrideView.cpp
 	PaletteView.cpp
 	PlacementControl.cpp
+	PopupManager.cpp
 	RegisterView.cpp
 	ReportView.cpp
 	ROMInfo.cpp

--- a/src/platform/qt/CoreConsumer.cpp
+++ b/src/platform/qt/CoreConsumer.cpp
@@ -1,0 +1,96 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "CoreConsumer.h"
+
+#include "CoreController.h"
+
+using namespace QGBA;
+
+CoreProvider::CoreProvider(std::shared_ptr<CoreController> controller) {
+	setController(controller);
+}
+
+CoreProvider::~CoreProvider() {
+	for (CoreConsumer* consumer : m_consumers) {
+		consumer->m_provider = nullptr;
+	}
+}
+
+void CoreProvider::setController(std::shared_ptr<CoreController> controller) {
+	if (m_controller) {
+		// Disconnect all signals from old controller
+		QObject::disconnect(m_controller.get(), nullptr, this, nullptr);
+	}
+	std::shared_ptr<CoreController> oldController = m_controller;
+	m_controller = controller;
+	for (CoreConsumer* consumer : m_consumers) {
+		if (consumer->onControllerChanged) {
+			consumer->onControllerChanged();
+		}
+	}
+}
+
+void CoreProvider::setController(CoreController* controller) {
+	setController(std::shared_ptr<CoreController>(controller));
+}
+
+CoreController* CoreProvider::get() const {
+	return m_controller.get();
+}
+
+void CoreProvider::addConsumer(CoreConsumer* consumer) {
+	m_consumers.insert(consumer);
+}
+
+void CoreProvider::removeConsumer(CoreConsumer* consumer) {
+	m_consumers.erase(consumer);
+}
+
+void CoreProvider::swap(std::shared_ptr<CoreController>& controller) {
+	m_controller.swap(controller);
+}
+
+CoreConsumer::CoreConsumer(CoreProvider* provider) {
+	setCoreProvider(provider);
+}
+
+CoreConsumer::CoreConsumer(const CoreConsumer& other) {
+	setCoreProvider(other.m_provider);
+}
+
+CoreConsumer::~CoreConsumer() {
+	if (m_provider) {
+		m_provider->removeConsumer(this);
+	}
+}
+
+void CoreConsumer::setCoreProvider(CoreProvider* provider) {
+	if (m_provider) {
+		m_provider->removeConsumer(this);
+	}
+	m_provider = provider;
+	if (provider) {
+		provider->addConsumer(this);
+	}
+}
+
+CoreController* CoreConsumer::controller() const {
+	if (!m_provider) {
+		return nullptr;
+	}
+	return m_provider->get();
+}
+
+std::shared_ptr<CoreController> CoreConsumer::sharedController() const {
+	if (!m_provider) {
+		return nullptr;
+	}
+	return *m_provider;
+}
+
+void CoreConsumer::providerDestroyed() {
+	m_provider = nullptr;
+}

--- a/src/platform/qt/CoreConsumer.cpp
+++ b/src/platform/qt/CoreConsumer.cpp
@@ -27,9 +27,7 @@ void CoreProvider::setController(std::shared_ptr<CoreController> controller) {
 	std::shared_ptr<CoreController> oldController = m_controller;
 	m_controller = controller;
 	for (CoreConsumer* consumer : m_consumers) {
-		if (consumer->onControllerChanged) {
-			consumer->onControllerChanged();
-		}
+		consumer->callControllerChanged(oldController);
 	}
 }
 
@@ -89,6 +87,12 @@ std::shared_ptr<CoreController> CoreConsumer::sharedController() const {
 		return nullptr;
 	}
 	return *m_provider;
+}
+
+void CoreConsumer::callControllerChanged(std::shared_ptr<CoreController> oldController) {
+	if (onControllerChanged) {
+		onControllerChanged(oldController);
+	}
 }
 
 void CoreConsumer::providerDestroyed() {

--- a/src/platform/qt/CoreConsumer.h
+++ b/src/platform/qt/CoreConsumer.h
@@ -1,0 +1,65 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include <QObject>
+
+#include <memory>
+#include <unordered_set>
+
+namespace QGBA {
+
+class CoreController;
+class CoreConsumer;
+
+class CoreProvider : public QObject {
+public:
+	CoreProvider() = default;
+	CoreProvider(std::shared_ptr<CoreController> controller);
+	virtual ~CoreProvider();
+
+	void addConsumer(CoreConsumer* consumer);
+	void removeConsumer(CoreConsumer* consumer);
+
+	void setController(std::shared_ptr<CoreController> controller);
+	void setController(CoreController* controller);
+	CoreController* get() const;
+	inline CoreController* operator->() const { return get(); }
+	inline operator std::shared_ptr<CoreController>&() { return m_controller; }
+	inline operator bool() const { return get(); }
+
+	void swap(std::shared_ptr<CoreController>& controller);
+
+private:
+	std::shared_ptr<CoreController> m_controller;
+	std::unordered_set<CoreConsumer*> m_consumers;
+};
+
+class CoreConsumer {
+	friend class CoreProvider;
+public:
+	using ControllerCallback = std::function<void()>;
+
+	CoreConsumer() = default;
+	CoreConsumer(const CoreConsumer& other);
+	CoreConsumer(CoreProvider* provider);
+	virtual ~CoreConsumer();
+
+	void setCoreProvider(CoreProvider* provider);
+	inline CoreProvider* coreProvider() const { return m_provider; }
+	CoreController* controller() const;
+	std::shared_ptr<CoreController> sharedController() const;
+	inline operator bool() const { return controller(); }
+
+	ControllerCallback onControllerChanged;
+
+private:
+	void providerDestroyed();
+
+	CoreProvider* m_provider = nullptr;
+};
+
+}

--- a/src/platform/qt/DebuggerConsoleController.cpp
+++ b/src/platform/qt/DebuggerConsoleController.cpp
@@ -16,8 +16,8 @@
 
 using namespace QGBA;
 
-DebuggerConsoleController::DebuggerConsoleController(QObject* parent)
-	: DebuggerController(&m_cliDebugger.d, parent)
+DebuggerConsoleController::DebuggerConsoleController(CoreProvider* provider, QObject* parent)
+	: DebuggerController(&m_cliDebugger.d, provider, parent)
 {
 	m_backend.printf = printf;
 	m_backend.init = init;

--- a/src/platform/qt/DebuggerConsoleController.h
+++ b/src/platform/qt/DebuggerConsoleController.h
@@ -15,13 +15,11 @@
 
 namespace QGBA {
 
-class CoreController;
-
 class DebuggerConsoleController : public DebuggerController {
 Q_OBJECT
 
 public:
-	DebuggerConsoleController(QObject* parent = nullptr);
+	DebuggerConsoleController(CoreProvider* provider, QObject* parent = nullptr);
 
 	QStringList history() const { return m_history; }
 

--- a/src/platform/qt/DebuggerController.cpp
+++ b/src/platform/qt/DebuggerController.cpp
@@ -9,9 +9,10 @@
 
 using namespace QGBA;
 
-DebuggerController::DebuggerController(mDebuggerModule* debugger, QObject* parent)
+DebuggerController::DebuggerController(mDebuggerModule* debugger, CoreProvider* provider, QObject* parent)
 	: QObject(parent)
 	, m_debugger(debugger)
+	, m_gameController(this, provider)
 {
 }
 
@@ -22,13 +23,12 @@ bool DebuggerController::isAttached() {
 	return m_gameController->debugger() == m_debugger->p;
 }
 
-void DebuggerController::setController(std::shared_ptr<CoreController> controller) {
-	if (m_gameController && controller != m_gameController) {
-		m_gameController->disconnect(this);
+void DebuggerController::setController(std::shared_ptr<CoreController> oldController) {
+	if (oldController && m_gameController != oldController) {
+		oldController->disconnect(this);
 		detach();
 	}
-	m_gameController = controller;
-	if (controller) {
+	if (m_gameController) {
 		connect(m_gameController.get(), &CoreController::stopping, [this]() {
 			setController(nullptr);
 		});

--- a/src/platform/qt/DebuggerController.h
+++ b/src/platform/qt/DebuggerController.h
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+#include "CoreConsumer.h"
+
 struct mDebuggerModule;
 
 namespace QGBA {
@@ -19,11 +21,11 @@ class DebuggerController : public QObject {
 Q_OBJECT
 
 public:
-	DebuggerController(mDebuggerModule* debugger, QObject* parent = nullptr);
+	DebuggerController(mDebuggerModule* debugger, CoreProvider* provider, QObject* parent = nullptr);
 
 public:
 	bool isAttached();
-	void setController(std::shared_ptr<CoreController>);
+	void setController(std::shared_ptr<CoreController> oldController);
 
 public slots:
 	virtual void attach();
@@ -36,7 +38,7 @@ protected:
 	virtual void shutdownInternal();
 
 	mDebuggerModule* const m_debugger;
-	std::shared_ptr<CoreController> m_gameController;
+	CorePointer<DebuggerController> m_gameController;
 
 private:
 	bool m_autoattach = false;

--- a/src/platform/qt/GDBController.cpp
+++ b/src/platform/qt/GDBController.cpp
@@ -9,8 +9,8 @@
 
 using namespace QGBA;
 
-GDBController::GDBController(QObject* parent)
-	: DebuggerController(&m_gdbStub.d, parent)
+GDBController::GDBController(CoreProvider* provider, QObject* parent)
+	: DebuggerController(&m_gdbStub.d, provider, parent)
 	, m_bindAddress({ IPV4, {0} })
 {
 	GDBStubCreate(&m_gdbStub);

--- a/src/platform/qt/GDBController.h
+++ b/src/platform/qt/GDBController.h
@@ -13,13 +13,11 @@
 
 namespace QGBA {
 
-class CoreController;
-
 class GDBController : public DebuggerController {
 Q_OBJECT
 
 public:
-	GDBController(QObject* parent = nullptr);
+	GDBController(CoreProvider* provider, QObject* parent = nullptr);
 
 public:
 	ushort port();

--- a/src/platform/qt/LogController.cpp
+++ b/src/platform/qt/LogController.cpp
@@ -96,7 +96,7 @@ void LogController::postLog(int level, int category, const QString& string) {
 	if (!mLogFilterTest(&m_filter, category, static_cast<mLogLevel>(level))) {
 		return;
 	}
-	if (m_logToStdout || m_logToFile) {
+	if ((m_logToStdout || m_logToFile) && this == &s_global) {
 		QString line = tr("[%1] %2: %3").arg(LogController::toString(level)).arg(mLogCategoryName(category)).arg(string);
 
 		if (m_logToStdout) {

--- a/src/platform/qt/OverrideView.cpp
+++ b/src/platform/qt/OverrideView.cpp
@@ -24,7 +24,7 @@
 
 using namespace QGBA;
 
-OverrideView::OverrideView(ConfigController* config, QWidget* parent)
+OverrideView::OverrideView(std::shared_ptr<CoreController> controller, ConfigController* config, QWidget* parent)
 	: QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
 	, m_config(config)
 {
@@ -111,12 +111,16 @@ OverrideView::OverrideView(ConfigController* config, QWidget* parent)
 
 	m_recheck.setInterval(200);
 	connect(&m_recheck, &QTimer::timeout, this, &OverrideView::recheck);
+
+	setController(controller);
 }
 
 void OverrideView::setController(std::shared_ptr<CoreController> controller) {
 	m_controller = controller;
-	connect(controller.get(), &CoreController::started, this, &OverrideView::gameStarted);
-	connect(controller.get(), &CoreController::stopping, this, &OverrideView::gameStopped);
+	if (controller) {
+		connect(controller.get(), &CoreController::started, this, &OverrideView::gameStarted);
+		connect(controller.get(), &CoreController::stopping, this, &OverrideView::gameStopped);
+	}
 	recheck();
 }
 

--- a/src/platform/qt/OverrideView.h
+++ b/src/platform/qt/OverrideView.h
@@ -31,7 +31,7 @@ class OverrideView : public QDialog {
 Q_OBJECT
 
 public:
-	OverrideView(ConfigController* config, QWidget* parent = nullptr);
+	OverrideView(std::shared_ptr<CoreController> controller, ConfigController* config, QWidget* parent = nullptr);
 
 	void setController(std::shared_ptr<CoreController> controller);
 

--- a/src/platform/qt/PopupManager.cpp
+++ b/src/platform/qt/PopupManager.cpp
@@ -15,7 +15,7 @@ using CorePtr = PopupManagerBase::CorePtr;
 PopupManagerBase::PopupManagerBase(PopupManagerBase::Private* d)
 : m_d(d)
 {
-	d->controller.onControllerChanged = [d]{
+	d->controller.onControllerChanged = [d](CorePtr) {
 		d->updateConnections();
 		d->notifyWindow();
 	};

--- a/src/platform/qt/PopupManager.cpp
+++ b/src/platform/qt/PopupManager.cpp
@@ -1,0 +1,65 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "PopupManager.h"
+
+#include <QDialog>
+
+#include "CoreController.h"
+
+using namespace QGBA;
+using CorePtr = PopupManagerBase::CorePtr;
+
+PopupManagerBase::PopupManagerBase(PopupManagerBase::Private* d)
+: m_d(d)
+{
+	d->controller.onControllerChanged = [d]{
+		d->updateConnections();
+		d->notifyWindow();
+	};
+}
+
+void PopupManagerBase::show() {
+	QWidget* w = construct();
+	if (!w) {
+		return;
+	}
+	if (d()->isModal) {
+		w->setWindowModality(Qt::ApplicationModal);
+	}
+	w->show();
+	w->activateWindow();
+	w->raise();
+}
+
+QWidget* PopupManagerBase::construct() {
+	QWidget* w = d()->window();
+	if (w) {
+		return w;
+	}
+	constructImpl();
+	w = d()->window();
+	if (w && d()->keepAlive) {
+		w->setAttribute(Qt::WA_DeleteOnClose);
+	}
+	d()->updateConnections();
+	return w;
+}
+
+void PopupManagerBase::Private::setProvider(CoreProvider* provider) {
+	controller.setCoreProvider(provider);
+	updateConnections();
+}
+
+void PopupManagerBase::Private::updateConnections() {
+	if (stopConnection) {
+		QObject::disconnect(stopConnection);
+	}
+	CoreController* c = controller.controller();
+	QWidget* w = window();
+	if (c && w) {
+		stopConnection = QObject::connect(c, &CoreController::stopping, w, &QWidget::close);
+	}
+}

--- a/src/platform/qt/PopupManager.h
+++ b/src/platform/qt/PopupManager.h
@@ -34,7 +34,8 @@ protected:
 	class Private : public QSharedData {
 	public:
 		Private(PopupManagerBase* pub) : pub(pub) {}
-		Private(const Private& other) = default;
+		Private(const Private& other) = delete;
+		virtual ~Private() = default;
 
 		PopupManagerBase* pub;
 		bool isModal = false;

--- a/src/platform/qt/PopupManager.h
+++ b/src/platform/qt/PopupManager.h
@@ -1,0 +1,176 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include <QExplicitlySharedDataPointer>
+#include <QPointer>
+#include <QSharedData>
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include "CoreConsumer.h"
+
+namespace QGBA {
+
+class CoreController;
+
+class PopupManagerBase {
+public:
+	using CorePtr = std::shared_ptr<CoreController>;
+
+	PopupManagerBase(const PopupManagerBase&) = default;
+	virtual ~PopupManagerBase() = default;
+
+	QWidget* construct();
+	void show();
+	inline void operator()() { show(); }
+
+protected:
+	class Private : public QSharedData {
+	public:
+		Private(PopupManagerBase* pub) : pub(pub) {}
+		Private(const Private& other) = default;
+
+		PopupManagerBase* pub;
+		bool isModal = false;
+		bool keepAlive = false;
+		CoreConsumer controller;
+		QMetaObject::Connection stopConnection;
+
+		void setProvider(CoreProvider* provide);
+		void updateConnections();
+		virtual QWidget* window() const = 0;
+		virtual void notifyWindow() = 0;
+	};
+
+	PopupManagerBase(Private* d);
+
+	virtual void constructImpl() = 0;
+
+	virtual Private* d() const { return m_d.data(); }
+	virtual Private* d() { return m_d.data(); }
+
+private:
+	QExplicitlySharedDataPointer<Private> m_d;
+};
+
+template <class WINDOW>
+class PopupManager : public PopupManagerBase {
+	static_assert(std::is_convertible<WINDOW*, QWidget*>::value, "class must derive from QWidget");
+
+protected:
+	class Private;
+	Private* d() const override { return static_cast<Private*>(PopupManagerBase::d()); }
+	Private* d() override { return static_cast<Private*>(PopupManagerBase::d()); }
+
+	template <typename T>
+	struct HasSetController {
+		using Pass = char;
+		using Fail = int;
+		struct Base { bool setController; };
+		struct Test : T, Base {};
+		template <typename U> static Fail Check(decltype(U::setController)*);
+		template <typename U> static Pass Check(U*);
+		static constexpr bool value = sizeof(Check<Test>(nullptr)) == sizeof(Pass);
+	};
+
+public:
+	PopupManager() : PopupManagerBase(new Private(this)) {}
+	PopupManager(const PopupManager&) = default;
+
+	bool isNull() const { return d()->ptr.isNull(); }
+	WINDOW* operator->() const { return d()->ptr; }
+	WINDOW& operator*() const { return &d()->ptr; }
+	operator WINDOW*() const { return d()->ptr; }
+
+	PopupManager& withController(CoreProvider& provider) { d()->setProvider(&provider); return *this; }
+	PopupManager& setModal(bool modal) { d()->isModal = modal; return *this; }
+	PopupManager& setKeepAlive(bool keepAlive) { d()->keepAlive = keepAlive; return *this; }
+	PopupManager& constructWith(const std::function<WINDOW*()>& ctor) { d()->construct = ctor; return *this; }
+
+	template <typename... Args>
+	PopupManager& constructWith(Args... args) {
+		d()->construct = makeConstruct<WINDOW, Args...>(args...);
+		return *this;
+	}
+
+protected:
+	virtual void constructImpl() override {
+		Private* d = this->d();
+		if (!d->construct) {
+			qWarning("No valid constructor specified for popup");
+			return;
+		}
+		WINDOW* w = d->construct();
+		if (!w) {
+			qWarning("Constructor did not return a window");
+			return;
+		}
+		d->ptr = w;
+	}
+
+	template <typename T, typename... Args>
+	typename std::enable_if<std::is_constructible<T, CorePtr, Args...>::value, std::function<T*()>>::type makeConstruct(Args... args) {
+		return [=]() -> T* { return new T(d()->controller.sharedController(), args...); };
+	}
+
+	template <typename T, typename... Args>
+	typename std::enable_if<!std::is_constructible<T, CorePtr, Args...>::value, std::function<T*()>>::type makeConstruct(Args... args) {
+		return [=]() -> T* { return new T(args...); };
+	}
+
+	class Private : public PopupManagerBase::Private {
+		template <class T = WINDOW>
+		struct Ctors {
+			static constexpr bool useController = std::is_constructible<T, CorePtr>::value;
+			static constexpr bool useDefault = !useController && std::is_default_constructible<T>::value;
+			static constexpr bool noDefault = !useController && !useDefault;
+		};
+
+	public:
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::useDefault>::type* = 0)
+		: PopupManagerBase::Private(pub), construct([]{ return new WINDOW(); }) {}
+
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::useController>::type* = 0)
+		: PopupManagerBase::Private(pub), construct([this]{ return new WINDOW(controller.sharedController()); }) {}
+
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::noDefault>::type* = 0)
+		: PopupManagerBase::Private(pub) {}
+
+		~Private() {
+			if (ptr && !keepAlive) {
+				ptr->close();
+				ptr->deleteLater();
+			}
+		}
+
+		virtual QWidget* window() const override { return ptr.data(); }
+
+		virtual void notifyWindow() override { notifyWindow<WINDOW>(); }
+
+		template<class T>
+		typename std::enable_if<HasSetController<T>::value>::type notifyWindow() {
+			if (ptr) {
+				ptr->setController(controller.sharedController());
+			}
+		}
+
+		template<class T>
+		typename std::enable_if<!HasSetController<T>::value>::type notifyWindow() {
+			// Nothing to do
+		}
+
+		QPointer<WINDOW> ptr;
+		std::function<WINDOW*()> construct;
+	};
+};
+
+}

--- a/src/platform/qt/PopupManager.h
+++ b/src/platform/qt/PopupManager.h
@@ -69,17 +69,6 @@ protected:
 	Private* d() const override { return static_cast<Private*>(PopupManagerBase::d()); }
 	Private* d() override { return static_cast<Private*>(PopupManagerBase::d()); }
 
-	template <typename T>
-	struct HasSetController {
-		using Pass = char;
-		using Fail = int;
-		struct Base { bool setController; };
-		struct Test : T, Base {};
-		template <typename U> static Fail Check(decltype(U::setController)*);
-		template <typename U> static Pass Check(U*);
-		static constexpr bool value = sizeof(Check<Test>(nullptr)) == sizeof(Pass);
-	};
-
 public:
 	PopupManager() : PopupManagerBase(new Private(this)) {}
 	PopupManager(const PopupManager&) = default;
@@ -158,14 +147,14 @@ protected:
 		virtual void notifyWindow() override { notifyWindow<WINDOW>(); }
 
 		template<class T>
-		typename std::enable_if<HasSetController<T>::value>::type notifyWindow() {
+		typename std::enable_if<CoreConsumer::HasSetController<T>::value>::type notifyWindow() {
 			if (ptr) {
 				ptr->setController(controller.sharedController());
 			}
 		}
 
 		template<class T>
-		typename std::enable_if<!HasSetController<T>::value>::type notifyWindow() {
+		typename std::enable_if<!CoreConsumer::HasSetController<T>::value>::type notifyWindow() {
 			// Nothing to do
 		}
 

--- a/src/platform/qt/PopupManager.h
+++ b/src/platform/qt/PopupManager.h
@@ -81,7 +81,7 @@ public:
 	PopupManager& withController(CoreProvider& provider) { d()->setProvider(&provider); return *this; }
 	PopupManager& setModal(bool modal) { d()->isModal = modal; return *this; }
 	PopupManager& setKeepAlive(bool keepAlive) { d()->keepAlive = keepAlive; return *this; }
-	PopupManager& constructWith(const std::function<WINDOW*()>& ctor) { d()->construct = ctor; return *this; }
+	PopupManager& constructWithCallback(const std::function<WINDOW*()>& ctor) { d()->construct = ctor; return *this; }
 
 	template <typename... Args>
 	PopupManager& constructWith(Args... args) {

--- a/src/platform/qt/SensorView.cpp
+++ b/src/platform/qt/SensorView.cpp
@@ -71,28 +71,30 @@ SensorView::SensorView(std::shared_ptr<CoreController> controller, InputControll
 
 void SensorView::setController(std::shared_ptr<CoreController> controller) {
 	m_controller = controller;
-	if (controller) {
-		connect(m_ui.timeNoOverride, &QAbstractButton::clicked, controller.get(), &CoreController::setRealTime);
-		connect(m_ui.timeFixed, &QRadioButton::clicked, [controller, this] () {
-			controller->setFixedTime(m_ui.time->dateTime().toUTC());
-		});
-		connect(m_ui.timeFakeEpoch, &QRadioButton::clicked, [controller, this] () {
-			controller->setFakeEpoch(m_ui.time->dateTime().toUTC());
-		});
-		connect(m_ui.timeOffset, &QRadioButton::clicked, [controller, this] () {
-			controller->setTimeOffset(m_ui.offsetSeconds->value());
-		});
-		connect(m_ui.offsetSeconds, qOverload<int>(&QSpinBox::valueChanged), [controller, this] (int value) {
-			if (m_ui.timeOffset->isChecked()) {
-				controller->setTimeOffset(value);
-			}
-		});
-		m_ui.timeButtons->checkedButton()->clicked();
-
-		connect(controller.get(), &CoreController::stopping, [this]() {
-			m_controller.reset();
-		});
+	if (!controller) {
+		return;
 	}
+
+	connect(m_ui.timeNoOverride, &QAbstractButton::clicked, controller.get(), &CoreController::setRealTime);
+	connect(m_ui.timeFixed, &QRadioButton::clicked, [controller, this] () {
+		controller->setFixedTime(m_ui.time->dateTime().toUTC());
+	});
+	connect(m_ui.timeFakeEpoch, &QRadioButton::clicked, [controller, this] () {
+		controller->setFakeEpoch(m_ui.time->dateTime().toUTC());
+	});
+	connect(m_ui.timeOffset, &QRadioButton::clicked, [controller, this] () {
+		controller->setTimeOffset(m_ui.offsetSeconds->value());
+	});
+	connect(m_ui.offsetSeconds, qOverload<int>(&QSpinBox::valueChanged), [controller, this] (int value) {
+		if (m_ui.timeOffset->isChecked()) {
+			controller->setTimeOffset(value);
+		}
+	});
+	m_ui.timeButtons->checkedButton()->clicked();
+
+	connect(controller.get(), &CoreController::stopping, [this]() {
+		m_controller.reset();
+	});
 }
 
 void SensorView::jiggerer(QAbstractButton* button, void (InputDriver::*setter)(int)) {

--- a/src/platform/qt/SensorView.h
+++ b/src/platform/qt/SensorView.h
@@ -27,7 +27,7 @@ class SensorView : public QDialog {
 Q_OBJECT
 
 public:
-	SensorView(InputController* input, QWidget* parent = nullptr);
+	SensorView(std::shared_ptr<CoreController> controller, InputController* input, QWidget* parent = nullptr);
 
 	void setController(std::shared_ptr<CoreController>);
 

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -1724,7 +1724,8 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	m_actions.addMenu(tr("&Tools"), "tools");
 	m_actions.addAction(tr("View &logs..."), "viewLogs", openNamedTView(&m_logView, true, &m_log, this), "tools");
-	m_actions.addAction(tr("Game &overrides..."), "overrideWindow", openNamedControllerTView(&m_overrideView, true, m_config, this), "tools");
+	m_overrideView.withController(m_controller).constructWith(m_config, this);
+	m_actions.addAction(tr("Game &overrides..."), "overrideWindow", m_overrideView, "tools");
 	m_actions.addAction(tr("Game Pak sensors..."), "sensorWindow", openNamedControllerTView(&m_sensorView, true, &m_inputController, this), "tools");
 
 	addGameAction(tr("&Cheats..."), "cheatsWindow", openNamedControllerTView(&m_cheatsView, false), "tools");
@@ -2155,7 +2156,7 @@ void Window::setController(CoreController* controller, const QString& fname) {
 		reloadDisplayDriver();
 	}
 
-	m_controller = std::shared_ptr<CoreController>(controller);
+	m_controller.setController(controller);
 	m_controller->setInputController(&m_inputController);
 	m_controller->setLogger(&m_log);
 
@@ -2232,10 +2233,6 @@ void Window::setController(CoreController* controller, const QString& fname) {
 
 	if (m_sensorView) {
 		m_sensorView->setController(m_controller);
-	}
-
-	if (m_overrideView) {
-		m_overrideView->setController(m_controller);
 	}
 
 	if (!m_pendingPatch.isEmpty()) {

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -22,6 +22,8 @@
 #include "InputController.h"
 #include "LoadSaveState.h"
 #include "LogController.h"
+#include "OverrideView.h"
+#include "PopupManager.h"
 #include "SettingsView.h"
 #ifdef ENABLE_SCRIPTING
 #include "scripting/ScriptingController.h"
@@ -194,7 +196,7 @@ private:
 	QString getFiltersArchive() const;
 
 	CoreManager* m_manager;
-	std::shared_ptr<CoreController> m_controller;
+	CoreProvider m_controller;
 	std::unique_ptr<AudioProcessor> m_audioProcessor;
 
 	std::unique_ptr<QGBA::Display> m_display;
@@ -245,7 +247,7 @@ private:
 	bool m_multiActive = true;
 	int m_playerId;
 
-	QPointer<OverrideView> m_overrideView;
+	PopupManager<OverrideView> m_overrideView;
 	QPointer<SensorView> m_sensorView;
 	QPointer<DolphinConnector> m_dolphinView;
 	QPointer<FrameView> m_frameView;

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -30,6 +30,7 @@
 namespace QGBA {
 
 class AudioProcessor;
+class CheatsView;
 class ConfigController;
 class CoreController;
 class CoreManager;
@@ -178,6 +179,7 @@ private:
 	void ensureScripting();
 
 	template <typename T, typename... A> std::function<void()> openTView(A... arg);
+	template <typename T, typename... A> std::function<void()> openTViewModal(A... arg);
 	template <typename T, typename... A> std::function<void()> openControllerTView(A... arg);
 	template <typename T, typename... A> std::function<void()> openNamedTView(QPointer<T>*, bool keepalive, A... arg);
 	template <typename T, typename... A> std::function<void()> openNamedControllerTView(QPointer<T>*, bool keepalive, A... arg);
@@ -209,7 +211,7 @@ private:
 	QMap<int, std::shared_ptr<Action>> m_frameSizes;
 
 	LogController m_log{0};
-	LogView* m_logView;
+	QPointer<LogView> m_logView;
 #ifdef ENABLE_DEBUGGERS
 	DebuggerConsoleController* m_console = nullptr;
 #endif
@@ -247,6 +249,7 @@ private:
 	QPointer<SensorView> m_sensorView;
 	QPointer<DolphinConnector> m_dolphinView;
 	QPointer<FrameView> m_frameView;
+	QPointer<CheatsView> m_cheatsView;
 
 #ifdef USE_FFMPEG
 	QPointer<VideoView> m_videoView;

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -19,11 +19,11 @@
 #include <mgba/core/thread.h>
 
 #include "ActionMapper.h"
+#include "CoreConsumer.h"
 #include "InputController.h"
 #include "LoadSaveState.h"
 #include "LogController.h"
 #include "OverrideView.h"
-#include "PopupManager.h"
 #include "SettingsView.h"
 #ifdef ENABLE_SCRIPTING
 #include "scripting/ScriptingController.h"
@@ -32,24 +32,17 @@
 namespace QGBA {
 
 class AudioProcessor;
-class CheatsView;
 class ConfigController;
 class CoreController;
 class CoreManager;
 class DebuggerConsoleController;
 class Display;
-class DolphinConnector;
-class FrameView;
 class GDBController;
-class GIFView;
 class LibraryController;
-class LogView;
-class OverrideView;
-class SensorView;
 class ShaderSelector;
 class ShortcutController;
-class VideoView;
 class WindowBackground;
+class WindowPopups;
 
 class Window : public QMainWindow {
 Q_OBJECT
@@ -167,6 +160,7 @@ private:
 	static const int FPS_TIMER_INTERVAL = 2000;
 	static const int MUST_RESTART_TIMEOUT = 10000;
 
+	void setupPopups();
 	void setupMenu(QMenuBar*);
 	void setupOptions();
 	void openStateWindow(LoadSave);
@@ -179,12 +173,6 @@ private:
 	void updateMRU();
 
 	void ensureScripting();
-
-	template <typename T, typename... A> std::function<void()> openTView(A... arg);
-	template <typename T, typename... A> std::function<void()> openTViewModal(A... arg);
-	template <typename T, typename... A> std::function<void()> openControllerTView(A... arg);
-	template <typename T, typename... A> std::function<void()> openNamedTView(QPointer<T>*, bool keepalive, A... arg);
-	template <typename T, typename... A> std::function<void()> openNamedControllerTView(QPointer<T>*, bool keepalive, A... arg);
 
 	std::shared_ptr<Action> addGameAction(const QString& visibleName, const QString& name, Action::Function action, const QString& menu = {}, const QKeySequence& = {});
 	template<typename T, typename V> std::shared_ptr<Action> addGameAction(const QString& visibleName, const QString& name, T* obj, V (T::*action)(), const QString& menu = {}, const QKeySequence& = {});
@@ -213,7 +201,6 @@ private:
 	QMap<int, std::shared_ptr<Action>> m_frameSizes;
 
 	LogController m_log{0};
-	QPointer<LogView> m_logView;
 #ifdef ENABLE_DEBUGGERS
 	DebuggerConsoleController* m_console = nullptr;
 #endif
@@ -247,16 +234,7 @@ private:
 	bool m_multiActive = true;
 	int m_playerId;
 
-	PopupManager<OverrideView> m_overrideView;
-	QPointer<SensorView> m_sensorView;
-	QPointer<DolphinConnector> m_dolphinView;
-	QPointer<FrameView> m_frameView;
-	QPointer<CheatsView> m_cheatsView;
-
-#ifdef USE_FFMPEG
-	QPointer<VideoView> m_videoView;
-	QPointer<GIFView> m_gifView;
-#endif
+	std::unique_ptr<WindowPopups> m_popups;
 
 #ifdef ENABLE_GDB_STUB
 	GDBController* m_gdbController = nullptr;


### PR DESCRIPTION
I noticed that some popups (memory logging, cheats) weren't getting deduplicated, and others (log view) weren't getting raised if they were already open when the menu command was clicked.

I also noticed some code duplication for overrides and sensors, so I was going to try to refactor them together, only to notice that the template magic I was about to write already existed.

So I went through all of the popups I could find and made sure they were recycled. In a few cases I made them modal dialogs instead of non-modal since they're clearly intended to be standalone interfaces. And in the case of MemoryAccessLogView, I had to go about deduplication a little differently because there are two ways to open it.