### PR TITLE
GBA Cart: Add Everdrive SD emulation

### DIFF
--- a/include/mgba/internal/gba/cart/everdrive-sd.h
+++ b/include/mgba/internal/gba/cart/everdrive-sd.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2013-2026 Jeffrey Pfau
+ * Copyright (c) 2026 Felix Jones
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef GBA_CART_EVERDRIVE_SD_H
+#define GBA_CART_EVERDRIVE_SD_H
+
+#include <mgba-util/common.h>
+
+CXX_GUARD_START
+
+struct GBA;
+struct VFile;
+
+enum {
+	GBA_EVERDRIVE_SD_BASE = 0x09FC0000,
+	GBA_EVERDRIVE_SD_EEP_BASE = 0x09FE0000,
+	GBA_EVERDRIVE_SD_REG_SIZE = 0x200,
+};
+
+struct GBAEverdriveSD {
+	struct VFile* image;
+
+	bool readOnly;
+	bool cardIdle;
+	bool appCmd;
+	bool readMulti;
+	bool writeMulti;
+	bool writeCapturing;
+
+	uint8_t regs[0x100];
+	uint8_t status;
+	uint32_t currentReadSector;
+	uint32_t currentWriteSector;
+
+	uint8_t cmdPacket[6];
+	int cmdPacketLen;
+	uint8_t cmdResponse[32];
+	int cmdResponseLen;
+	int cmdResponsePos;
+
+	uint8_t dataBlock[512];
+	int dataBlockPos;
+	uint8_t dataScript[32];
+	int dataScriptLen;
+	int dataScriptPos;
+};
+
+void GBAEverdriveSDInit(struct GBAEverdriveSD* sd);
+void GBAEverdriveSDDeinit(struct GBAEverdriveSD* sd);
+void GBAEverdriveSDReset(struct GBAEverdriveSD* sd);
+void GBAEverdriveSDConfigure(struct GBAEverdriveSD* sd, bool enabled, const char* path);
+
+bool GBAEverdriveSDIsActive(const struct GBAEverdriveSD* sd);
+bool GBAEverdriveSDHandlesAddress(uint32_t address);
+
+uint16_t GBAEverdriveSDRead16(struct GBAEverdriveSD* sd, uint32_t address);
+void GBAEverdriveSDWrite16(struct GBAEverdriveSD* sd, uint32_t address, uint16_t value);
+
+CXX_GUARD_END
+
+#endif

--- a/include/mgba/internal/gba/memory.h
+++ b/include/mgba/internal/gba/memory.h
@@ -16,6 +16,7 @@ CXX_GUARD_START
 #include <mgba/internal/gba/dma.h>
 #include <mgba/internal/gba/savedata.h>
 #include <mgba/internal/gba/cart/ereader.h>
+#include <mgba/internal/gba/cart/everdrive-sd.h>
 #include <mgba/internal/gba/cart/gpio.h>
 #include <mgba/internal/gba/cart/matrix.h>
 #include <mgba/internal/gba/cart/unlicensed.h>
@@ -111,6 +112,7 @@ struct GBAMemory {
 	struct GBAMatrix matrix;
 	struct GBAUnlCart unl;
 	struct GBACartEReader ereader;
+	struct GBAEverdriveSD everdrive;
 	size_t romSize;
 	uint32_t romMask;
 	uint16_t romID;

--- a/src/gba/CMakeLists.txt
+++ b/src/gba/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE_FILES
 	audio.c
 	bios.c
 	cart/ereader.c
+	cart/everdrive-sd.c
 	cart/gpio.c
 	cart/matrix.c
 	cart/unlicensed.c

--- a/src/gba/cart/everdrive-sd.c
+++ b/src/gba/cart/everdrive-sd.c
@@ -1,0 +1,471 @@
+/* Copyright (c) 2013-2026 Jeffrey Pfau
+ * Copyright (c) 2026 Felix Jones
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include <mgba/internal/gba/cart/everdrive-sd.h>
+
+#include <mgba-util/vfs.h>
+
+#include <string.h>
+
+enum {
+	REG_CFG = 0x00,
+	REG_STATUS = 0x01,
+	REG_SD_CMD = 0x08,
+	REG_SD_DAT = 0x09,
+	REG_SD_CFG = 0x0A,
+	REG_SD_RAM = 0x0B,
+	REG_KEY = 0x5A,
+};
+
+enum {
+	STAT_SDC_TOUT = 2,
+};
+
+enum {
+	CMD0_GO_IDLE_STATE = 0x40,
+	CMD2_ALL_SEND_CID = 0x42,
+	CMD3_SEND_RELATIVE_ADDR = 0x43,
+	CMD6_SWITCH_FUNC = 0x46,
+	CMD7_SELECT_DESELECT_CARD = 0x47,
+	CMD8_SEND_IF_COND = 0x48,
+	CMD9_SEND_CSD = 0x49,
+	CMD12_STOP_TRANSMISSION = 0x4C,
+	CMD17_READ_SINGLE_BLOCK = 0x51,
+	CMD18_READ_MULTIPLE_BLOCK = 0x52,
+	CMD24_WRITE_SINGLE_BLOCK = 0x58,
+	CMD25_WRITE_MULTIPLE_BLOCK = 0x59,
+	CMD55_APP_CMD = 0x77,
+	CMD58_READ_OCR = 0x7A,
+	ACMD41_SEND_OP_COND = 0x69,
+};
+
+enum {
+	SD_CFG_WAIT_F0 = 0x08,
+	SD_CFG_STRT_F0 = 0x10,
+	SD_CFG_MODE_MASK = 0x1E,
+	SD_CFG_MODE1 = 0x00,
+};
+
+enum {
+	SD_SECTOR_SIZE = 512,
+	SD_RESPONSE_R1_LEN = 6,
+	SD_RESPONSE_R2_LEN = 17,
+	SD_TOKEN_IDLE = 0xFF,
+	SD_TOKEN_DATA_RESPONSE = 0xFE,
+	SD_TOKEN_START_BLOCK = 0xF0,
+};
+
+static void _closeImage(struct GBAEverdriveSD* sd) {
+	if (sd->image) {
+		sd->image->close(sd->image);
+		sd->image = NULL;
+	}
+}
+
+static uint8_t _crc7(const uint8_t* data, size_t len) {
+	unsigned crc = 0;
+	while (len--) {
+		crc ^= *data++;
+		for (int i = 0; i < 8; ++i) {
+			crc <<= 1;
+			if (crc & (1 << 8)) {
+				crc ^= 0x12;
+			}
+		}
+	}
+	return (uint8_t) ((crc & 0xFE) | 1);
+}
+
+static void _finalizeResponseCrc(uint8_t* response, const int len) {
+	if (len < 2) {
+		return;
+	}
+	if (len == SD_RESPONSE_R2_LEN) {
+		response[len - 1] = _crc7(&response[1], len - 2);
+	} else {
+		response[len - 1] = _crc7(response, len - 1);
+	}
+}
+
+static void _queueCmdResponse(struct GBAEverdriveSD* sd, const uint8_t* response, int len) {
+	const int idleLeadBytes = len > 0 ? 1 : 0;
+	if (len + idleLeadBytes > (int) sizeof(sd->cmdResponse)) {
+		len = sizeof(sd->cmdResponse) - idleLeadBytes;
+	}
+	if (len > 0) {
+		memcpy(sd->cmdResponse, response, len);
+		_finalizeResponseCrc(sd->cmdResponse, len);
+		memmove(&sd->cmdResponse[1], sd->cmdResponse, len);
+		sd->cmdResponse[0] = SD_TOKEN_IDLE;
+	}
+	sd->cmdResponseLen = len + idleLeadBytes;
+	sd->cmdResponsePos = 0;
+}
+
+static uint8_t _cmdRead(struct GBAEverdriveSD* sd) {
+	if (sd->cmdResponsePos >= sd->cmdResponseLen) {
+		return SD_TOKEN_IDLE;
+	}
+	return sd->cmdResponse[sd->cmdResponsePos++];
+}
+
+static uint8_t _cmdPeek(const struct GBAEverdriveSD* sd) {
+	if (sd->cmdResponsePos >= sd->cmdResponseLen) {
+		return SD_TOKEN_IDLE;
+	}
+	return sd->cmdResponse[sd->cmdResponsePos];
+}
+
+static bool _readSector(struct GBAEverdriveSD* sd, const uint32_t sector) {
+	const off_t base = (off_t) sector * SD_SECTOR_SIZE;
+	if (!sd->image || sd->image->seek(sd->image, base, SEEK_SET) < 0) {
+		return false;
+	}
+	const ssize_t read = sd->image->read(sd->image, sd->dataBlock, sizeof(sd->dataBlock));
+	if (read < 0) {
+		return false;
+	}
+	if (read < (ssize_t) sizeof(sd->dataBlock)) {
+		memset(&sd->dataBlock[read], 0, sizeof(sd->dataBlock) - read);
+	}
+	sd->dataBlockPos = 0;
+	return true;
+}
+
+static bool _writeSector(const struct GBAEverdriveSD* sd, const uint32_t sector) {
+	if (!sd->image || sd->readOnly) {
+		return false;
+	}
+	const off_t base = (off_t) sector * SD_SECTOR_SIZE;
+	if (sd->image->seek(sd->image, base, SEEK_SET) < 0) {
+		return false;
+	}
+	const ssize_t written = sd->image->write(sd->image, sd->dataBlock, sizeof(sd->dataBlock));
+	if (written != (ssize_t) sizeof(sd->dataBlock)) {
+		return false;
+	}
+	if (sd->image->sync) {
+		sd->image->sync(sd->image, NULL, 0);
+	}
+	return true;
+}
+
+static void _queueWriteDataResponse(struct GBAEverdriveSD* sd, const uint8_t responseCode) {
+	sd->dataScriptLen = 0;
+	sd->dataScript[sd->dataScriptLen++] = SD_TOKEN_IDLE;
+	sd->dataScript[sd->dataScriptLen++] = SD_TOKEN_DATA_RESPONSE;
+	sd->dataScript[sd->dataScriptLen++] = (responseCode >> 2) & 1;
+	sd->dataScript[sd->dataScriptLen++] = (responseCode >> 1) & 1;
+	sd->dataScript[sd->dataScriptLen++] = responseCode & 1;
+	sd->dataScript[sd->dataScriptLen++] = SD_TOKEN_IDLE;
+	sd->dataScriptPos = 0;
+}
+
+static uint8_t _dataReadByte(struct GBAEverdriveSD* sd) {
+	if (sd->dataScriptPos < sd->dataScriptLen) {
+		return sd->dataScript[sd->dataScriptPos++];
+	}
+	if (sd->readMulti && sd->dataBlockPos < (int) sizeof(sd->dataBlock)) {
+		return sd->dataBlock[sd->dataBlockPos++];
+	}
+	return SD_TOKEN_IDLE;
+}
+
+static void _handleReadStart(struct GBAEverdriveSD* sd) {
+	if (!sd->readMulti) {
+		return;
+	}
+	if (!_readSector(sd, sd->currentReadSector)) {
+		sd->status |= STAT_SDC_TOUT;
+		return;
+	}
+	sd->status &= (uint8_t) ~STAT_SDC_TOUT;
+	++sd->currentReadSector;
+	sd->dataScriptLen = 2;
+	sd->dataScript[0] = SD_TOKEN_START_BLOCK;
+	sd->dataScript[1] = SD_TOKEN_IDLE;
+	sd->dataScriptPos = 0;
+}
+
+static void _appendWriteByte(struct GBAEverdriveSD* sd, const uint8_t byte) {
+	if (!sd->writeMulti) {
+		return;
+	}
+	if (!sd->writeCapturing) {
+		if (byte == SD_TOKEN_START_BLOCK) {
+			sd->writeCapturing = true;
+			sd->dataBlockPos = 0;
+		}
+		return;
+	}
+	if (sd->dataBlockPos < (int) sizeof(sd->dataBlock)) {
+		sd->dataBlock[sd->dataBlockPos++] = byte;
+	}
+	if (sd->dataBlockPos == (int) sizeof(sd->dataBlock)) {
+		const bool ok = _writeSector(sd, sd->currentWriteSector);
+		if (ok) {
+			++sd->currentWriteSector;
+			_queueWriteDataResponse(sd, 0x2);
+		} else {
+			_queueWriteDataResponse(sd, 0x5);
+		}
+		sd->writeCapturing = false;
+		sd->dataBlockPos = 0;
+	}
+}
+
+static void _execCmd(struct GBAEverdriveSD* sd, const uint8_t cmd, const uint32_t arg) {
+	uint8_t resp[18] = { 0 };
+
+	switch (cmd) {
+	case CMD0_GO_IDLE_STATE:
+		sd->cardIdle = true;
+		sd->appCmd = false;
+		sd->readMulti = false;
+		sd->writeMulti = false;
+		resp[0] = 0x01;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD8_SEND_IF_COND:
+		resp[0] = sd->cardIdle ? 0x01 : 0x00;
+		resp[3] = 0x01;
+		resp[4] = 0xAA;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD55_APP_CMD:
+		sd->appCmd = true;
+		resp[0] = sd->cardIdle ? 0x01 : 0x00;
+		resp[1] = 0xFF;
+		resp[2] = 0xFF;
+		resp[3] = 0xFF;
+		resp[4] = 0xFF;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case ACMD41_SEND_OP_COND:
+		if (sd->appCmd) {
+			sd->cardIdle = false;
+			resp[0] = 0x00;
+			resp[1] = 0xC0;
+			_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		} else {
+			resp[0] = 0x04;
+			_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		}
+		sd->appCmd = false;
+		break;
+	case CMD58_READ_OCR:
+		resp[0] = sd->cardIdle ? 0x01 : 0x00;
+		resp[1] = 0xC0;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD2_ALL_SEND_CID:
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R2_LEN);
+		break;
+	case CMD3_SEND_RELATIVE_ADDR:
+		resp[0] = 0x00;
+		resp[1] = 0x00;
+		resp[2] = 0x01;
+		resp[3] = 0x00;
+		resp[4] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD7_SELECT_DESELECT_CARD:
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD9_SEND_CSD:
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R2_LEN);
+		break;
+	case CMD6_SWITCH_FUNC:
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD17_READ_SINGLE_BLOCK:
+		sd->currentReadSector = arg;
+		sd->readMulti = true;
+		_handleReadStart(sd);
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD18_READ_MULTIPLE_BLOCK:
+		sd->currentReadSector = arg;
+		sd->readMulti = true;
+		_queueCmdResponse(sd, NULL, 0);
+		break;
+	case CMD12_STOP_TRANSMISSION:
+		sd->readMulti = false;
+		sd->writeMulti = false;
+		sd->writeCapturing = false;
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	case CMD24_WRITE_SINGLE_BLOCK:
+	case CMD25_WRITE_MULTIPLE_BLOCK:
+		sd->currentWriteSector = arg;
+		sd->writeMulti = true;
+		sd->writeCapturing = false;
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	default:
+		resp[0] = 0x00;
+		_queueCmdResponse(sd, resp, SD_RESPONSE_R1_LEN);
+		break;
+	}
+}
+
+static void _cmdWrite(struct GBAEverdriveSD* sd, const uint8_t value) {
+	if (!sd->cmdPacketLen && (value & 0xC0) == 0x40) {
+		sd->cmdPacketLen = 0;
+		sd->cmdPacket[sd->cmdPacketLen++] = value;
+		return;
+	}
+	if (!sd->cmdPacketLen) {
+		return;
+	}
+	if (sd->cmdPacketLen < (int) sizeof(sd->cmdPacket)) {
+		sd->cmdPacket[sd->cmdPacketLen++] = value;
+	}
+	if (sd->cmdPacketLen == (int) sizeof(sd->cmdPacket)) {
+		const uint32_t arg = ((uint32_t) sd->cmdPacket[1] << 24)
+			| ((uint32_t) sd->cmdPacket[2] << 16)
+			| ((uint32_t) sd->cmdPacket[3] << 8)
+			| sd->cmdPacket[4];
+		_execCmd(sd, sd->cmdPacket[0], arg);
+		sd->cmdPacketLen = 0;
+	}
+}
+
+void GBAEverdriveSDInit(struct GBAEverdriveSD* sd) {
+	memset(sd, 0, sizeof(*sd));
+	GBAEverdriveSDReset(sd);
+}
+
+void GBAEverdriveSDDeinit(struct GBAEverdriveSD* sd) {
+	_closeImage(sd);
+}
+
+void GBAEverdriveSDReset(struct GBAEverdriveSD* sd) {
+	sd->status = 0;
+	sd->cardIdle = true;
+	sd->appCmd = false;
+	sd->readMulti = false;
+	sd->writeMulti = false;
+	sd->writeCapturing = false;
+	sd->cmdPacketLen = 0;
+	sd->cmdResponseLen = 0;
+	sd->cmdResponsePos = 0;
+	sd->dataScriptLen = 0;
+	sd->dataScriptPos = 0;
+	sd->dataBlockPos = 0;
+	memset(sd->regs, 0, sizeof(sd->regs));
+}
+
+void GBAEverdriveSDConfigure(struct GBAEverdriveSD* sd, bool enabled, const char* path) {
+	sd->readOnly = false;
+	_closeImage(sd);
+
+	if (!enabled || !path || !path[0]) {
+		return;
+	}
+
+	sd->image = VFileOpen(path, O_RDWR);
+	if (!sd->image) {
+		sd->image = VFileOpen(path, O_RDONLY);
+		if (!sd->image) {
+			return;
+		}
+		sd->readOnly = true;
+	}
+
+	GBAEverdriveSDReset(sd);
+}
+
+bool GBAEverdriveSDIsActive(const struct GBAEverdriveSD* sd) {
+	return sd->image != NULL;
+}
+
+bool GBAEverdriveSDHandlesAddress(const uint32_t address) {
+	if (address >= GBA_EVERDRIVE_SD_BASE && address < GBA_EVERDRIVE_SD_BASE + GBA_EVERDRIVE_SD_REG_SIZE) {
+		return true;
+	}
+	if (address >= GBA_EVERDRIVE_SD_EEP_BASE && address < GBA_EVERDRIVE_SD_EEP_BASE + 0x20000) {
+		return true;
+	}
+	return false;
+}
+
+uint16_t GBAEverdriveSDRead16(struct GBAEverdriveSD* sd, const uint32_t address) {
+	if (address >= GBA_EVERDRIVE_SD_EEP_BASE) {
+		return 0xFFFF;
+	}
+
+	const uint32_t reg = (address - GBA_EVERDRIVE_SD_BASE) >> 1;
+	if (sd->readMulti && reg != REG_STATUS) {
+		const uint8_t lo = _dataReadByte(sd);
+		const uint8_t hi = _dataReadByte(sd);
+		return ((uint16_t) hi << 8) | lo;
+	}
+
+	switch (reg) {
+	case REG_STATUS:
+		return sd->status;
+	case REG_SD_CMD:
+		return _cmdRead(sd);
+	case REG_SD_CFG:
+		return _cmdPeek(sd);
+	case REG_SD_DAT: {
+		if ((sd->regs[REG_SD_CFG] & SD_CFG_MODE_MASK) == SD_CFG_MODE1) {
+			const uint8_t value = _dataReadByte(sd);
+			return ((uint16_t) value << 8) | value;
+		}
+		const uint8_t lo = _dataReadByte(sd);
+		const uint8_t hi = _dataReadByte(sd);
+		return ((uint16_t) hi << 8) | lo;
+	}
+	default:
+		if (reg < sizeof(sd->regs)) {
+			return sd->regs[reg];
+		}
+		return 0xFFFF;
+	}
+}
+
+void GBAEverdriveSDWrite16(struct GBAEverdriveSD* sd, const uint32_t address, const uint16_t value) {
+	if (address >= GBA_EVERDRIVE_SD_EEP_BASE) {
+		return;
+	}
+
+	const uint32_t reg = (address - GBA_EVERDRIVE_SD_BASE) >> 1;
+	if (reg < sizeof(sd->regs)) {
+		sd->regs[reg] = (uint8_t) value;
+	}
+
+	switch (reg) {
+	case REG_SD_CMD:
+		_cmdWrite(sd, (uint8_t) value);
+		break;
+	case REG_SD_CFG:
+		if ((value & (SD_CFG_WAIT_F0 | SD_CFG_STRT_F0)) == (SD_CFG_WAIT_F0 | SD_CFG_STRT_F0)) {
+			_handleReadStart(sd);
+		}
+		break;
+	case REG_SD_DAT:
+		_appendWriteByte(sd, (uint8_t) value);
+		_appendWriteByte(sd, (uint8_t) (value >> 8));
+		break;
+	case REG_STATUS:
+		sd->status = (uint8_t) value;
+		break;
+	case REG_KEY:
+	case REG_CFG:
+	case REG_SD_RAM:
+	default:
+		break;
+	}
+}

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -388,6 +388,8 @@ static void _GBACoreLoadConfig(struct mCore* core, const struct mCoreConfig* con
 	mCoreConfigCopyValue(&core->config, config, "gba.bios");
 	mCoreConfigCopyValue(&core->config, config, "gba.forceGbp");
 	mCoreConfigCopyValue(&core->config, config, "vbaBugCompat");
+	mCoreConfigCopyValue(&core->config, config, "everdrive.sd.enable");
+	mCoreConfigCopyValue(&core->config, config, "everdrive.sd.image");
 
 #ifndef DISABLE_THREADING
 	mCoreConfigCopyValue(&core->config, config, "threadedVideo");
@@ -783,6 +785,10 @@ static void _GBACoreReset(struct mCore* core) {
 	if (!vbaBugCompat) {
 		gba->vbaBugCompat = false;
 	}
+	bool everdriveSDEnable = false;
+	mCoreConfigGetBoolValue(&core->config, "everdrive.sd.enable", &everdriveSDEnable);
+	const char* everdriveSDPath = mCoreConfigGetValue(&core->config, "everdrive.sd.image");
+	GBAEverdriveSDConfigure(&gba->memory.everdrive, everdriveSDEnable, everdriveSDPath);
 	gbacore->memoryBlockType = -2;
 
 #ifdef ENABLE_VFS

--- a/src/gba/memory.c
+++ b/src/gba/memory.c
@@ -99,6 +99,7 @@ void GBAMemoryInit(struct GBA* gba) {
 	gba->memory.ereader.p = gba;
 	gba->memory.ereader.dots = NULL;
 	memset(gba->memory.ereader.cards, 0, sizeof(gba->memory.ereader.cards));
+	GBAEverdriveSDInit(&gba->memory.everdrive);
 }
 
 void GBAMemoryDeinit(struct GBA* gba) {
@@ -114,6 +115,7 @@ void GBAMemoryDeinit(struct GBA* gba) {
 	}
 
 	GBACartEReaderDeinit(&gba->memory.ereader);
+	GBAEverdriveSDDeinit(&gba->memory.everdrive);
 }
 
 void GBAMemoryReset(struct GBA* gba) {
@@ -153,6 +155,7 @@ void GBAMemoryReset(struct GBA* gba) {
 	GBADMAReset(gba);
 	GBAUnlCartReset(gba);
 	memset(&gba->memory.matrix, 0, sizeof(gba->memory.matrix));
+	GBAEverdriveSDReset(&gba->memory.everdrive);
 }
 
 void GBAMemoryClearAGBPrint(struct GBA* gba) {
@@ -589,6 +592,10 @@ uint32_t GBALoad16(struct ARMCore* cpu, uint32_t address, int* cycleCounter) {
 	case GBA_REGION_ROM1_EX:
 	case GBA_REGION_ROM2:
 		wait = memory->waitstatesNonseq16[address >> BASE_OFFSET];
+		if (GBAEverdriveSDIsActive(&memory->everdrive) && GBAEverdriveSDHandlesAddress(address)) {
+			value = GBAEverdriveSDRead16(&memory->everdrive, address & ~1);
+			break;
+		}
 		if ((address & (GBA_SIZE_ROM0 - 2)) < memory->romSize) {
 			LOAD_16(value, address & (GBA_SIZE_ROM0 - 2), memory->rom);
 		} else if (memory->unl.type == GBA_UNL_CART_VFAME) {
@@ -705,6 +712,10 @@ uint32_t GBALoad8(struct ARMCore* cpu, uint32_t address, int* cycleCounter) {
 	case GBA_REGION_ROM2:
 	case GBA_REGION_ROM2_EX:
 		wait = memory->waitstatesNonseq16[address >> BASE_OFFSET];
+		if (GBAEverdriveSDIsActive(&memory->everdrive) && GBAEverdriveSDHandlesAddress(address)) {
+			value = GBAEverdriveSDRead16(&memory->everdrive, address & ~1) >> ((address & 1) << 3);
+			break;
+		}
 		if ((address & (GBA_SIZE_ROM0 - 1)) < memory->romSize) {
 			value = ((uint8_t*) memory->rom)[address & (GBA_SIZE_ROM0 - 1)];
 		} else if (memory->unl.type == GBA_UNL_CART_VFAME) {
@@ -928,6 +939,10 @@ void GBAStore16(struct ARMCore* cpu, uint32_t address, int16_t value, int* cycle
 		}
 		break;
 	case GBA_REGION_ROM0:
+		if (GBAEverdriveSDIsActive(&memory->everdrive) && GBAEverdriveSDHandlesAddress(address)) {
+			GBAEverdriveSDWrite16(&memory->everdrive, address & ~1, value);
+			break;
+		}
 		if (IS_GPIO_REGISTER(address & 0xFFFFFE)) {
 			if (!(memory->hw.devices & HW_GPIO)) {
 				mLOG(GBA_HW, WARN, "Write to GPIO address %08X on cartridge without GPIO", address);
@@ -943,6 +958,10 @@ void GBAStore16(struct ARMCore* cpu, uint32_t address, int16_t value, int* cycle
 		}
 		// Fall through
 	case GBA_REGION_ROM0_EX:
+		if (GBAEverdriveSDIsActive(&memory->everdrive) && GBAEverdriveSDHandlesAddress(address)) {
+			GBAEverdriveSDWrite16(&memory->everdrive, address & ~1, value);
+			break;
+		}
 		if ((address & 0x00FFFFFF) >= AGB_PRINT_BASE) {
 			uint32_t agbPrintAddr = address & 0x00FFFFFF;
 			if (agbPrintAddr == AGB_PRINT_PROTECT) {
@@ -1057,6 +1076,17 @@ void GBAStore8(struct ARMCore* cpu, uint32_t address, int8_t value, int* cycleCo
 		mLOG(GBA_MEM, GAME_ERROR, "Cannot Store8 to OAM: 0x%08X", address);
 		break;
 	case GBA_REGION_ROM0:
+	case GBA_REGION_ROM0_EX:
+	case GBA_REGION_ROM1:
+	case GBA_REGION_ROM1_EX:
+	case GBA_REGION_ROM2:
+	case GBA_REGION_ROM2_EX:
+		if (GBAEverdriveSDIsActive(&memory->everdrive) && GBAEverdriveSDHandlesAddress(address)) {
+			uint16_t pair = GBAEverdriveSDRead16(&memory->everdrive, address & ~1);
+			pair = (address & 1) ? ((pair & 0x00FF) | ((uint8_t) value << 8)) : ((pair & 0xFF00) | (uint8_t) value);
+			GBAEverdriveSDWrite16(&memory->everdrive, address & ~1, pair);
+			break;
+		}
 		mLOG(GBA_MEM, STUB, "Unimplemented memory Store8: 0x%08X", address);
 		break;
 	case GBA_REGION_SRAM:

--- a/src/platform/qt/SettingsView.cpp
+++ b/src/platform/qt/SettingsView.cpp
@@ -149,6 +149,17 @@ SettingsView::SettingsView(ConfigController* controller, InputController* inputC
 	connect(m_ui.bgImageBrowse, &QAbstractButton::pressed, [this] () {
 		selectImage(m_ui.bgImage);
 	});
+	connect(m_ui.everdriveSdImageBrowse, &QAbstractButton::pressed, [this] () {
+		if (const QString path = GBAApp::app()->getOpenFileName(this, tr("Select SD image")); !path.isNull()) {
+			m_ui.everdriveSdImage->setText(makePortablePath(path));
+		}
+	});
+	connect(m_ui.everdriveSdEnable, &QAbstractButton::toggled, [this](const bool enabled) {
+		m_ui.everdriveSdImage->setEnabled(enabled);
+		m_ui.everdriveSdImageBrowse->setEnabled(enabled);
+	});
+	m_ui.everdriveSdImage->setEnabled(m_ui.everdriveSdEnable->isChecked());
+	m_ui.everdriveSdImageBrowse->setEnabled(m_ui.everdriveSdEnable->isChecked());
 	connect(m_ui.clearCache, &QAbstractButton::pressed, this, &SettingsView::libraryCleared);
 
 	// TODO: Move to reloadConfig()
@@ -540,6 +551,8 @@ void SettingsView::updateConfig() {
 	saveSetting("dynamicTitle", m_ui.dynamicTitle);
 	saveSetting("videoScale", m_ui.videoScale);
 	saveSetting("gba.forceGbp", m_ui.forceGbp);
+	saveSetting("everdrive.sd.enable", m_ui.everdriveSdEnable);
+	saveSetting("everdrive.sd.image", m_ui.everdriveSdImage);
 	saveSetting("vbaBugCompat", m_ui.vbaBugCompat);
 	saveSetting("updateAutoCheck", m_ui.updateAutoCheck);
 	saveSetting("showFilenameInLibrary", m_ui.showFilenameInLibrary);
@@ -762,6 +775,8 @@ void SettingsView::reloadConfig() {
 	loadSetting("useDiscordPresence", m_ui.useDiscordPresence);
 	loadSetting("dynamicTitle", m_ui.dynamicTitle, true);
 	loadSetting("gba.forceGbp", m_ui.forceGbp);
+	loadSetting("everdrive.sd.enable", m_ui.everdriveSdEnable);
+	loadSetting("everdrive.sd.image", m_ui.everdriveSdImage);
 	loadSetting("vbaBugCompat", m_ui.vbaBugCompat, true);
 	loadSetting("updateAutoCheck", m_ui.updateAutoCheck);
 	loadSetting("showFilenameInLibrary", m_ui.showFilenameInLibrary);

--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -1386,6 +1386,43 @@
          </layout>
         </widget>
        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QGroupBox" name="everdriveGroup">
+          <property name="title">
+           <string>Everdrive</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_20">
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="everdriveSdEnable">
+             <property name="text">
+              <string>Enable Everdrive SD API</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelEverdriveSdImage">
+             <property name="text">
+              <string>SD image:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayoutEverdriveSdImage">
+             <item>
+              <widget class="QLineEdit" name="everdriveSdImage"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="everdriveSdImageBrowse">
+               <property name="text">
+                <string>Browse</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
       </layout>
      </widget>
      <widget class="QWidget" name="bios">


### PR DESCRIPTION
I had a hacky version of this sitting on my drive for a while, and I was planning to figure out a sane & secure way to use a host defined folder before attempting to clean this up (because I really don't want GBA ROMs writing within my raw file system without some safety rails being in the way), but I couldn't come up with any ideas

So this uses disk images instead. If the user wants to manage the files in the disk image then they'll have to mount it on their OS. To me, this is a good enough security compromise, but there's something to be said about the loss of ease of use.

The implementation is based on the everdrive GBA development API [krikzz.com/pub/support/everdrive-gba/original-series/development](https://krikzz.com/pub/support/everdrive-gba/original-series/development/), and the SD protocol as detailed from https://elm-chan.org/docs/mmc/mmc_e.html

This does not implement the other Everdrive hardware features, I'm leaving that as a future exercise for anyone interested.

Switched from using C stdio to VFile, but I've only got this implemented for QT at the moment so this is QT only as of this PR

This means that GBAIO.GBA from the above linked everdrive development download now works:

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/5bb8a8ec-3690-44bf-93e5-32f86f6a5f69" />

I do plan to follow this up with an EZ Flash API version as well, but that's less graceful than Everdrive so I'd like to try this PR first and if this goes well then I'll tackle the tougher challenge of cleaning up the EZ Flash version

---

And this is what it looks like in the Enhancements screen

<img width="1086" height="985" alt="image" src="https://github.com/user-attachments/assets/c8914057-0969-47b7-96ce-7e6932769830" />