### PR TITLE
QT: drop QtLogging include

### DIFF
--- a/src/platform/qt/LogController.cpp
+++ b/src/platform/qt/LogController.cpp
@@ -6,9 +6,6 @@
 #include "LogController.h"
 
 #include <QMessageBox>
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QtLogging>
-#endif
 
 #include "ConfigController.h"
 


### PR DESCRIPTION
QtLogging is only available since qtbase v6.5.0 and is redundant in LogController.cpp.