### PR TITLE
Qt: Explicitly request desktop OpenGL with LibGL

### DIFF
--- a/src/platform/qt/DisplayGL.cpp
+++ b/src/platform/qt/DisplayGL.cpp
@@ -287,6 +287,7 @@ void DisplayGL::startDrawing(std::shared_ptr<CoreController> controller) {
 bool DisplayGL::highestCompatible(QSurfaceFormat& format) {
 #if defined(BUILD_GLES2) || defined(BUILD_GLES3) || defined(USE_EPOXY)
 	if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
+		format.setRenderableType(QSurfaceFormat::OpenGL);
 		format.setVersion(3, 3);
 		format.setProfile(QSurfaceFormat::CoreProfile);
 		if (DisplayGL::supportsFormat(format)) {


### PR DESCRIPTION
```
~ % echo $XDG_SESSION_TYPE
wayland
~ % glxinfo | rg "OpenGL core profile version string"
OpenGL core profile version string: 4.6.0 NVIDIA 590.48.01
```

I recently built mGBA from source for the first time and had some trouble with Qt being able to use OpenGL. I got `EGL_BAD_MATCH` from the `LibGL` version detection branch, and had to use `QT_QPA_PLATFORM=xcb` to get it running.

I fiddled around with this and realized that asking for version 3.2 works... curious, since OpenGL *ES* 3.2 is the last version of OpenGL ES. It seems that without explicitly asking for desktop OpenGL, Qt's heuristics are going for OpenGL ES. We can fix this by making the request explicit.

(Unfortunately when loading a ROM there is a separate issue between QtWayland and Nvidia drivers v555+ doing explicit sync: `wp_linux_drm_syncobj_surface_v1#53: error 4: explicit sync is used, but no acquire point is set`. But that's another issue.)