### PR TITLE
Debugger: Allow execute command when hit breakpoint (CLI debugger)

### DIFF
--- a/include/mgba/debugger/debugger.h
+++ b/include/mgba/debugger/debugger.h
@@ -127,12 +127,20 @@ struct mDebuggerEntryInfo {
 	struct mDebuggerModule* target;
 };
 
+struct BreakCommand{
+	void * commandData;
+	bool (*handleCommand)(void*);
+	void (*freeData)(void*);
+	struct BreakCommand* next;
+};
+
 struct mBreakpoint {
 	ssize_t id;
 	uint32_t address;
 	int segment;
 	enum mBreakpointType type;
 	struct ParseTree* condition;
+	struct BreakCommand* commands;
 	bool isTemporary;
 };
 

--- a/include/mgba/internal/debugger/cli-debugger.h
+++ b/include/mgba/internal/debugger/cli-debugger.h
@@ -33,6 +33,11 @@ struct CLIDebugVector {
 	int segmentValue;
 };
 
+struct CLIDebugCMD{
+	char* command;
+	struct CLIDebugger* dbg;
+};
+
 typedef void (*CLIDebuggerCommand)(struct CLIDebugger*, struct CLIDebugVector*);
 
 struct CLIDebuggerCommandSummary {

--- a/src/debugger/cli-debugger.c
+++ b/src/debugger/cli-debugger.c
@@ -1073,6 +1073,13 @@ static int _tryCommands(struct CLIDebugger* debugger, struct CLIDebuggerCommandS
 }
 
 bool CLIDebuggerRunCommand(struct CLIDebugger* debugger, const char* line, size_t count) {
+	while (isspace(*line)) {
+		++line;
+		--count;
+	}
+	while (isspace(*(line + count - 1))) {
+		--count;
+	}
 	const char* firstSpace = strchr(line, ' ');
 	size_t cmdLength;
 	if (firstSpace) {


### PR DESCRIPTION
- syntax : break address condition do command_1; command_2; ... command_n;
- example: b 0x8001D3C r0==2 || r0==3 do print r1; print lr; c;
- explanation: only pause when pc reach 0x8001D3C if r0 == 2 or r0 == 3 after paused print r1 and lr then resume execution