### PR TITLE
Scripting: Add mImage:encode()

### DIFF
--- a/src/script/image.c
+++ b/src/script/image.c
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include <mgba/script.h>
+#include <mgba-util/vfs.h>
 
 struct mScriptPainter {
 	struct mPainter painter;
@@ -29,6 +30,28 @@ static struct mScriptValue* _mImageNew(unsigned width, unsigned height) {
 	struct mScriptValue* result = mScriptValueAlloc(mSCRIPT_TYPE_MS_S(mImage));
 	result->value.opaque = image;
 	result->flags = mSCRIPT_VALUE_FLAG_DEINIT;
+	return result;
+}
+
+static struct mScriptValue* _mImageEncode(const struct mImage* image, const char* format) {
+	struct VFile* vf = VFileMemChunk(0, 0);
+	if (!vf) {
+		return NULL;
+	}
+	bool success = mImageSaveVF(image, vf, format);
+	if (!success) {
+		vf->close(vf);
+		return NULL;
+	}
+	ssize_t size = vf->size(vf);
+	const void* data = vf->map(vf, size, 0);
+	if (!data || size < 1) {
+		vf->close(vf);
+		return 0;
+	}
+	struct mScriptValue* result = mScriptStringCreateFromBytes(data, size);
+	vf->unmap(vf, (void*) data, size);
+	vf->close(vf);
 	return result;
 }
 
@@ -78,6 +101,11 @@ mSCRIPT_DEFINE_STRUCT_BINDING_DEFAULTS(mImage, save)
 mSCRIPT_DEFINE_DEFAULTS_END;
 #endif
 
+mSCRIPT_DECLARE_STRUCT_METHOD_WITH_DEFAULTS(mImage, WSTR, encode, _mImageEncode, 1, CHARP, format);
+mSCRIPT_DEFINE_STRUCT_BINDING_DEFAULTS(mImage, encode)
+	mSCRIPT_CHARP("PNG")
+mSCRIPT_DEFINE_DEFAULTS_END;
+
 mSCRIPT_DEFINE_STRUCT(mImage)
 	mSCRIPT_DEFINE_CLASS_DOCSTRING(
 		"A single, static image."
@@ -87,6 +115,8 @@ mSCRIPT_DEFINE_STRUCT(mImage)
 	mSCRIPT_DEFINE_DOCSTRING("Save the image to a file. Currently, only `PNG` format is supported")
 	mSCRIPT_DEFINE_STRUCT_METHOD(mImage, save)
 #endif
+	mSCRIPT_DEFINE_DOCSTRING("Encode the image to a byte array. Currently, only `PNG` format is supported")
+	mSCRIPT_DEFINE_STRUCT_METHOD(mImage, encode)
 	mSCRIPT_DEFINE_DOCSTRING("Get the ARGB value of the pixel at a given coordinate")
 	mSCRIPT_DEFINE_STRUCT_METHOD(mImage, getPixel)
 	mSCRIPT_DEFINE_DOCSTRING("Set the ARGB value of the pixel at a given coordinate")

--- a/src/script/test/image.c
+++ b/src/script/test/image.c
@@ -42,9 +42,9 @@ M_TEST_DEFINE(members) {
 	TEST_PROGRAM("assert(im.width == 1)");
 	TEST_PROGRAM("assert(im.height == 1)");
 	TEST_PROGRAM("assert(im.save)");
-	TEST_PROGRAM("assert(im.save)");
 	TEST_PROGRAM("assert(im.getPixel)");
 	TEST_PROGRAM("assert(im.setPixel)");
+	TEST_PROGRAM("assert(im.encode)");
 
 	mScriptContextDeinit(&context);
 }
@@ -100,6 +100,18 @@ M_TEST_DEFINE(saveLoadRoundTrip) {
 }
 #endif
 
+#ifdef USE_PNG
+M_TEST_DEFINE(encodeBasic) {
+	SETUP_LUA;
+
+	TEST_PROGRAM("im = image.new(1, 1)");
+	TEST_PROGRAM("assert(type(im:encode()) == 'string')");
+	TEST_PROGRAM("assert(#im:encode() >= 8)");
+
+	mScriptContextDeinit(&context);
+}
+#endif
+
 M_TEST_DEFINE(painterBasic) {
 	SETUP_LUA;
 
@@ -121,6 +133,7 @@ M_TEST_SUITE_DEFINE_SETUP_TEARDOWN(mScriptImage,
 	cmocka_unit_test(pixelColorRoundTrip),
 #ifdef USE_PNG
 	cmocka_unit_test(saveLoadRoundTrip),
+	cmocka_unit_test(encodeBasic),
 #endif
 	cmocka_unit_test(painterBasic),
 )


### PR DESCRIPTION
## The what
Added an `encode` function to enable direct access to screenshot data as encoded byte-string, without having to save it to disk first

~~Also deleted a test assertion that I assume to be an accidental duplicate~~

## The why
I'm working on a project where I send multiple frames per second over the network. The current limitation to `save()` results in longer processing times and unnecessary I/O operations, when they are supposed to be processed later in the script.

## The tests
Added `encodeBasic` to `src/script/test/image.c` but I was unable to run the test suite locally. However I did build mGBA from source (using clang, due to a gcc bug) and verified the functionality end to end. Both via external script, as well as the scripting console itself.