### PR TITLE
Qt: Increase maximum for "High-resolution scale" to 27x (6480x4320)

### DIFF
--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -1341,7 +1341,7 @@
                <number>1</number>
               </property>
               <property name="maximum">
-               <number>16</number>
+               <number>27</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
27x (6480x4320 pixels) is useful for 4x supersampling[^1], when playing games in fullscreen-mode on a 4K-UltraHD-screen (3840x2160 pixels).

<details><summary>Image-comparison (F-Zero)</summary>

16x:
<img width="3840" height="2160" alt="16x" src="https://github.com/user-attachments/assets/7f523303-c692-4b7c-a465-656d34db85b3" />

27x:
<img width="3840" height="2160" alt="27x" src="https://github.com/user-attachments/assets/907542d8-f604-48d2-9a61-73e0aad4e85f" />

</details>

In 3 games of the "F-Zero"-series, the image-quality-improvements are practically rather subtle, but still appreciable:
The view is more stable (mostly in the distance); the surroundings of the courses look less noisy; and shapes are easier to see clearly.

With a "Core i7-12700K"-CPU, and a "Radeon RX 6750 XT"-GPU, the performance was good.
Though, with rewinding enabled, there was audio-stuttering when the audio-buffer-size was set to 512 samples.
With rewinding disabled, an audio-buffer-size of 512 samples was still enough to play without audio-stuttering.
Average GPU-load while playing the 3 games was ~70% (according to Mangohud).

[^1]: When using bilinear-resampling with higher resolutions than those with which games are displayed, the resulting images will be supersampled. With this resampling-algorithm, that works properly with up to twice the displayed width and height. Area-sampling would also work well with larger resolution-differences.