### PR TITLE
Debugger: Make debugger aware of thread status when using threads

### DIFF
--- a/include/mgba/debugger/debugger.h
+++ b/include/mgba/debugger/debugger.h
@@ -212,10 +212,13 @@ struct mDebuggerPlatform {
 	void (*nextInstructionInfo)(struct mDebuggerPlatform* d, struct mDebuggerInstructionInfo* info);
 };
 
+struct mCoreThreadInternal;
+
 struct mDebugger {
 	struct mCPUComponent d;
 	struct mDebuggerPlatform* platform;
 	enum mDebuggerState state;
+	struct mCoreThreadInternal* threadImpl;
 	struct mCore* core;
 	struct mScriptBridge* bridge;
 	struct mStackTrace stackTrace;
@@ -245,9 +248,13 @@ void mDebuggerInit(struct mDebugger*);
 void mDebuggerDeinit(struct mDebugger*);
 
 void mDebuggerAttach(struct mDebugger*, struct mCore*);
+#ifndef DISABLE_THREADING
+void mDebuggerSetThread(struct mDebugger*, struct mCoreThreadInternal*);
+void mDebuggerUnsetThread(struct mDebugger*);
+#endif
 void mDebuggerAttachModule(struct mDebugger*, struct mDebuggerModule*);
 void mDebuggerDetachModule(struct mDebugger*, struct mDebuggerModule*);
-void mDebuggerRunTimeout(struct mDebugger* debugger, int32_t timeoutMs);
+void mDebuggerRunTimeout(struct mDebugger*, int32_t);
 void mDebuggerRun(struct mDebugger*);
 void mDebuggerRunFrame(struct mDebugger*);
 void mDebuggerEnter(struct mDebugger*, enum mDebuggerEntryReason, struct mDebuggerEntryInfo*);


### PR DESCRIPTION
When mGBA used Threading, the debugger ignored this and would run even when the thread status was not RUNNING. This issue has been addressed by allowing the debugger to know thread's current status at every momment.
Mutex handling has also been added (when using threads) to prevent unwanted or unpredictable changes during critical sections.

Between this and #3602 issue #3355 should be fixed.