### PR TITLE
ARM, SM83: Avoid single stepping if CPU is halted or blocked

### DIFF
--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -227,15 +227,18 @@ static inline void ThumbStep(struct ARMCore* cpu) {
 }
 
 void ARMRun(struct ARMCore* cpu) {
-	while (cpu->cycles >= cpu->nextEvent) {
+	if (cpu->cycles >= cpu->nextEvent) {
 		cpu->irqh.processEvents(cpu);
+	}
+	if (cpu->cycles == cpu->nextEvent) {
+		return;
 	}
 	if (cpu->executionMode == MODE_THUMB) {
 		ThumbStep(cpu);
 	} else {
 		ARMStep(cpu);
 	}
-	while (cpu->cycles >= cpu->nextEvent) {
+	if (cpu->cycles >= cpu->nextEvent) {
 		cpu->irqh.processEvents(cpu);
 	}
 }

--- a/src/sm83/sm83.c
+++ b/src/sm83/sm83.c
@@ -179,11 +179,11 @@ static inline bool _SM83TickInternal(struct SM83Core* cpu) {
 void SM83Tick(struct SM83Core* cpu) {
 	while (cpu->cycles >= cpu->nextEvent) {
 		cpu->irqh.processEvents(cpu);
+		if (cpu->halted) {
+			return;
+		}
 	}
 	_SM83TickInternal(cpu);
-	while (cpu->cycles >= cpu->nextEvent) {
-		cpu->irqh.processEvents(cpu);
-	}
 }
 
 void SM83Run(struct SM83Core* cpu) {


### PR DESCRIPTION
Single step functions would run an instruction even if CPU was halted or blocked.  This disrupted the order of events as well as synchronization between the different components. SIO even caused emulator crashes randomly.