### PR TITLE
Minor fixes for SDL3

### DIFF
--- a/src/platform/example/client-server/client.c
+++ b/src/platform/example/client-server/client.c
@@ -49,6 +49,7 @@ int main() {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 	SDL_Window* window = SDL_CreateWindow(projectName, width, height, SDL_WINDOW_OPENGL);
 	SDL_Renderer* renderer = SDL_CreateRenderer(window, NULL);
+	SDL_SetRenderVSync(renderer, 1);
 #else
 	SDL_Window* window = SDL_CreateWindow(projectName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL);
 	SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);

--- a/src/platform/sdl/sdl-events.c
+++ b/src/platform/sdl/sdl-events.c
@@ -101,6 +101,7 @@ bool mSDLInitEvents(struct mSDLEvents* context) {
 			_mSDLOpenJoystick(context, ids[i]);
 		}
 	}
+	SDL_free(ids);
 #else
 	SDL_JoystickEventState(SDL_ENABLE);
 	int nJoysticks = SDL_NumJoysticks();

--- a/src/platform/sdl/sw-sdl2.c
+++ b/src/platform/sdl/sw-sdl2.c
@@ -25,6 +25,7 @@ bool mSDLSWInit(struct mSDLRenderer* renderer) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 	renderer->window = SDL_CreateWindow(projectName, renderer->viewportWidth, renderer->viewportHeight, SDL_WINDOW_FULLSCREEN * renderer->player.fullscreen);
 	renderer->sdlRenderer = SDL_CreateRenderer(renderer->window, NULL);
+	SDL_SetRenderVSync(renderer->sdlRenderer, 1);
 #else
 	renderer->window = SDL_CreateWindow(projectName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, renderer->viewportWidth, renderer->viewportHeight, SDL_WINDOW_FULLSCREEN_DESKTOP * renderer->player.fullscreen);
 	renderer->sdlRenderer = SDL_CreateRenderer(renderer->window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);


### PR DESCRIPTION
Set VSync for SDL_Renderers (to match older SDL usage)
Free ids from SDL_GetJoysticks (this must be freed by the user)