### PR TITLE
fix(gba/audio): rescale the FIFO DMA source offset to 32-bit width

### DIFF
--- a/src/gba/audio.c
+++ b/src/gba/audio.c
@@ -106,6 +106,14 @@ void GBAAudioScheduleFifoDma(struct GBAAudio* audio, int number, struct GBADMA* 
 	info->reg = GBADMARegisterSetDestControl(info->reg, GBA_DMA_FIXED);
 	info->reg = GBADMARegisterSetWidth(info->reg, 1);
 	info->destOffset = 0;
+	// The width was just forced to 32-bit, but sourceOffset was cached at CNT_HI
+	// write time from the width the game programmed. Rescale it, keeping the
+	// direction the source control selected.
+	if (info->sourceOffset > 0) {
+		info->sourceOffset = 4;
+	} else if (info->sourceOffset < 0) {
+		info->sourceOffset = -4;
+	}
 	switch (info->dest) {
 	case GBA_BASE_IO | GBA_REG_FIFO_A_LO:
 		audio->chA.dmaSource = number;


### PR DESCRIPTION
Upstream 2deb4aa6f ("GBA DMA: Minor refactoring; cache offsets") caches a DMA's sourceOffset and destOffset when CNT_HI is written, from the width the game programmed. GBAAudioScheduleFifoDma then forces the FIFO DMA to 32-bit and fixed destination and zeroes destOffset, but leaves sourceOffset at the old width. A FIFO DMA the game set up as 16-bit therefore steps its source by 2 bytes while transferring 4-byte words, and the FIFO plays doubled, misaligned sample bytes

Bisected against Classic NES Series - The Legend of Zelda with a hard-jump oracle: 4062fb985 clean, 2deb4aa6f and every later commit 