### PR TITLE
fix freetype include

### DIFF
--- a/src/platform/qt/ReportView.cpp
+++ b/src/platform/qt/ReportView.cpp
@@ -62,7 +62,8 @@
 #endif
 
 #ifdef USE_FREETYPE
-#include <freetype/freetype.h>
+#include <ft2build.h>
+#include FT_FREETYPE_H
 #endif
 
 #ifdef USE_JSON_C


### PR DESCRIPTION
resolves a build error I was getting on a rather exotic Linux environment.
```cmake
[ 87%] Building CXX object qt/CMakeFiles/mgba-qt.dir/ReportView.cpp.o
In file included from /home/runner/mgba/src/platform/qt/ReportView.cpp:65:
/usr/include/freetype2/freetype/freetype.h:24:2: error: #error "ft2build.h' hasn't been included yet!"   24 | #error "ft2build.h' hasn't been included yet!"
|  ^~~~~
/usr/include/freetype2/freetype/freetype.h:25:2: error: #error "Please always use macros to include FreeType header files."
25 | #error "Please always use macros to include FreeType header files."
|  ^~~~~
/usr/include/freetype2/freetype/freetype.h:26:2: error: #error "Example:"
26 | #error "Example:"
|  ^~~~~
/usr/include/freetype2/freetype/freetype.h:27:2: error: #error "  #include <ft2build.h>"
27 | #error "  #include <ft2build.h>"
|  ^~~~~
/usr/include/freetype2/freetype/freetype.h:28:2: error: #error "  #include FT_FREETYPE_H"
28 | #error "  #include FT_FREETYPE_H"
|  ^~~~~
```
https://freetype.org/freetype2/docs/reference/ft2-header_inclusion.html
https://freetype.org/freetype2/docs/reference/ft2-header_file_macros.html
I haven't tested this, but it looks like this approach is used [elsewhere](https://github.com/mgba-emu/mgba/blob/a2ce093c0bb47d91f54602f38476fffa2df67c22/src/util/image/font.c#L13) in the codebase already, so should be fine?