### PR TITLE
fix(lua/gb): emu:readRegister() returns garbage in high bytes

### DIFF
--- a/src/core/scripting.c
+++ b/src/core/scripting.c
@@ -398,7 +398,7 @@ static struct mScriptValue* _mScriptCoreReadRange(struct mCore* core, uint32_t a
 }
 
 static struct mScriptValue* _mScriptCoreReadRegister(const struct mCore* core, const char* regName) {
-	int32_t out;
+	int32_t out = 0;
 	if (!core->readRegister(core, regName, &out)) {
 		return &mScriptValueNull;
 	}


### PR DESCRIPTION
while playing with lua scripting with the gb core, i found sometimes emu:readRegister() returns 16 bits value for 8 bit registers.

assuming cpu.b = 0x12, emu:readRegister("b") might return 0x12, 0x7F12 or any others.

the issue is in _GBCoreReadRegister(), param `void* out` is casted to `uint8_t*`, and `*value = cpu->b` will only write to the lowest byte, leave whatever garbage in high bytes untouched.