### PR TITLE
Send hangup `$W00` to GDB

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -825,6 +825,8 @@ cleanup:
 }
 
 void GDBStubHangup(struct GDBStub* stub) {
+	strncpy(stub->outgoing, "W00", GDB_STUB_MAX_LINE - 4);
+	_sendMessage(stub);
 	if (!SOCKET_FAILED(stub->connection)) {
 		SocketClose(stub->connection);
 		stub->connection = INVALID_SOCKET;


### PR DESCRIPTION
When debugging with GDB closing mGBA doesn't send the GDB end session command (`$W00`); it only closes the socket (which is not enough)

The effect of this is when using GDB to debug, if mGBA is closed the GDB session may stay open. This is obvious when debugging GBA programs with IDEs such as Visual Studio Code or CLion.

Information on the W AA process exit stop packet:
https://sourceware.org/gdb/current/onlinedocs/gdb.html/Stop-Reply-Packets.html

Here's a video showing the issue on mGBA master versus this branch - notice how when closing mGBA the debugger tools hang around and require an explicit press of the "Stop" button, which does not stop the debugging until it times out with a `-1`

https://github.com/user-attachments/assets/74e61b60-215f-41b4-842f-46c332e1de44

However closing mGBA with the change in this PR immediately disconnects the debugger