### PR TITLE
Qt: fix oversight in autorun serialization

### DIFF
--- a/src/platform/qt/scripting/AutorunScriptModel.cpp
+++ b/src/platform/qt/scripting/AutorunScriptModel.cpp
@@ -8,10 +8,12 @@
 #include "Log.h"
 
 QDataStream& operator<<(QDataStream& stream, const QGBA::AutorunScriptModel::ScriptInfo& object) {
+	int restoreVersion = stream.version();
 	stream.setVersion(QDataStream::Qt_5_0);
 	stream << QGBA::AutorunScriptModel::ScriptInfo::VERSION;
 	stream << object.filename.toUtf8();
 	stream << object.active;
+	stream.setVersion(restoreVersion);
 	return stream;
 }
 


### PR DESCRIPTION
I happened to notice an oversight in my code from https://github.com/mgba-emu/mgba/pull/3599 -- I don't think this would have broken anything because `ScriptInfo` is only ever serialized inside a `QVariant` and not as part of a larger datastream, but let's not leave a subtle issue like this around where it _might_ cause problems later if we ever change our minds.