### PR TITLE
Qt: Fix persistence of NUMPAD+ shortcut

### DIFF
--- a/src/platform/qt/ShortcutController.cpp
+++ b/src/platform/qt/ShortcutController.cpp
@@ -254,7 +254,7 @@ bool ShortcutController::loadShortcuts(std::shared_ptr<Shortcut> item) {
 		QString s = shortcut.toString();
 		if (s.endsWith('+') &&
 			(s.contains("Ctrl") || s.contains("Shift") ||
-			s.contains("Alt")  || s.contains("Meta"))) {
+			s.contains("Alt") || s.contains("Meta"))) {
 			updateKey(item, toModifierShortcut(s));
 		} else {
 			updateKey(item, QKeySequence(s)[0]);


### PR DESCRIPTION
NUMPAD+ shortcuts were saved as '+' in qt.ini but would not persist across restarts. Previously, NUMPAD+ was interpreted as a modifier-only shortcut. This change ensures only true modifier shortcuts follow the modifier path, allowing NUMPAD+ to be restored correctly.

Fixes issue #3614.