### PR TITLE
Interpolator fix

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TEST_FILES
 	test/geometry.c
 	test/hash.c
 	test/image.c
+	test/interpolator.c
 	test/sfo.c
 	test/string-parser.c
 	test/string-utf8.c

--- a/src/util/interpolator.c
+++ b/src/util/interpolator.c
@@ -33,15 +33,17 @@ void mInterpolatorSincInit(struct mInterpolatorSinc* interp, unsigned resolution
 	interp->sincLut = calloc(samples + 1, sizeof(double));
 	interp->windowLut = calloc(samples + 1, sizeof(double));
 
-	interp->sincLut[0] = 0;
+	// Initialize the removable singularity and window origin
+	interp->sincLut[0] = 1;
 	interp->windowLut[0] = 1;
 
 	interp->width = width;
 	interp->resolution = resolution;
 
 	unsigned i;
+	// Build a normalized sinc table spanning the full window
 	for (i = 1; i <= samples; ++i, x += dx, y += dy) {
-		interp->sincLut[i] = x < width ? sin(x) / x : 0.0;
+		interp->sincLut[i] = sin(x) / x;
 		// Three term Nuttall window with continuous first derivative
 		interp->windowLut[i] = 0.40897 + 0.5 * cos(y) + 0.09103 * cos(2 * y);
 	}
@@ -56,28 +58,18 @@ int16_t mInterpolatorSincInterpolate(const struct mInterpolator* interpolator, c
 	struct mInterpolatorSinc* interp = (struct mInterpolatorSinc*) interpolator;
 	int index = time;
 	double subsample = time - floor(time);
-	unsigned step = sampleStep < 1 ? interp->resolution * sampleStep : interp->resolution;
-	unsigned yShift = subsample * step;
-	unsigned xShift = subsample * interp->resolution;
+	double cutoff = sampleStep > 1 ? 1.0 / sampleStep : 1.0;
+	int shift = subsample * interp->resolution;
 	double sum = 0.0;
 	double kernelSum = 0.0;
 	double kernel;
 
 	int i;
+	// Apply the windowed low-pass kernel around the fractional source position
 	for (i = 1 - (int) interp->width; i <= (int) interp->width; ++i) {
-		unsigned window = (i >= 0 ? i : -i) * interp->resolution;
-		if (yShift > window) {
-			window = yShift - window;
-		} else {
-			window -= yShift;
-		}
-
-		unsigned sinc = (i >= 0 ? i : -i) * step;
-		if (xShift > sinc) {
-			sinc = xShift - sinc;
-		} else {
-			sinc -= xShift;
-		}
+		int offset = i * (int) interp->resolution - shift;
+		unsigned window = offset < 0 ? -offset : offset;
+		unsigned sinc = window * cutoff;
 
 		kernel = interp->sincLut[sinc] * interp->windowLut[window];
 		kernelSum += kernel;

--- a/src/util/test/interpolator.c
+++ b/src/util/test/interpolator.c
@@ -1,0 +1,100 @@
+/* Copyright (c) 2013-2026 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "util/test/suite.h"
+
+#include <mgba-util/interpolator.h>
+
+struct TestSamples {
+	const int16_t* samples;
+	size_t count;
+};
+
+static int16_t _sampleAt(int index, const void* context) {
+	const struct TestSamples* samples = context;
+
+	// Return silence outside the test signal
+	if (index < 0 || (size_t) index >= samples->count) {
+		return 0;
+	}
+	return samples->samples[index];
+}
+
+M_TEST_DEFINE(sincAtIntegerPosition) {
+	// Prepare an asymmetric signal that exposes a displaced kernel center
+	static const int16_t source[] = { 0, 100, -300, 700, 1200, -900, 400, 2000, -1500, 600, 0, 300, -100, 50, 0, 0, 0 };
+	struct TestSamples samples = {
+		.samples = source,
+		.count = sizeof(source) / sizeof(*source),
+	};
+	struct mInterpolationData data = {
+		.at = _sampleAt,
+		.context = &samples,
+	};
+	struct mInterpolatorSinc interp;
+	mInterpolatorSincInit(&interp, 0, 0);
+
+	// Verify exact source positions survive both equal-rate and upsampled paths
+	assert_int_equal(interp.d.interpolate(&interp.d, &data, 7.0, 1.0), source[7]);
+	assert_int_equal(interp.d.interpolate(&interp.d, &data, 7.0, 32768.0 / 44100.0), source[7]);
+
+	// Release the interpolation tables
+	mInterpolatorSincDeinit(&interp);
+}
+
+M_TEST_DEFINE(sincFractionalSymmetry) {
+	// Prepare a centered impulse for comparing opposite fractional phases
+	int16_t source[17] = {0};
+	source[8] = 12000;
+	struct TestSamples samples = {
+		.samples = source,
+		.count = sizeof(source) / sizeof(*source),
+	};
+	struct mInterpolationData data = {
+		.at = _sampleAt,
+		.context = &samples,
+	};
+	struct mInterpolatorSinc interp;
+	mInterpolatorSincInit(&interp, 0, 0);
+
+	// Verify the kernel has matching responses on either side of the impulse
+	int16_t left = interp.d.interpolate(&interp.d, &data, 7.75, 32768.0 / 44100.0);
+	int16_t right = interp.d.interpolate(&interp.d, &data, 8.25, 32768.0 / 44100.0);
+	assert_int_equal(left, right);
+
+	// Release the interpolation tables
+	mInterpolatorSincDeinit(&interp);
+}
+
+M_TEST_DEFINE(sincDownsampleLowPass) {
+	// Prepare a Nyquist-frequency signal that must be rejected when halving the rate
+	int16_t source[33];
+	size_t i;
+	for (i = 0; i < sizeof(source) / sizeof(*source); ++i) {
+		source[i] = i & 1 ? -12000 : 12000;
+	}
+	struct TestSamples samples = {
+		.samples = source,
+		.count = sizeof(source) / sizeof(*source),
+	};
+	struct mInterpolationData data = {
+		.at = _sampleAt,
+		.context = &samples,
+	};
+	struct mInterpolatorSinc interp;
+	mInterpolatorSincInit(&interp, 0, 0);
+
+	// Verify downsampling applies a low-pass cutoff instead of aliasing Nyquist to DC
+	int16_t sample = interp.d.interpolate(&interp.d, &data, 16.0, 2.0);
+	assert_in_range(sample, -100, 100);
+
+	// Release the interpolation tables
+	mInterpolatorSincDeinit(&interp);
+}
+
+M_TEST_SUITE_DEFINE(Interpolator,
+	cmocka_unit_test(sincAtIntegerPosition),
+	cmocka_unit_test(sincFractionalSymmetry),
+	cmocka_unit_test(sincDownsampleLowPass))


### PR DESCRIPTION
I asked ChatGPT 5.6 Sol to inspect the audio interpolation code and it found some issues. Here's what it says:

> The sinc interpolator calculated its kernel incorrectly:
> 
> - `sinc(0)` was initialized to `0` instead of its limiting value, `1`.
> - The sinc lookup table was truncated after `width` radians rather than spanning the full window.
> - Fractional offsets discarded the sample index’s sign, producing incorrect and asymmetric kernel distances.
> - Upsampling scaled the kernel unnecessarily, while downsampling lacked the required anti-aliasing cutoff.
> 
> The fix builds the complete sinc table, calculates each tap from its signed distance to the fractional source position, preserves the source bandwidth when upsampling, and applies an appropriate low-pass cutoff when downsampling.
> 
> Regression tests cover exact source positions, fractional impulse symmetry, and Nyquist-frequency rejection during downsampling.