### PR TITLE
Debugger: Fix gdb watchpoint removal check

### DIFF
--- a/src/debugger/gdb-stub.c
+++ b/src/debugger/gdb-stub.c
@@ -668,9 +668,8 @@ static void _clearBreakpoint(struct GDBStub* stub, const char* message) {
 		for (index = 0; index < mWatchpointListSize(&watchpoints); ++index) {
 			struct mWatchpoint* watchpoint = mWatchpointListGetPointer(&watchpoints, index);
 			if (address >= watchpoint->minAddress && address < watchpoint->maxAddress) {
-				continue;
+				stub->d.p->platform->clearBreakpoint(stub->d.p->platform, watchpoint->id);
 			}
-			stub->d.p->platform->clearBreakpoint(stub->d.p->platform, watchpoint->id);
 		}
 		mWatchpointListDeinit(&watchpoints);
 		break;


### PR DESCRIPTION
This fixes the watchpoint removal check in the GDB stub.

When using GDB remote debugging with `target remote localhost:2345`, a watchpoint at `0x03007ef4` is stored in mGBA as:

```c
minAddress = 0x03007ef4;
maxAddress = 0x03007ef5;
```

`maxAddress` is the exclusive end of the watchpoint range.

The old check skipped the watchpoint when the requested address was inside this range, so a `z2` packet did not remove the matching watchpoint. As a result, repeated set/remove cycles from GDB could leave stale watchpoints in mGBA, and `mWatchpointListSize(&watchpoints)` could keep growing.

This changes the condition to clear matching watchpoints instead.
