### PR TITLE
PNG save states: Allow custom PNG chunks to appear before the IDAT chunk again

### DIFF
--- a/src/core/serialize.c
+++ b/src/core/serialize.c
@@ -265,23 +265,6 @@ static void* _loadPNGState(struct mCore* core, struct VFile* vf, struct mStateEx
 		return false;
 	}
 
-	if (!PNGReadHeader(png, info)) {
-		PNGReadClose(png, info, end);
-		return false;
-	}
-	unsigned width = png_get_image_width(png, info);
-	unsigned height = png_get_image_height(png, info);
-	if (width > 0x4000 || height > 0x4000) {
-		// These images are ridiculously large...let's assume a DOS attempt and reject
-		PNGReadClose(png, info, end);
-		return false;
-	}
-	uint32_t* pixels = malloc(width * height * 4);
-	if (!pixels) {
-		PNGReadClose(png, info, end);
-		return false;
-	}
-
 	size_t stateSize = core->stateSize(core);
 	void* state = anonymousMemoryMap(stateSize);
 	struct mBundledState bundle = {
@@ -290,8 +273,28 @@ static void* _loadPNGState(struct mCore* core, struct VFile* vf, struct mStateEx
 		.extdata = extdata
 	};
 
-	bool success = true;
 	PNGInstallChunkHandler(png, &bundle, _loadPNGChunkHandler, "gbAs gbAx");
+	if (!PNGReadHeader(png, info)) {
+		PNGReadClose(png, info, end);
+		mappedMemoryFree(state, stateSize);
+		return false;
+	}
+	unsigned width = png_get_image_width(png, info);
+	unsigned height = png_get_image_height(png, info);
+	if (width > 0x4000 || height > 0x4000) {
+		// These images are ridiculously large...let's assume a DOS attempt and reject
+		PNGReadClose(png, info, end);
+		mappedMemoryFree(state, stateSize);
+		return false;
+	}
+	uint32_t* pixels = malloc(width * height * 4);
+	if (!pixels) {
+		PNGReadClose(png, info, end);
+		mappedMemoryFree(state, stateSize);
+		return false;
+	}
+
+	bool success = true;
 	success = success && PNGReadPixels(png, info, pixels, width, height, width);
 	success = success && PNGReadFooter(png, end);
 	PNGReadClose(png, info, end);


### PR DESCRIPTION
During a recent (as in, after v0.10.5) change in the PNG save state loading routine the order of calls was changed so that the PNG chunk handler for the custom `gbAs` and `gbAx` chunks is only installed _after_ the IDAT chunk has been read (which happens in `PNGReadHeader()` I believe.)

That means that existing save state files where these custom chunks appear before IDAT will no longer load because libpng returns an error code due to an unknown chunk type.

I noticed that because I have some save states that I've created with a custom tool where these custom chunks have been (unintentionally) been placed before IDAT. These worked fine in v0.10.5 but fail to load in the current development branch.

This PR contains a fix for that -- but because this issue cannot affect save states created by mGBA itself and I only ran into this issue due to doing something 'weird', I'd also understand if you didn't want to support that at all. I just wanted to offer a fix for mGBA itself, but I can also solve that on my end by adding a wrapper that re-arranges the PNG chunks before loading them in mGBA.