### PR TITLE
Qt: Add "Reload Shader" button

### DIFF
--- a/src/platform/qt/ShaderSelector.cpp
+++ b/src/platform/qt/ShaderSelector.cpp
@@ -41,6 +41,7 @@ ShaderSelector::ShaderSelector(Display* display, ConfigController* config, QWidg
 
 	refreshShaders();
 
+	connect(m_ui.reload, &QAbstractButton::clicked, this, &ShaderSelector::reloadShaders);
 	connect(m_ui.load, &QAbstractButton::clicked, this, &ShaderSelector::selectShader);
 	connect(m_ui.unload, &QAbstractButton::clicked, this, &ShaderSelector::clearShader);
 	connect(m_ui.buttonBox, &QDialogButtonBox::clicked, this, &ShaderSelector::buttonPressed);
@@ -121,6 +122,16 @@ void ShaderSelector::loadShader(const QString& path, bool saveToSettings) {
 	}
 	if (error) {
 		QMessageBox::warning(this, tr("Error loading shader"), tr("The shader \"%1\" could not be loaded successfully.").arg(shaderPath));
+	}
+}
+
+void ShaderSelector::reloadShaders() {
+	if (!m_shaderPath.isEmpty()) {
+		int activeTab = m_ui.passes->currentIndex();
+		loadShader(m_shaderPath);
+		if (activeTab < m_ui.passes->count()) {
+			m_ui.passes->setCurrentIndex(activeTab);
+		}
 	}
 }
 

--- a/src/platform/qt/ShaderSelector.h
+++ b/src/platform/qt/ShaderSelector.h
@@ -36,6 +36,7 @@ public slots:
 private slots:
 	void selectShader();
 	void loadShader(const QString& path, bool saveToSettings = false);
+	void reloadShaders();
 	void clearShader(bool saveToSettings = false);
 	void buttonPressed(QAbstractButton*);
 

--- a/src/platform/qt/ShaderSelector.ui
+++ b/src/platform/qt/ShaderSelector.ui
@@ -96,7 +96,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="2">
+     <item row="0" column="2">
+      <widget class="QPushButton" name="reload">
+       <property name="text">
+        <string>Reload Shader</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="3">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Adds a "Reload Shader" button to the "Shaders" section of the Settings window, to save the trouble of navigating to the manifest.ini of the currently-loaded shader over and over when wanting to see the effect of tweaks to its source files.

The only 'gotcha' is that reloading the shader also resets all of the uniforms to the value they had when "Apply" was last clicked, but given that this is the same behavior that already happens when reloading the shader through "Load New Shader", I think it's to be expected.