### PR TITLE
Qt: Add options for audio-buffer-sizes of 48 and 32 samples

### DIFF
--- a/src/platform/qt/SettingsView.ui
+++ b/src/platform/qt/SettingsView.ui
@@ -140,8 +140,18 @@
                <string>1536</string>
               </property>
               <property name="currentIndex">
-               <number>9</number>
+               <number>11</number>
               </property>
+              <item>
+               <property name="text">
+                <string>32</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>48</string>
+               </property>
+              </item>
               <item>
                <property name="text">
                 <string>64</string>


### PR DESCRIPTION
I did notice a small difference in delay between an audio-buffer-size of 64 samples and 32 samples.
Would be nice if these 2 options for 32 samples and 48 samples would be added too. :)

I do not know how long the actual delays were, when i compared those. Sound-cards typically can use 2 or 3 buffers, and there is other processing, such as a mixer, for combining the audio of multiple applications; so the difference of the delay between buffer-sizes can increase. 3 buffers of 64 samples at 48 kHz would be 4 ms, which seems long enough to be perceivable.

32 samples was the lowest audio-buffer-size that worked properly on my computer while using USB-connected speakers; lower values (16 and 24) resulted in seemingly slowed down audio.

Playing games (F-Zero, and Kirby & The Amazing Mirror) with an audio-buffer-size of 32 samples, and Sync set to Audio, worked fine, without audible issues with the sound, even with 27x resolution, as long as the energy-mode of my computer was set to Performance, and rewinding was disabled.

Operating-system: Debian GNU/Linux Testing (Forky)
CPU: Core i7-12700K
GPU: Radeon RX 6750 XT
Audio-device: Creative Pebble Pro