### PR TITLE
Load optional SDL gamepad mappings from `$configdir/gamecontrollerdb.txt`

### DIFF
--- a/src/platform/sdl/sdl-events.c
+++ b/src/platform/sdl/sdl-events.c
@@ -67,6 +67,24 @@ static struct SDL_JoystickCombo* _mSDLOpenJoystick(struct mSDLEvents* events, in
 }
 
 bool mSDLInitEvents(struct mSDLEvents* context) {
+#if SDL_VERSION_ATLEAST(2, 0, 2)
+	char path[PATH_MAX + 1];
+	mCoreConfigDirectory(path, PATH_MAX);
+	strncat(path, PATH_SEP "gamecontrollerdb.txt", PATH_MAX - strlen(path));
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	int result = SDL_AddGamepadMappingsFromFile(path);
+#else
+	int result = SDL_GameControllerAddMappingsFromFile(path);
+#endif
+
+	if (result < 0) {
+		mLOG(SDL_EVENTS, DEBUG, "SDL failed to load optional game controller mappings from %s: %s", path, SDL_GetError());
+	} else {
+		mLOG(SDL_EVENTS, INFO, "Loaded %d gamepad mappings from %s", result, path);
+	}
+#endif
+
 #if SDL_VERSION_ATLEAST(2, 0, 4)
 	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 #endif


### PR DESCRIPTION
This optional gamepad mapping file allows updates to SDL’s controller database without having to compile mGBA with newer versions of SDL.

To quote the SDL docs:
> Add support for gamepads that SDL is unaware of or change the binding of an existing gamepad.

We try to load the database before the `SDL_InitSubSystem` calls, because the SDL2 docs hint that it’s the best place to do so:
> If this function is called before `SDL_Init`, SDL will generate an `SDL_CONTROLLERDEVICEADDED` event for matching controllers that are plugged in at the time that `SDL_Init` is called.

In SDL3 this remark was changed to say
> Any new mappings for already plugged in controllers will generate SDL_EVENT_GAMEPAD_ADDED events.