### PR TITLE
feat(debugger): show PSR mode field in register dump, show SPSR

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Features:
  - Initial support for bootleg GBA multicarts
  - Debugger: Add range watchpoints
  - Debugger: Add enabling/disabling for breakpoints and watchpoints
+ - Debugger: Show SPSR register and PSR mode fields
  - "Headless" frontend for running tests, automation, etc.
 Emulation fixes:
  - ARM: Add framework for coprocessor support

--- a/src/arm/debugger/cli-debugger.c
+++ b/src/arm/debugger/cli-debugger.c
@@ -40,15 +40,37 @@ static struct CLIDebuggerCommandAlias _armCommandAliases[] = {
 	{ 0, 0 }
 };
 
+static inline const char* _getPSRModeString(union PSR psr) {
+	switch (psr.priv) {
+	case MODE_USER:
+		return "usr";
+	case MODE_FIQ:
+		return "fiq";
+	case MODE_IRQ:
+		return "irq";
+	case MODE_SUPERVISOR:
+		return "svc";
+	case MODE_ABORT:
+		return "abt";
+	case MODE_UNDEFINED:
+		return "und";
+	case MODE_SYSTEM:
+		return "sys";
+	default:
+		return "invalid";
+	}
+}
+
 static inline void _printPSR(struct CLIDebuggerBackend* be, union PSR psr) {
-	be->printf(be, "%08X [%c%c%c%c%c%c%c]\n", psr.packed,
+	be->printf(be, "%08X [%c%c%c%c%c%c%c] (%s)\n", psr.packed,
 	           psr.n ? 'N' : '-',
 	           psr.z ? 'Z' : '-',
 	           psr.c ? 'C' : '-',
 	           psr.v ? 'V' : '-',
 	           psr.i ? 'I' : '-',
 	           psr.f ? 'F' : '-',
-	           psr.t ? 'T' : '-');
+	           psr.t ? 'T' : '-',
+	           _getPSRModeString(psr));
 }
 
 static void _disassemble(struct CLIDebuggerSystem* debugger, struct CLIDebugVector* dv) {
@@ -141,6 +163,10 @@ static void _printStatus(struct CLIDebuggerSystem* debugger) {
 	}
 	be->printf(be, "cpsr: ");
 	_printPSR(be, cpu->cpsr);
+	if (cpu->cpsr.priv != MODE_USER && cpu->cpsr.priv != MODE_SYSTEM) {
+		be->printf(be, "spsr: ");
+		_printPSR(be, cpu->spsr);
+	}
 	be->printf(be, "Cycle: %" PRIu64 "\n", mTimingGlobalTime(debugger->p->d.p->core->timing));
 	int instructionLength;
 	enum ExecutionMode mode = cpu->cpsr.t;


### PR DESCRIPTION
tiny patch, should hopefully be good to go. Marked as draft because I can't get mGBA to compile:

```
git/mgba/build ❯ cmake ..
-- The C compiler identification is GNU 16.2.1
-- The CXX compiler identification is GNU 16.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "3.0.5")
-- Looking for strdup
-- Looking for strdup - found
-- Looking for strlcpy
-- Looking for strlcpy - found
-- Looking for strndup
-- Looking for strndup - found
-- Looking for vasprintf
-- Looking for vasprintf - found
-- Looking for freelocale
-- Looking for freelocale - found
-- Looking for newlocale
-- Looking for newlocale - found
-- Looking for setlocale
-- Looking for setlocale - found
-- Looking for snprintf_l
-- Looking for snprintf_l - not found
-- Looking for uselocale
-- Looking for uselocale - found
-- Looking for popcount32
-- Looking for popcount32 - not found
-- Looking for futimens
-- Looking for futimens - found
-- Looking for futimes
-- Looking for futimes - found
-- Looking for localtime_r
-- Looking for localtime_r - found
-- Looking for realpath
-- Looking for realpath - found
-- Looking for include file xlocale.h
-- Looking for include file xlocale.h - not found
-- Looking for include file pthread.h
-- Looking for include file pthread.h - found
-- Performing Test HAVE_PTHREAD
-- Performing Test HAVE_PTHREAD - Success
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Looking for include file pthread_np.h
-- Looking for include file pthread_np.h - not found
-- Looking for pthread_setname_np
-- Looking for pthread_setname_np - found
-- Looking for pthread_set_name_np
-- Looking for pthread_set_name_np - not found
-- Checking for one of the modules 'libedit'
-- Checking for one of the modules 'libavcodec'
-- Checking for one of the modules 'libavfilter'
-- Checking for one of the modules 'libavformat'
-- Checking for one of the modules 'libavutil'
-- Checking for one of the modules 'libswscale'
-- Checking for one of the modules 'libswresample'
-- Checking for one of the modules 'minizip'
-- Checking for one of the modules 'libelf'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found OpenGL: /usr/lib/libGL.so
-- Found WrapOpenGL: TRUE
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)
CMake Error at src/platform/qt/CMakeLists.txt:506 (string):
  string sub-command REPLACE requires at least four arguments.


-- Build type: Release
-- Platforms:
-- 	Game Boy Advance: ON
-- 	Game Boy: ON
-- Features:
-- 	Debuggers: ON
-- 	CLI debugger: ON
-- 	GDB stub: ON
-- 	GIF/Video recording: ON
-- 	Screenshot/advanced savestate support: ON
-- 	ZIP support: libzip
-- 	7-Zip support: ON
-- 	SQLite3 game database: ON
-- 	ELF loading support: ON
-- 	Discord Rich Presence support: ON
-- 	OpenGL support: libepoxy
-- Scripting support: ON
-- 	Lua: 5.5.1
-- 	storage API: ON
-- 	Font rendering: ON
-- Frontends:
-- 	Qt: ON
-- 	SDL (3): ON
-- 	Headless: OFF
-- 	Python bindings: OFF
-- 	Examples: OFF
-- Test tools:
-- 	Profiling: OFF
-- 	Test harness: OFF
-- 	Test suite: OFF
-- 	Video test suite: OFF
-- Cores:
-- 	Libretro core: OFF
-- Libraries:
-- 	Static: OFF
-- 	Shared: ON
-- Configuring incomplete, errors occurred!
```

seems like my cmake might be too new?