### PR TITLE
Qt: Fix PageDown scripting key mapping

### DIFF
--- a/src/platform/qt/scripting/ScriptingController.cpp
+++ b/src/platform/qt/scripting/ScriptingController.cpp
@@ -432,7 +432,7 @@ uint32_t ScriptingController::qtToScriptingKey(const QKeyEvent* event) {
 		{Qt::Key_Right, mSCRIPT_KEY_RIGHT},
 		{Qt::Key_Down, mSCRIPT_KEY_DOWN},
 		{Qt::Key_PageUp, mSCRIPT_KEY_PAGE_UP},
-		{Qt::Key_PageDown, mSCRIPT_KEY_DOWN},
+		{Qt::Key_PageDown, mSCRIPT_KEY_PAGE_DOWN},
 		{Qt::Key_Shift, mSCRIPT_KEY_SHIFT},
 		{Qt::Key_Control, mSCRIPT_KEY_CONTROL},
 		{Qt::Key_Meta, mSCRIPT_KEY_SUPER},


### PR DESCRIPTION
`Qt::Key_PageDown` was mapped to `mSCRIPT_KEY_DOWN`, causing scripts to receive `Down` when `PageDown` was pressed.

Map it to `mSCRIPT_KEY_PAGE_DOWN` instead