### PR TITLE
GBA: Configured overrides should have priority

### DIFF
--- a/include/mgba/gba/interface.h
+++ b/include/mgba/gba/interface.h
@@ -105,6 +105,7 @@ bool GBAIsMB(struct VFile* vf);
 bool GBAIsBIOS(struct VFile* vf);
 
 bool GBAOverrideFind(const struct Configuration*, struct GBACartridgeOverride* override);
+bool GBAOverrideFindConfig(const struct Configuration*, struct GBACartridgeOverride* override);
 void GBAOverrideSave(struct Configuration*, const struct GBACartridgeOverride* override);
 
 struct GBASIODriver {

--- a/src/gba/cart/gpio.c
+++ b/src/gba/cart/gpio.c
@@ -64,7 +64,7 @@ void GBAHardwareReset(struct GBACartridgeHardware* hw) {
 }
 
 void GBAHardwareClear(struct GBACartridgeHardware* hw) {
-	hw->devices = HW_NONE | (hw->devices & HW_GB_PLAYER_DETECTION);
+	hw->devices = HW_NO_OVERRIDE | (hw->devices & HW_GB_PLAYER_DETECTION);
 	hw->readWrite = GPIO_WRITE_ONLY;
 	hw->writeLatch = 0;
 	hw->pinState = 0;

--- a/src/platform/qt/OverrideView.cpp
+++ b/src/platform/qt/OverrideView.cpp
@@ -237,6 +237,7 @@ void OverrideView::gameStarted() {
 		m_ui.tabWidget->setCurrentWidget(m_ui.tabGBA);
 		GBA* gba = static_cast<GBA*>(thread->core->board);
 		m_ui.savetype->setCurrentIndex(gba->memory.savedata.type + 1);
+		m_ui.hwAutodetect->setChecked(gba->memory.hw.devices & HW_NO_OVERRIDE);
 		m_ui.hwRTC->setChecked(gba->memory.hw.devices & HW_RTC);
 		m_ui.hwGyro->setChecked(gba->memory.hw.devices & HW_GYRO);
 		m_ui.hwLight->setChecked(gba->memory.hw.devices & HW_LIGHT_SENSOR);


### PR DESCRIPTION
User "Erukurawjin" in Discord pointed out that game overrides weren't saving across mGBA restarts.

After digging into the code, I discovered that this only affects Pokemon ROM hacks. A special case in `GBAOverrideApplyDefaults` checks for Pokemon ROMs with an unexpected CRC and applies a special default override. However, this code path then doesn't check `config.ini` for manually-assigned overrides.

The practical effect of this is that overrides would work when you set them manually, and they would save to `config.ini` as expected, but then they would be ignored the next time you launched mGBA. 

This PR moves the `if (config)` branch of `GBAOverrideFind` into a separate function so that it can be invoked by `GBAOverrideApplyDefaults` to load overrides from the config file.

Additionally, nothing in `OverrideView` ever turned off the "Autodetect" checkbox, so even if overrides _were_ applied, checking the game overrides window would falsely appear to still have autodetect enabled. My solution was to store the "no overrides" bit in `hw.devices` in the same way it's used in the overrides code. I'm... less confident about my solution to this and I'm open to discussing alternatives.