### PR TITLE
Flag for Window to skip reload of log levels (issue #3496)

### DIFF
--- a/src/platform/qt/GBAApp.cpp
+++ b/src/platform/qt/GBAApp.cpp
@@ -131,6 +131,7 @@ Window* GBAApp::newWindow() {
 		return nullptr;
 	}
 	Window* w = new Window(&m_manager, m_configController, m_windows.count());
+	w->setSkipResetLevels(true);
 	connect(w, &Window::destroyed, [this, w]() {
 		m_windows.removeAll(w);
 		for (Window* w : m_windows) {

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -314,7 +314,9 @@ void Window::loadConfig() {
 void Window::reloadConfig() {
 	const mCoreOptions* opts = m_config->options();
 
-	m_log.setLevels(opts->logLevel);
+	if (!m_skipResetLevels) {
+		m_log.setLevels(opts->logLevel);
+	}
 
 	if (m_controller) {
 		m_controller->loadConfig(m_config);
@@ -1418,6 +1420,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	m_actions.addSeparator("file");
 	m_multiWindow = m_actions.addAction(tr("New multiplayer window"), "multiWindow", GBAApp::app(), &GBAApp::newWindow, "file");
+	setSkipResetLevels(false);
 
 #ifdef M_CORE_GBA
 	auto dolphin = m_actions.addAction(tr("Connect to Dolphin..."), "connectDolphin", openNamedTView<DolphinConnector>(&m_dolphinView, true, this), "file");
@@ -2368,4 +2371,8 @@ void WindowBackground::paintEvent(QPaintEvent* event) {
 	painter.fillRect(QRect(QPoint(), size()), Qt::black);
 	QRect full(clampSize(QSize(m_aspectWidth, m_aspectHeight), size(), true, false));
 	painter.drawPixmap(full, logo);
+}
+
+void Window::setSkipResetLevels(bool doSkip) {
+	m_skipResetLevels = doSkip;
 }

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -111,6 +111,8 @@ public slots:
 
 	void openView(QWidget* widget);
 
+	void setSkipResetLevels(bool doSkip);
+
 #ifdef ENABLE_DEBUGGERS
 	void consoleOpen();
 #endif
@@ -242,6 +244,8 @@ private:
 	bool m_inactiveMute = false;
 	bool m_multiActive = true;
 	int m_playerId;
+
+	bool m_skipResetLevels = false;
 
 	QPointer<OverrideView> m_overrideView;
 	QPointer<SensorView> m_sensorView;


### PR DESCRIPTION
#3496 

Component modified: Qt

To fix the above issue, a flag _m_skipResetLevels_ is added to Window that is false by default. When set to true (which is done in GBAApp::newWindow), the logging levels are not refreshed in Window::reloadConfig.