### PR TITLE
Qt: Shader uniforms appear in order

### DIFF
--- a/src/platform/qt/ShaderSelector.h
+++ b/src/platform/qt/ShaderSelector.h
@@ -49,6 +49,7 @@ private:
 	void addUniform(QGridLayout*, const QString& section, const QString& name, float* value, float min, float max, int y, int x);
 	void addUniform(QGridLayout*, const QString& section, const QString& name, int* value, int min, int max, int y, int x);
 	void addMatchingUniformRows(mGLES2Shader* shader, QFormLayout* layout, const QString& name, int pass, const QString& uniformName, bool addAll);
+	void parseShaderIniLine(mGLES2Shader* shader, QFormLayout* layout, const QString& name, int pass, QString lineString);
 	QWidget* makePage(mGLES2Shader*, const QString& name, int pass, bool defaultPage);
 
 	Ui::ShaderSelector m_ui;


### PR DESCRIPTION
After getting the uniforms from the manifest.ini in the usual way (through inih), ShaderSelector::makePage now runs through the manifest.ini one more time, much more simply, just to determine the order to add the Qt rows in.